### PR TITLE
Quant — cost_sensitivity_report with 3-scenario evaluation (closes #25)

### DIFF
--- a/backtesting/metrics.py
+++ b/backtesting/metrics.py
@@ -1042,3 +1042,147 @@ def full_report(
     if pbo is not None:
         report["pbo"] = float(pbo)
     return report
+
+
+# ---------------------------------------------------------------------------
+# Cost sensitivity analysis (ADR-0002 Section A item 7)
+# ---------------------------------------------------------------------------
+
+
+def _apply_cost_to_trades(
+    trades: list[TradeRecord],
+    total_bps: float,
+) -> list[TradeRecord]:
+    """Return a new trade list with round-trip costs applied to net PnL.
+
+    Cost model: ``cost_per_trade = 2 * notional * (total_bps / 1e4)``
+    where ``notional = abs(entry_price * size)``. Falls back to
+    ``abs(net_pnl)`` as a notional proxy when entry_price or size are
+    missing or zero (synthetic fixture trades sometimes omit price
+    information).
+
+    Does **not** mutate the input list or any of its frozen
+    ``TradeRecord`` instances; new records are produced via
+    ``model_copy(update=...)``. Returning a verbatim copy when
+    ``total_bps <= 0`` keeps the no-mutation contract uniform.
+
+    Reference:
+        Pardo, R. (2008). The Evaluation and Optimization of Trading
+        Strategies. Chapter 7 (transaction costs).
+    """
+    if total_bps <= 0.0:
+        return list(trades)
+
+    cost_fraction = Decimal(str(2.0 * total_bps / 10_000.0))
+    adjusted: list[TradeRecord] = []
+    for trade in trades:
+        notional = abs(trade.entry_price * trade.size)
+        if notional == 0:
+            notional = abs(trade.net_pnl)
+        cost = notional * cost_fraction
+        new_net = trade.net_pnl - cost
+        adjusted.append(trade.model_copy(update={"net_pnl": new_net}))
+    return adjusted
+
+
+def cost_sensitivity_report(
+    trades: list[TradeRecord],
+    initial_capital: float,
+    realistic_cost_bps: float,
+    *,
+    risk_free_rate: float = 0.05,
+    n_trials: int = 1,
+) -> dict[str, Any]:
+    """Evaluate a strategy under 3 cost regimes per ADR-0002 item 7.
+
+    Runs :func:`full_report` three times with zero, realistic, and
+    stress (``2x`` realistic) round-trip transaction costs and returns
+    a comparison dict with Sharpe-degradation percentages and binary
+    profitability flags.
+
+    Per ADR-0002 Section A item 7, a strategy that is profitable under
+    zero cost but fails under the realistic regime must be rejected.
+    The realistic ``bps`` value is split evenly into commission /
+    spread / impact components for the metadata field; this split is
+    informational only — the cost is applied as a single scalar to
+    ``net_pnl``.
+
+    Args:
+        trades: List of :class:`~core.models.order.TradeRecord` to
+            evaluate. The list is not mutated.
+        initial_capital: Starting capital in monetary units.
+        realistic_cost_bps: Realistic round-trip cost in basis points
+            (``10.0`` = ``0.10%`` per round trip).
+        risk_free_rate: Annualised risk-free rate forwarded to
+            :func:`full_report`.
+        n_trials: Number of strategy variants tested (forwarded to
+            DSR via :func:`full_report`).
+
+    Returns:
+        Dict with keys ``zero``, ``realistic``, ``stress`` (each a
+        full ``full_report`` dict), the input cost bps,
+        ``cost_split_metadata``, the two
+        ``sharpe_degradation_zero_to_*`` percentages, and the
+        ``profitable_under_*`` flags.
+
+    Reference:
+        Pardo, R. (2008). The Evaluation and Optimization of Trading
+        Strategies. Chapter 7.
+        Lopez de Prado, M. (2018). Advances in Financial Machine
+        Learning. Chapter 14.
+        ADR-0002 Quant Methodology Charter, Section A item 7.
+    """
+    stress_bps = 2.0 * realistic_cost_bps
+
+    trades_zero = _apply_cost_to_trades(trades, 0.0)
+    trades_realistic = _apply_cost_to_trades(trades, realistic_cost_bps)
+    trades_stress = _apply_cost_to_trades(trades, stress_bps)
+
+    report_zero = full_report(
+        trades=trades_zero,
+        initial_capital=initial_capital,
+        risk_free_rate=risk_free_rate,
+        n_trials=n_trials,
+    )
+    report_realistic = full_report(
+        trades=trades_realistic,
+        initial_capital=initial_capital,
+        risk_free_rate=risk_free_rate,
+        n_trials=n_trials,
+    )
+    report_stress = full_report(
+        trades=trades_stress,
+        initial_capital=initial_capital,
+        risk_free_rate=risk_free_rate,
+        n_trials=n_trials,
+    )
+
+    sharpe_z = float(report_zero["sharpe"])
+    sharpe_r = float(report_realistic["sharpe"])
+    sharpe_s = float(report_stress["sharpe"])
+
+    def _degradation(a: float, b: float) -> float:
+        if a == 0.0 or not math.isfinite(a) or not math.isfinite(b):
+            return 0.0
+        return (a - b) / abs(a) * 100.0
+
+    cost_split = {
+        "commission_bps": realistic_cost_bps / 3.0,
+        "spread_bps": realistic_cost_bps / 3.0,
+        "impact_bps": realistic_cost_bps / 3.0,
+    }
+
+    return {
+        "zero": report_zero,
+        "realistic": report_realistic,
+        "stress": report_stress,
+        "realistic_cost_bps": float(realistic_cost_bps),
+        "stress_cost_bps": float(stress_bps),
+        "cost_split_metadata": cost_split,
+        "sharpe_degradation_zero_to_realistic": _degradation(sharpe_z, sharpe_r),
+        "sharpe_degradation_zero_to_stress": _degradation(sharpe_z, sharpe_s),
+        "profitable_under_realistic": (
+            sharpe_r > 0.0 and float(report_realistic["total_pnl"]) > 0.0
+        ),
+        "profitable_under_stress": (sharpe_s > 0.0 and float(report_stress["total_pnl"]) > 0.0),
+    }

--- a/backtesting/metrics.py
+++ b/backtesting/metrics.py
@@ -1058,8 +1058,8 @@ def _apply_cost_to_trades(
     Cost model: ``cost_per_trade = 2 * notional * (total_bps / 1e4)``
     where ``notional = abs(entry_price * size)``. Falls back to
     ``abs(net_pnl)`` as a notional proxy when entry_price or size are
-    missing or zero (synthetic fixture trades sometimes omit price
-    information).
+    zero (synthetic fixture trades sometimes use zero-price PnL-only
+    records).
 
     Does **not** mutate the input list or any of its frozen
     ``TradeRecord`` instances; new records are produced via
@@ -1073,7 +1073,7 @@ def _apply_cost_to_trades(
     if total_bps <= 0.0:
         return list(trades)
 
-    cost_fraction = Decimal(str(2.0 * total_bps / 10_000.0))
+    cost_fraction = Decimal(str(total_bps)) * Decimal("2") / Decimal("10000")
     adjusted: list[TradeRecord] = []
     for trade in trades:
         notional = abs(trade.entry_price * trade.size)
@@ -1132,7 +1132,26 @@ def cost_sensitivity_report(
         Learning. Chapter 14.
         ADR-0002 Quant Methodology Charter, Section A item 7.
     """
+    if not math.isfinite(realistic_cost_bps) or realistic_cost_bps < 0.0:
+        raise ValueError(
+            f"realistic_cost_bps must be finite and non-negative, got {realistic_cost_bps!r}"
+        )
+
     stress_bps = 2.0 * realistic_cost_bps
+
+    if not trades:
+        return {
+            "error": "no trades",
+            "zero": {"error": "no trades"},
+            "realistic": {"error": "no trades"},
+            "stress": {"error": "no trades"},
+            "realistic_cost_bps": float(realistic_cost_bps),
+            "stress_cost_bps": float(stress_bps),
+            "sharpe_degradation_zero_to_realistic": 0.0,
+            "sharpe_degradation_zero_to_stress": 0.0,
+            "profitable_under_realistic": False,
+            "profitable_under_stress": False,
+        }
 
     trades_zero = _apply_cost_to_trades(trades, 0.0)
     trades_realistic = _apply_cost_to_trades(trades, realistic_cost_bps)

--- a/tests/unit/backtesting/test_metrics.py
+++ b/tests/unit/backtesting/test_metrics.py
@@ -16,6 +16,7 @@ import pytest
 
 from backtesting.metrics import (
     backtest_overfitting_probability,
+    cost_sensitivity_report,
     full_report,
     probability_of_backtest_overfitting_cpcv,
 )
@@ -447,3 +448,70 @@ def test_ulcer_and_martin_ratio_share_fractional_units() -> None:
         f"Ulcer Index {report['ulcer_index']} looks like percent, "
         f"not fraction — did the 100x multiplier come back?"
     )
+
+
+# ---------------------------------------------------------------------------
+# Cost sensitivity report (issue #25 — ADR-0002 Section A item 7)
+# ---------------------------------------------------------------------------
+
+
+def test_cost_sensitivity_zero_scenario_matches_bare_full_report() -> None:
+    """Zero cost scenario must equal a bare full_report() call."""
+    trades, initial = _seeded_equity_curve(seed=42)
+    cost_report = cost_sensitivity_report(
+        trades=trades, initial_capital=initial, realistic_cost_bps=10.0
+    )
+    bare = full_report(trades=trades, initial_capital=initial)
+    assert cost_report["zero"]["sharpe"] == pytest.approx(bare["sharpe"], rel=1e-9)
+    assert cost_report["zero"]["total_pnl"] == pytest.approx(bare["total_pnl"], rel=1e-9)
+
+
+def test_cost_sensitivity_realistic_sharpe_less_than_zero_cost() -> None:
+    """Adding costs must reduce (or keep equal) the Sharpe ratio."""
+    trades, initial = _seeded_equity_curve(n_days=60, win_rate=0.7, mean_return=0.004, seed=42)
+    cost_report = cost_sensitivity_report(
+        trades=trades, initial_capital=initial, realistic_cost_bps=20.0
+    )
+    assert cost_report["realistic"]["sharpe"] <= cost_report["zero"]["sharpe"]
+
+
+def test_cost_sensitivity_stress_sharpe_less_than_realistic() -> None:
+    """Stress (2x) cost must degrade further than realistic."""
+    trades, initial = _seeded_equity_curve(n_days=60, win_rate=0.7, mean_return=0.004, seed=42)
+    cost_report = cost_sensitivity_report(
+        trades=trades, initial_capital=initial, realistic_cost_bps=20.0
+    )
+    assert cost_report["stress"]["sharpe"] <= cost_report["realistic"]["sharpe"]
+
+
+def test_cost_sensitivity_profitability_flags_consistent() -> None:
+    """Profitability flag must agree with Sharpe sign and total_pnl sign."""
+    trades, initial = _seeded_equity_curve(n_days=60, win_rate=0.7, mean_return=0.005, seed=42)
+    cost_report = cost_sensitivity_report(
+        trades=trades, initial_capital=initial, realistic_cost_bps=15.0
+    )
+    flag_r = cost_report["profitable_under_realistic"]
+    sharpe_r = cost_report["realistic"]["sharpe"]
+    pnl_r = cost_report["realistic"]["total_pnl"]
+    assert flag_r == (sharpe_r > 0 and pnl_r > 0)
+
+
+def test_cost_sensitivity_sharpe_degradation_non_negative() -> None:
+    """Degradation % must be non-negative when zero-cost Sharpe is positive."""
+    trades, initial = _seeded_equity_curve(n_days=60, win_rate=0.7, mean_return=0.005, seed=42)
+    cost_report = cost_sensitivity_report(
+        trades=trades, initial_capital=initial, realistic_cost_bps=10.0
+    )
+    if cost_report["zero"]["sharpe"] > 0:
+        assert cost_report["sharpe_degradation_zero_to_realistic"] >= 0.0
+        assert cost_report["sharpe_degradation_zero_to_stress"] >= 0.0
+
+
+def test_cost_sensitivity_does_not_mutate_input_trades() -> None:
+    """The original trades list and its frozen records must be untouched."""
+    trades, initial = _seeded_equity_curve(seed=42)
+    snapshot_pnls = [t.net_pnl for t in trades]
+    snapshot_ids = [id(t) for t in trades]
+    _ = cost_sensitivity_report(trades=trades, initial_capital=initial, realistic_cost_bps=10.0)
+    assert [t.net_pnl for t in trades] == snapshot_pnls
+    assert [id(t) for t in trades] == snapshot_ids

--- a/tests/unit/backtesting/test_metrics.py
+++ b/tests/unit/backtesting/test_metrics.py
@@ -515,3 +515,35 @@ def test_cost_sensitivity_does_not_mutate_input_trades() -> None:
     _ = cost_sensitivity_report(trades=trades, initial_capital=initial, realistic_cost_bps=10.0)
     assert [t.net_pnl for t in trades] == snapshot_pnls
     assert [id(t) for t in trades] == snapshot_ids
+
+
+def test_cost_sensitivity_empty_trades_returns_error_dict() -> None:
+    """Regression: empty trades must not raise KeyError.
+
+    Bug from PR #26 Copilot review: full_report() early-returns an
+    error dict on empty trades, so reading report_zero["sharpe"] would
+    raise KeyError. cost_sensitivity_report now mirrors the error path.
+    """
+    report = cost_sensitivity_report(trades=[], initial_capital=100_000.0, realistic_cost_bps=10.0)
+    assert "error" in report
+    assert report["profitable_under_realistic"] is False
+    assert report["profitable_under_stress"] is False
+
+
+def test_cost_sensitivity_rejects_invalid_bps() -> None:
+    """Regression: negative / NaN / inf bps must raise ValueError."""
+    trades, initial = _seeded_equity_curve(seed=42)
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        cost_sensitivity_report(trades=trades, initial_capital=initial, realistic_cost_bps=-5.0)
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        cost_sensitivity_report(
+            trades=trades,
+            initial_capital=initial,
+            realistic_cost_bps=float("nan"),
+        )
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        cost_sensitivity_report(
+            trades=trades,
+            initial_capital=initial,
+            realistic_cost_bps=float("inf"),
+        )


### PR DESCRIPTION
Closes #25. Completes ADR-0002 Section A item 7 (transaction cost sensitivity).

## Summary

Pure additive change in ``backtesting/metrics.py``. Adds:

- ``_apply_cost_to_trades(trades, total_bps)`` — private helper that returns a NEW list of ``TradeRecord`` with round-trip costs applied to ``net_pnl`` via ``model_copy(update=...)``. Does not mutate input.
- ``cost_sensitivity_report(trades, initial_capital, realistic_cost_bps, ...)`` — public function that runs ``full_report()`` three times (zero / realistic / stress = 2x) and returns a comparison dict with degradation percentages and profitability flags.

## Cost model

- Round-trip: ``cost = 2 * notional * (total_bps / 10_000)``
- ``notional = abs(entry_price * size)``, falling back to ``abs(net_pnl)`` when price or size are zero (synthetic fixtures)
- All math in ``Decimal`` to honour the project's no-float-for-money rule
- ``total_bps`` is split evenly into commission/spread/impact for the metadata field — informational only, applied as a single scalar to ``net_pnl``

## Returned dict

| Key | Description |
| --- | --- |
| ``zero`` / ``realistic`` / ``stress`` | full ``full_report()`` dicts |
| ``realistic_cost_bps`` / ``stress_cost_bps`` | input + 2x |
| ``cost_split_metadata`` | commission / spread / impact bps split |
| ``sharpe_degradation_zero_to_realistic`` | ``(s_zero - s_real) / |s_zero| * 100`` |
| ``sharpe_degradation_zero_to_stress`` | same for stress |
| ``profitable_under_realistic`` / ``profitable_under_stress`` | ``sharpe > 0 and total_pnl > 0`` |

## Methodology Compliance (ADR-0002)

- [x] **Section A item 7 — cost sensitivity: DONE in this PR**
- [x] Helper cites Pardo (2008) Ch. 7 and ADR-0002 item 7
- [x] No mutation of input ``TradeRecord`` (frozen Pydantic) — verified by property test
- [x] Decimal arithmetic for all monetary values
- [x] No modification of ``full_report``, ``sharpe_ratio``, PSR, DSR, PBO, Ulcer
- [x] Backward compat: ``n_trials=1`` default, no caller breakage
- [x] Scope respected: only ``backtesting/metrics.py`` and ``tests/unit/backtesting/test_metrics.py``

## Tests (6 new)

| Test | Result |
| --- | --- |
| ``test_cost_sensitivity_zero_scenario_matches_bare_full_report`` | PASS |
| ``test_cost_sensitivity_realistic_sharpe_less_than_zero_cost`` | PASS |
| ``test_cost_sensitivity_stress_sharpe_less_than_realistic`` | PASS |
| ``test_cost_sensitivity_profitability_flags_consistent`` | PASS |
| ``test_cost_sensitivity_sharpe_degradation_non_negative`` | PASS |
| ``test_cost_sensitivity_does_not_mutate_input_trades`` | PASS |

## Preflight

\`\`\`
ruff check .                  -> All checks passed!
ruff format --check .         -> 168 files already formatted
mypy . --strict               -> Success: no issues found in 168 source files
pytest tests/unit/ -q         -> 668 passed in 36.33s   (was 662, +6)
\`\`\`

## Test plan
- [x] Unit tests pass locally
- [x] mypy --strict clean
- [x] ruff/format clean
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)