### PR TITLE
Quant — OOS walk-forward gate with embargo (closes #29)

### DIFF
--- a/backtesting/metrics.py
+++ b/backtesting/metrics.py
@@ -1011,12 +1011,66 @@ def _return_distribution_stats(
     return {"skewness": skew, "excess_kurtosis": kurt, "tail_ratio": tail}
 
 
+# ---------------------------------------------------------------------------
+# OOS walk-forward split (ADR-0002 Section A item 2)
+# ---------------------------------------------------------------------------
+
+
+def _split_trades_is_oos(
+    trades: list[TradeRecord],
+    oos_fraction: float,
+    embargo_days: int,
+) -> tuple[list[TradeRecord], list[TradeRecord]]:
+    """Split trades into in-sample and out-of-sample sets with embargo.
+
+    Trades are sorted by ``exit_timestamp_ms``. The last
+    ``oos_fraction`` of trades become OOS. An embargo gap of
+    ``embargo_days`` calendar days is removed from the IS tail
+    to prevent information leakage across the boundary.
+
+    Args:
+        trades: All trades (any order, will be sorted internally).
+        oos_fraction: Fraction of trades reserved for OOS (e.g. 0.3).
+        embargo_days: Calendar days to remove from IS tail.
+
+    Returns:
+        Tuple ``(is_trades, oos_trades)``. Embargo trades are excluded
+        from both sets.
+
+    Raises:
+        ValueError: If ``oos_fraction`` is not in the open interval (0, 1).
+
+    Reference:
+        Lopez de Prado (2018). AFML Chapter 7.
+        Pardo (2008). Chapter 5.
+    """
+    if oos_fraction <= 0.0 or oos_fraction >= 1.0:
+        msg = f"oos_fraction must be in (0, 1), got {oos_fraction}"
+        raise ValueError(msg)
+
+    sorted_trades = sorted(trades, key=lambda t: t.exit_timestamp_ms)
+    split_idx = int(len(sorted_trades) * (1.0 - oos_fraction))
+    oos_trades = sorted_trades[split_idx:]
+
+    if not oos_trades:
+        return sorted_trades[:split_idx], []
+
+    oos_start_ms = oos_trades[0].exit_timestamp_ms
+    embargo_ms = embargo_days * 24 * 3600 * 1000
+    is_trades = [
+        t for t in sorted_trades[:split_idx] if t.exit_timestamp_ms < oos_start_ms - embargo_ms
+    ]
+    return is_trades, oos_trades
+
+
 def full_report(
     trades: list[TradeRecord],
     initial_capital: float = 100_000.0,
     risk_free_rate: float = 0.05,
     *,
     n_trials: int = 1,
+    oos_fraction: float = 0.0,
+    embargo_days: int = 5,
     strategy_returns_matrix: np.ndarray[Any, np.dtype[np.float64]] | None = None,
     n_cv_splits: int = 10,
     n_cv_test_splits: int = 2,
@@ -1036,6 +1090,13 @@ def full_report(
         n_trials: Number of independent strategy variants tested. Used by
             the Deflated Sharpe Ratio to correct for selection bias.
             Defaults to 1 for backward compatibility.
+        oos_fraction: Fraction of trades reserved for out-of-sample
+            evaluation (e.g. 0.3). When > 0, the report includes
+            ``is_report``, ``oos_report``, and ``oos_sharpe_degradation``.
+            Default 0.0 disables the split (backward compatible).
+        embargo_days: Calendar days to remove from the IS tail to
+            prevent information leakage across the IS/OOS boundary.
+            Per Lopez de Prado (2018, Ch. 7). Default 5.
 
     Returns:
         Dict with all metrics: sharpe, sortino, calmar, max_dd, win_rate,
@@ -1180,6 +1241,50 @@ def full_report(
     }
     if pbo is not None:
         report["pbo"] = float(pbo)
+
+    # OOS walk-forward split (ADR-0002 Section A item 2).
+    if oos_fraction > 0.0:
+        is_trades, oos_trades = _split_trades_is_oos(trades, oos_fraction, embargo_days)
+        is_sub: dict[str, Any] = (
+            full_report(
+                trades=is_trades,
+                initial_capital=initial_capital,
+                risk_free_rate=risk_free_rate,
+                n_trials=n_trials,
+            )
+            if is_trades
+            else {"error": "no IS trades after embargo"}
+        )
+        oos_sub: dict[str, Any] = (
+            full_report(
+                trades=oos_trades,
+                initial_capital=initial_capital,
+                risk_free_rate=risk_free_rate,
+                n_trials=n_trials,
+            )
+            if oos_trades
+            else {"error": "no OOS trades"}
+        )
+
+        # Sharpe degradation IS → OOS.
+        if isinstance(is_sub.get("sharpe"), (int, float)) and isinstance(
+            oos_sub.get("sharpe"), (int, float)
+        ):
+            s_is = float(is_sub["sharpe"])
+            s_oos = float(oos_sub["sharpe"])
+            if s_is != 0.0 and math.isfinite(s_is) and math.isfinite(s_oos):
+                oos_deg = (s_is - s_oos) / abs(s_is) * 100.0
+            else:
+                oos_deg = 0.0
+        else:
+            oos_deg = 0.0
+
+        report["is_report"] = is_sub
+        report["oos_report"] = oos_sub
+        report["oos_sharpe_degradation"] = oos_deg
+        report["oos_fraction"] = oos_fraction
+        report["embargo_days"] = embargo_days
+
     return report
 
 

--- a/backtesting/metrics.py
+++ b/backtesting/metrics.py
@@ -1044,6 +1044,8 @@ def _split_trades_is_oos(
         Lopez de Prado (2018). AFML Chapter 7.
         Pardo (2008). Chapter 5.
     """
+    if embargo_days < 0:
+        raise ValueError(f"embargo_days must be non-negative, got {embargo_days}")
     if oos_fraction <= 0.0 or oos_fraction >= 1.0:
         msg = f"oos_fraction must be in (0, 1), got {oos_fraction}"
         raise ValueError(msg)
@@ -1103,6 +1105,10 @@ def full_report(
         profit_factor, avg_win, avg_loss, psr, dsr, sharpe_ci_95_low,
         sharpe_ci_95_high, by_session, by_regime, by_signal, equity_curve.
     """
+    if oos_fraction != 0.0:
+        if not math.isfinite(oos_fraction) or oos_fraction < 0.0 or oos_fraction >= 1.0:
+            raise ValueError(f"oos_fraction must be finite and in [0, 1), got {oos_fraction!r}")
+
     if not trades:
         return {"error": "no trades"}
 

--- a/tests/unit/backtesting/test_metrics.py
+++ b/tests/unit/backtesting/test_metrics.py
@@ -660,3 +660,63 @@ def test_regime_sharpe_uses_caller_risk_free_rate() -> None:
         "Per-regime Sharpe did not change with risk_free_rate — "
         "rf is not being forwarded to _regime_stats()"
     )
+
+
+# ---------------------------------------------------------------------------
+# OOS walk-forward gate (ADR-0002 Section A item 2)
+# ---------------------------------------------------------------------------
+
+
+def test_oos_split_produces_is_and_oos_reports() -> None:
+    """full_report(oos_fraction=0.3) returns IS and OOS sub-reports."""
+    trades, initial = _seeded_equity_curve(n_days=60, seed=42)
+    report = full_report(trades=trades, initial_capital=initial, oos_fraction=0.3)
+    assert "is_report" in report
+    assert "oos_report" in report
+    assert "sharpe" in report["is_report"]
+    assert "sharpe" in report["oos_report"]
+    assert "oos_sharpe_degradation" in report
+
+
+def test_oos_embargo_removes_trades_near_boundary() -> None:
+    """Embargo gap removes IS trades near the OOS start."""
+    trades, initial = _seeded_equity_curve(n_days=60, seed=42)
+    report_no_embargo = full_report(
+        trades=trades, initial_capital=initial, oos_fraction=0.3, embargo_days=0
+    )
+    report_with_embargo = full_report(
+        trades=trades, initial_capital=initial, oos_fraction=0.3, embargo_days=5
+    )
+    is_count_no = report_no_embargo["is_report"]["trade_count"]
+    is_count_with = report_with_embargo["is_report"]["trade_count"]
+    # Embargo must remove at least some trades from IS
+    assert is_count_with <= is_count_no
+
+
+def test_oos_fraction_zero_has_no_split_fields() -> None:
+    """Default oos_fraction=0.0 produces no IS/OOS fields."""
+    trades, initial = _seeded_equity_curve(seed=42)
+    report = full_report(trades=trades, initial_capital=initial)
+    assert "is_report" not in report
+    assert "oos_report" not in report
+    assert "oos_sharpe_degradation" not in report
+
+
+def test_oos_trade_counts_sum_correctly() -> None:
+    """IS + OOS + embargo trades = total trades."""
+    trades, initial = _seeded_equity_curve(n_days=60, seed=42)
+    report = full_report(trades=trades, initial_capital=initial, oos_fraction=0.3, embargo_days=0)
+    is_count = report["is_report"]["trade_count"]
+    oos_count = report["oos_report"]["trade_count"]
+    assert is_count + oos_count == len(trades)
+
+
+def test_oos_sharpe_degradation_computed_correctly() -> None:
+    """Manual verification of degradation formula."""
+    trades, initial = _seeded_equity_curve(n_days=60, seed=42)
+    report = full_report(trades=trades, initial_capital=initial, oos_fraction=0.3, embargo_days=0)
+    s_is = report["is_report"]["sharpe"]
+    s_oos = report["oos_report"]["sharpe"]
+    if s_is != 0.0:
+        expected = (s_is - s_oos) / abs(s_is) * 100.0
+        assert report["oos_sharpe_degradation"] == pytest.approx(expected, rel=1e-9)

--- a/tests/unit/backtesting/test_metrics.py
+++ b/tests/unit/backtesting/test_metrics.py
@@ -690,7 +690,10 @@ def test_oos_embargo_removes_trades_near_boundary() -> None:
     is_count_no = report_no_embargo["is_report"]["trade_count"]
     is_count_with = report_with_embargo["is_report"]["trade_count"]
     # Embargo must remove at least some trades from IS
-    assert is_count_with <= is_count_no
+    assert is_count_with < is_count_no, (
+        f"Embargo of 5 days should remove at least 1 IS trade, "
+        f"but IS count is {is_count_with} in both cases"
+    )
 
 
 def test_oos_fraction_zero_has_no_split_fields() -> None:
@@ -703,12 +706,25 @@ def test_oos_fraction_zero_has_no_split_fields() -> None:
 
 
 def test_oos_trade_counts_sum_correctly() -> None:
-    """IS + OOS + embargo trades = total trades."""
+    """IS + OOS trades = total (no embargo); with embargo, IS shrinks."""
     trades, initial = _seeded_equity_curve(n_days=60, seed=42)
-    report = full_report(trades=trades, initial_capital=initial, oos_fraction=0.3, embargo_days=0)
-    is_count = report["is_report"]["trade_count"]
-    oos_count = report["oos_report"]["trade_count"]
-    assert is_count + oos_count == len(trades)
+
+    # No embargo: IS + OOS = total
+    report_no = full_report(
+        trades=trades, initial_capital=initial, oos_fraction=0.3, embargo_days=0
+    )
+    is_no = report_no["is_report"]["trade_count"]
+    oos_no = report_no["oos_report"]["trade_count"]
+    assert is_no + oos_no == len(trades)
+
+    # With embargo: IS + OOS < total (embargo removed some IS trades)
+    report_emb = full_report(
+        trades=trades, initial_capital=initial, oos_fraction=0.3, embargo_days=5
+    )
+    is_emb = report_emb["is_report"]["trade_count"]
+    oos_emb = report_emb["oos_report"]["trade_count"]
+    assert is_emb + oos_emb < len(trades), "With embargo, IS + OOS should be less than total trades"
+    assert oos_emb == oos_no, "OOS count should be unaffected by embargo"
 
 
 def test_oos_sharpe_degradation_computed_correctly() -> None:
@@ -720,3 +736,17 @@ def test_oos_sharpe_degradation_computed_correctly() -> None:
     if s_is != 0.0:
         expected = (s_is - s_oos) / abs(s_is) * 100.0
         assert report["oos_sharpe_degradation"] == pytest.approx(expected, rel=1e-9)
+
+
+def test_oos_fraction_nan_raises_value_error() -> None:
+    """Regression: NaN oos_fraction must raise, not silently skip."""
+    trades, initial = _seeded_equity_curve(seed=42)
+    with pytest.raises(ValueError, match="oos_fraction"):
+        full_report(trades=trades, initial_capital=initial, oos_fraction=float("nan"))
+
+
+def test_oos_negative_embargo_raises_value_error() -> None:
+    """Regression: negative embargo_days must raise."""
+    trades, initial = _seeded_equity_curve(seed=42)
+    with pytest.raises(ValueError, match="embargo_days"):
+        full_report(trades=trades, initial_capital=initial, oos_fraction=0.3, embargo_days=-1)


### PR DESCRIPTION
## Summary

Adds optional IS/OOS walk-forward split with embargo to `full_report()`, implementing ADR-0002 Section A item 2. When `oos_fraction > 0`, trades are split chronologically into in-sample and out-of-sample sets with a configurable embargo gap, and separate sub-reports are computed for each half. Returns `oos_sharpe_degradation` to quantify IS-to-OOS Sharpe decay.

Default `oos_fraction=0.0` preserves full backward compatibility — no existing behavior changes.

## Linked issue
Closes #29

## Methodology Compliance (ADR-0002)

This PR has been evaluated against the Quant Methodology Charter.
Check each box or write "N/A — reason" on the same line.

### Evaluation basis
- [x] Sharpe computed on daily-resampled equity-curve returns (not per-trade)
- [x] Sortino and Calmar reported alongside Sharpe
- [x] Max drawdown (absolute and %) reported
- [x] Ulcer Index reported
- [x] Return distribution stats: skewness, excess kurtosis, tail ratio

### Out-of-sample discipline
- [x] Strict train/test split OR walk-forward with purging+embargo (LdP 2018 Ch. 7)
- [x] OOS holdout ≥ 30 % of the data — configurable via `oos_fraction`, recommended 0.3
- [x] No parameter tuned on the OOS period — sub-reports use same params as caller

### Statistical significance
- [x] 95 % confidence interval on Sharpe via stationary bootstrap (Politis-Romano 1994)
- [x] Probabilistic Sharpe Ratio reported (Bailey & López de Prado 2012)
- [x] If N > 1 variants evaluated: Deflated Sharpe OR Haircut Sharpe reported

### Cross-validation (if applicable)
- [x] Combinatorial Purged CV (LdP 2018 Ch. 12) rather than k-fold — N/A, orthogonal feature
- [x] PBO (Probability of Backtest Overfitting) reported — N/A, orthogonal feature

### Execution realism
- [x] Transaction costs applied (spread + commission) — N/A, additive feature
- [x] Slippage model: Almgren-Chriss or documented equivalent — N/A
- [x] Tested under zero-cost / realistic-cost / stress-cost (2x realistic) — N/A
- [x] Strategy remains profitable under realistic-cost scenario — N/A

### Capacity and turnover
- [ ] Annualized turnover reported — N/A, not in scope for this PR
- [ ] Alpha decay half-life estimated — N/A
- [ ] Capacity estimate — N/A

### Regime decomposition
- [x] Sharpe, DD, hit rate decomposed by at least one regime axis (vol or trend) — existing feature
- [x] Single-regime dependence declared if applicable — existing feature

### Code discipline
- [x] All prices and sizes use `Decimal`, never `float`
- [x] All timestamps use `datetime.now(UTC)`
- [x] Docstrings cite the academic reference for any non-trivial formula
- [x] mypy --strict clean, ruff clean
- [x] `make preflight` green (paste the tail below)

## Academic references cited
- Lopez de Prado (2018). AFML Chapter 7 — purging and embargo for cross-validation in finance
- Pardo (2008). The Evaluation and Optimization of Trading Strategies, Chapter 5 — walk-forward analysis
- ADR-0002 Section A item 2

## Preflight output
```
mypy --strict: Success, no issues found in 2 source files
ruff check: All checks passed
ruff format: 2 files already formatted
pytest tests/unit/: 681 passed in 41.32s
```

## Reviewer notes
- `_split_trades_is_oos()` sorts by `exit_timestamp_ms`, splits at `int(len * (1 - oos_fraction))`, and removes IS trades whose exit falls within `embargo_days` calendar days of OOS start
- Recursive `full_report()` calls for sub-reports do NOT pass `oos_fraction` — infinite recursion guard
- 5 new property tests covering: sub-report presence, embargo effect, backward compat, trade count arithmetic, degradation formula

🤖 Generated with [Claude Code](https://claude.com/claude-code)