### PR TITLE
Quant — Audit: productionize existing academic scaffolding

### DIFF
--- a/docs/audits/2026-04-08-quant-scaffolding-inventory.md
+++ b/docs/audits/2026-04-08-quant-scaffolding-inventory.md
@@ -180,7 +180,7 @@ dependency is noted. Labels assume the canonical 13-label set
 - **Labels:** `alpha`, `quant`, `methodology`, `backtest`, `P0`
 - **Scope:** `metrics.py::backtest_overfitting_probability` is a
   closed-form proxy that takes `(IS_sharpe, OOS_sharpe, n_trials)`
-  scalars. ADR-0002 #5 + Bailey 2015 Eq. 11 require the rank-based
+  scalars. ADR-0002 #12 + Bailey 2015 Eq. 11 require the rank-based
   PBO computed over a CPCV OOS distribution. CPCV already exists in
   `walk_forward.py:374` but is not invoked anywhere outside its unit
   test. This issue:


### PR DESCRIPTION
## Summary
Read-only audit of every quant / academic component in the repo,
evaluated against the ADR-0002 Quant Methodology Charter.

Produces one document: `docs/audits/2026-04-08-quant-scaffolding-inventory.md`
containing:
- Component inventory (29 components across backtesting, core/math, s02, s04, s06, s07)
- Gap analysis against the 19 ADR-0002 mandatory rows
- Proposed backlog of 8 Quant issues prioritized P0/P1/P2

## Why
ADR-0002 set the methodology bar. This audit measures the gap between
where we are and where the bar is, and produces an actionable backlog
rather than a vague TODO list.

## Top 3 findings
1. PSR / DSR / PBO / CPCV / fractional-diff / triple-barrier are all
   already implemented and unit-tested — but **none are wired into
   `full_report()` or any production service**. Wiring is the bottleneck.
2. The scalar `backtest_overfitting_probability` is a closed-form proxy,
   not the rank-based PBO from Bailey 2015 Eq. 11 — needs to be
   replaced and routed through CPCV.
3. Six ADR-0002 mandatory items have zero implementation: Ulcer Index,
   bootstrap CI on Sharpe, transaction-cost sensitivity, turnover,
   alpha-decay half-life, and capacity estimate.

## Scope
- Zero source code modified
- Zero tests modified
- Zero configuration modified
- Single file added: the audit report

## Next step
After merge, the orchestrator will open the 8 issues from Section C
of the audit report, one at a time, as separate Quant missions.