### PR TITLE
[Phase 2.2] Normalizer v2 — asset-agnostic data pipeline

### DIFF
--- a/services/s01_data_ingestion/normalizer.py
+++ b/services/s01_data_ingestion/normalizer.py
@@ -1,264 +1,53 @@
-"""Tick normalizers for the APEX Trading System Data Ingestion Service.
+"""DEPRECATED — Use services.s01_data_ingestion.normalizers instead.
 
-Provides :class:`SessionTagger` for UTC-timestamp-to-session mapping,
-:class:`BinanceNormalizer` for Binance trade-stream payloads, and
-:class:`AlpacaNormalizer` for Alpaca trade-stream payloads.
-All normalizers produce :class:`~core.models.tick.NormalizedTick` instances.
+This module re-exports legacy classes for backward compatibility.
+All new code should import from the normalizers package directly.
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
-from decimal import Decimal
 from typing import Any
 
-from core.logger import get_logger
-from core.models.tick import Market, NormalizedTick, RawTick, Session, TradeSide
-
-logger = get_logger("s01_data_ingestion.normalizer")
-
-
-class SessionTagger:
-    """Tags a UTC :class:`datetime` with the appropriate :class:`Session` value.
-
-    Session windows (all times UTC):
-
-    * **Weekend**   - Saturday or Sunday (weekday >= 5)
-    * **US Prime**  - 14:30-15:30 (open prime) *or* 20:00-21:00 (close prime)
-    * **US Normal** - 14:30-21:00 outside the prime windows
-    * **London**    - 08:00-10:00
-    * **Asian**     - 00:00-02:00
-    * **After Hours / Unknown** - everything else
-    """
-
-    # Boundaries expressed as (hour, minute) tuples (UTC, inclusive start).
-    _US_OPEN_HM = (14, 30)
-    _US_CLOSE_HM = (21, 0)
-    _PRIME_OPEN_START_HM = (14, 30)
-    _PRIME_OPEN_END_HM = (15, 30)
-    _PRIME_CLOSE_START_HM = (20, 0)
-    _PRIME_CLOSE_END_HM = (21, 0)
-    _LONDON_START_HM = (8, 0)
-    _LONDON_END_HM = (10, 0)
-    _ASIAN_START_HM = (0, 0)
-    _ASIAN_END_HM = (2, 0)
-
-    @staticmethod
-    def _to_minutes(hour: int, minute: int) -> int:
-        """Convert (hour, minute) to total minutes since midnight."""
-        return hour * 60 + minute
-
-    def tag(self, ts: datetime) -> Session:
-        """Return the :class:`Session` for *ts* (must be UTC-aware or naive UTC).
-
-        Args:
-            ts: UTC timestamp to classify.
-
-        Returns:
-            The matching :class:`Session` value.
-        """
-        # Normalise to UTC if timezone info is present.
-        if ts.tzinfo is not None:
-            ts = ts.astimezone(UTC)
-
-        # Weekend check: Python weekday() is 0=Mon … 6=Sun.
-        if ts.weekday() >= 5:
-            return Session.WEEKEND
-
-        total = self._to_minutes(ts.hour, ts.minute)
-
-        prime_open_start = self._to_minutes(*self._PRIME_OPEN_START_HM)
-        prime_open_end = self._to_minutes(*self._PRIME_OPEN_END_HM)
-        prime_close_start = self._to_minutes(*self._PRIME_CLOSE_START_HM)
-        prime_close_end = self._to_minutes(*self._PRIME_CLOSE_END_HM)
-        us_open = self._to_minutes(*self._US_OPEN_HM)
-        us_close = self._to_minutes(*self._US_CLOSE_HM)
-        london_start = self._to_minutes(*self._LONDON_START_HM)
-        london_end = self._to_minutes(*self._LONDON_END_HM)
-        asian_start = self._to_minutes(*self._ASIAN_START_HM)
-        asian_end = self._to_minutes(*self._ASIAN_END_HM)
-
-        if (prime_open_start <= total < prime_open_end) or (
-            prime_close_start <= total < prime_close_end
-        ):
-            return Session.US_PRIME
-
-        if us_open <= total < us_close:
-            return Session.US_NORMAL
-
-        if london_start <= total < london_end:
-            return Session.LONDON
-
-        if asian_start <= total < asian_end:
-            return Session.ASIAN
-
-        return Session.AFTER_HOURS
+from core.models.tick import Market, NormalizedTick
+from services.s01_data_ingestion.normalizers.session_tagger import (
+    SessionTagger as SessionTagger,
+)
 
 
 class BinanceNormalizer:
-    """Normalizes Binance combined-stream trade payloads to :class:`NormalizedTick`.
+    """Legacy wrapper — delegates to :class:`BinanceTickNormalizer`.
 
-    Expected raw-data keys (Binance trade stream ``data`` object):
-
-    * ``s`` - symbol (str)
-    * ``t`` - trade ID (not used directly)
-    * ``T`` - trade timestamp UTC ms (int) - use ``T`` not ``t``
-    * ``p`` - price (str)
-    * ``q`` - quantity / volume (str)
-    * ``m`` - is buyer the market maker (bool); ``True`` → aggressor is SELL
-
-    Optional book-ticker keys (merged from a separate subscription if present):
-
-    * ``b`` - best bid price (str)
-    * ``a`` - best ask price (str)
+    Preserves the old ``normalize(raw_data)`` single-argument API.
     """
 
-    _tagger = SessionTagger()
+    def __init__(self) -> None:
+        from services.s01_data_ingestion.normalizers.binance_tick import (
+            BinanceTickNormalizer,
+        )
+
+        self._impl = BinanceTickNormalizer()
 
     def normalize(self, raw_data: dict[str, Any]) -> NormalizedTick:
-        """Convert a Binance trade ``data`` dict[str, Any] to a :class:`NormalizedTick`.
-
-        Args:
-            raw_data: The ``data`` field from a Binance combined-stream message.
-
-        Returns:
-            A fully populated :class:`NormalizedTick` for the crypto market.
-        """
-        symbol: str = str(raw_data.get("s", "")).upper()
-
-        # Binance uses capital ``T`` for the actual trade execution timestamp (ms).
-        raw_ts = raw_data.get("T") or raw_data.get("t")
-        if not raw_ts:
-            raise ValueError(
-                f"Binance trade payload is missing timestamp fields 'T'/'t': {raw_data}"
-            )
-        timestamp_ms: int = int(raw_ts)
-
-        price = Decimal(str(raw_data["p"]))
-        volume = Decimal(str(raw_data["q"]))
-
-        # ``m=True``  → buyer is the market maker → trade was a SELL aggression.
-        # ``m=False`` → seller is the market maker → trade was a BUY aggression.
-        is_maker_buy: bool = bool(raw_data.get("m", False))
-        side = TradeSide.SELL if is_maker_buy else TradeSide.BUY
-
-        bid: Decimal | None = Decimal(str(raw_data["b"])) if raw_data.get("b") else None
-        ask: Decimal | None = Decimal(str(raw_data["a"])) if raw_data.get("a") else None
-
-        ts_utc = datetime.fromtimestamp(timestamp_ms / 1000.0, tz=UTC)
-        session = self._tagger.tag(ts_utc)
-
-        raw_tick = RawTick(
-            symbol=symbol,
-            market=Market.CRYPTO,
-            timestamp_ms=timestamp_ms,
-            price=price,
-            volume=volume,
-            side=side,
-            bid=bid,
-            ask=ask,
-            raw_data=raw_data,
-        )
-
-        return NormalizedTick(
-            symbol=symbol,
-            market=Market.CRYPTO,
-            timestamp_ms=timestamp_ms,
-            price=price,
-            volume=volume,
-            side=side,
-            bid=bid,
-            ask=ask,
-            session=session,
-            source_tick=raw_tick,
-        )
+        """Normalize a Binance trade payload (legacy single-arg API)."""
+        return self._impl.normalize_legacy(raw_data)
 
 
 class AlpacaNormalizer:
-    """Normalizes Alpaca trade-stream payloads to :class:`NormalizedTick`.
+    """Legacy wrapper — delegates to :class:`AlpacaTickNormalizer`.
 
-    Expected raw-data keys (Alpaca ``T="t"`` trade message):
-
-    * ``S`` - symbol (str)
-    * ``t`` - ISO 8601 timestamp string (e.g. ``"2024-01-15T14:30:00.123456789Z"``)
-    * ``p`` - price (float)
-    * ``s`` - size / volume (float)
-    * ``c`` - conditions list (list[str]); not reliably buy/sell, default UNKNOWN
+    Preserves the old ``normalize(raw_data)`` single-argument API.
     """
 
-    _tagger = SessionTagger()
+    def __init__(self) -> None:
+        from services.s01_data_ingestion.normalizers.alpaca_tick import (
+            AlpacaTickNormalizer,
+        )
+
+        self._impl = AlpacaTickNormalizer()
 
     def normalize(self, raw_data: dict[str, Any]) -> NormalizedTick:
-        """Convert an Alpaca trade message dict[str, Any] to a :class:`NormalizedTick`.
-
-        Args:
-            raw_data: A single Alpaca trade event dict[str, Any].
-
-        Returns:
-            A fully populated :class:`NormalizedTick` for the equity market.
-        """
-        symbol: str = str(raw_data.get("S", "")).upper()
-
-        # Alpaca sends ISO 8601 strings; strip sub-second nanos beyond 6 digits.
-        raw_ts: str = str(raw_data.get("t", ""))
-        ts_utc = self._parse_alpaca_timestamp(raw_ts)
-        timestamp_ms: int = int(ts_utc.timestamp() * 1000)
-
-        price = Decimal(str(raw_data["p"]))
-        volume = Decimal(str(raw_data["s"]))
-
-        # Alpaca trade conditions do not reliably encode aggressor side.
-        side = TradeSide.UNKNOWN
-
-        session = self._tagger.tag(ts_utc)
-
-        raw_tick = RawTick(
-            symbol=symbol,
-            market=Market.EQUITY,
-            timestamp_ms=timestamp_ms,
-            price=price,
-            volume=volume,
-            side=side,
-            raw_data=raw_data,
-        )
-
-        return NormalizedTick(
-            symbol=symbol,
-            market=Market.EQUITY,
-            timestamp_ms=timestamp_ms,
-            price=price,
-            volume=volume,
-            side=side,
-            session=session,
-            source_tick=raw_tick,
-        )
-
-    @staticmethod
-    def _parse_alpaca_timestamp(raw: str) -> datetime:
-        """Parse an Alpaca ISO 8601 timestamp to a UTC-aware :class:`datetime`.
-
-        Handles nanosecond precision by truncating to microseconds.
-
-        Args:
-            raw: ISO timestamp string, e.g. ``"2024-01-15T14:30:00.123456789Z"``.
-
-        Returns:
-            UTC-aware :class:`datetime`.
-        """
-        # Replace trailing Z with +00:00 for fromisoformat compatibility.
-        normalised = raw.replace("Z", "+00:00")
-
-        # Truncate sub-second component to at most 6 digits (microseconds).
-        if "." in normalised:
-            dot_idx = normalised.index(".")
-            tz_idx = (
-                normalised.index("+", dot_idx) if "+" in normalised[dot_idx:] else len(normalised)
-            )
-            sub_second = normalised[dot_idx + 1 : tz_idx]
-            truncated_sub = sub_second[:6].ljust(6, "0")
-            normalised = normalised[: dot_idx + 1] + truncated_sub + normalised[tz_idx:]
-
-        return datetime.fromisoformat(normalised)
+        """Normalize an Alpaca trade payload (legacy single-arg API)."""
+        return self._impl.normalize_legacy(raw_data)
 
 
 class NormalizerFactory:

--- a/services/s01_data_ingestion/normalizers/__init__.py
+++ b/services/s01_data_ingestion/normalizers/__init__.py
@@ -1,0 +1,23 @@
+"""APEX Normalizer v2 — asset-agnostic data normalization."""
+
+from services.s01_data_ingestion.normalizers.alpaca_tick import (
+    AlpacaTickNormalizer as AlpacaTickNormalizer,
+)
+from services.s01_data_ingestion.normalizers.asset_resolver import (
+    AssetResolver as AssetResolver,
+)
+from services.s01_data_ingestion.normalizers.base import (
+    NormalizerStrategy as NormalizerStrategy,
+)
+from services.s01_data_ingestion.normalizers.binance_bar import (
+    BinanceBarNormalizer as BinanceBarNormalizer,
+)
+from services.s01_data_ingestion.normalizers.binance_tick import (
+    BinanceTickNormalizer as BinanceTickNormalizer,
+)
+from services.s01_data_ingestion.normalizers.router import (
+    NormalizerRouter as NormalizerRouter,
+)
+from services.s01_data_ingestion.normalizers.session_tagger import (
+    SessionTagger as SessionTagger,
+)

--- a/services/s01_data_ingestion/normalizers/alpaca_tick.py
+++ b/services/s01_data_ingestion/normalizers/alpaca_tick.py
@@ -1,0 +1,112 @@
+"""Alpaca trade-stream tick normalizer.
+
+Refactored from the monolithic ``normalizer.py`` AlpacaNormalizer.
+Produces :class:`~core.models.tick.NormalizedTick` from Alpaca trade events.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from core.models.data import Asset
+from core.models.tick import Market, NormalizedTick, RawTick, TradeSide
+from services.s01_data_ingestion.normalizers.base import NormalizerStrategy
+from services.s01_data_ingestion.normalizers.session_tagger import SessionTagger
+
+
+class AlpacaTickNormalizer(NormalizerStrategy[dict[str, Any], NormalizedTick]):
+    """Normalizes Alpaca trade-stream payloads to :class:`NormalizedTick`.
+
+    Expected raw-data keys (Alpaca ``T="t"`` trade message):
+
+    * ``S`` - symbol (str)
+    * ``t`` - ISO 8601 timestamp string
+    * ``p`` - price (float)
+    * ``s`` - size / volume (float)
+    * ``c`` - conditions list (list[str])
+    """
+
+    _tagger = SessionTagger()
+
+    def normalize(self, raw: dict[str, Any], asset: Asset) -> NormalizedTick:
+        """Convert an Alpaca trade message dict to a :class:`NormalizedTick`.
+
+        Args:
+            raw: A single Alpaca trade event dict.
+            asset: The resolved asset (reserved for future use).
+
+        Returns:
+            A fully populated :class:`NormalizedTick` for the equity market.
+        """
+        return self._normalize_raw(raw)
+
+    def normalize_legacy(self, raw_data: dict[str, Any]) -> NormalizedTick:
+        """Legacy API — normalize without requiring an Asset.
+
+        Preserves backward compatibility with code that calls
+        ``AlpacaNormalizer().normalize(raw_data)``.
+        """
+        return self._normalize_raw(raw_data)
+
+    def _normalize_raw(self, raw_data: dict[str, Any]) -> NormalizedTick:
+        """Core normalization logic (shared by new and legacy APIs)."""
+        symbol: str = str(raw_data.get("S", "")).upper()
+
+        raw_ts: str = str(raw_data.get("t", ""))
+        ts_utc = self._parse_alpaca_timestamp(raw_ts)
+        timestamp_ms: int = int(ts_utc.timestamp() * 1000)
+
+        price = Decimal(str(raw_data["p"]))
+        volume = Decimal(str(raw_data["s"]))
+
+        side = TradeSide.UNKNOWN
+
+        session = self._tagger.tag(ts_utc)
+
+        raw_tick = RawTick(
+            symbol=symbol,
+            market=Market.EQUITY,
+            timestamp_ms=timestamp_ms,
+            price=price,
+            volume=volume,
+            side=side,
+            raw_data=raw_data,
+        )
+
+        return NormalizedTick(
+            symbol=symbol,
+            market=Market.EQUITY,
+            timestamp_ms=timestamp_ms,
+            price=price,
+            volume=volume,
+            side=side,
+            session=session,
+            source_tick=raw_tick,
+        )
+
+    @staticmethod
+    def _parse_alpaca_timestamp(raw: str) -> datetime:
+        """Parse an Alpaca ISO 8601 timestamp to a UTC-aware :class:`datetime`.
+
+        Handles nanosecond precision by truncating to microseconds.
+
+        Args:
+            raw: ISO timestamp string, e.g. ``"2024-01-15T14:30:00.123456789Z"``.
+
+        Returns:
+            UTC-aware :class:`datetime`.
+        """
+        normalised = raw.replace("Z", "+00:00")
+
+        if "." in normalised:
+            dot_idx = normalised.index(".")
+            tz_idx = (
+                normalised.index("+", dot_idx) if "+" in normalised[dot_idx:] else len(normalised)
+            )
+            sub_second = normalised[dot_idx + 1 : tz_idx]
+            truncated_sub = sub_second[:6].ljust(6, "0")
+            normalised = normalised[: dot_idx + 1] + truncated_sub + normalised[tz_idx:]
+
+        return datetime.fromisoformat(normalised)

--- a/services/s01_data_ingestion/normalizers/asset_resolver.py
+++ b/services/s01_data_ingestion/normalizers/asset_resolver.py
@@ -1,0 +1,80 @@
+"""Asset resolver with in-memory cache.
+
+Maps (symbol, exchange) pairs to :class:`~core.models.data.Asset` instances,
+backed by :class:`~core.data.timescale_repository.TimescaleRepository`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.data.timescale_repository import TimescaleRepository
+from core.models.data import Asset
+
+
+class AssetResolver:
+    """Resolves (symbol, exchange) -> Asset with in-memory cache."""
+
+    def __init__(self, repository: TimescaleRepository) -> None:
+        self._repo = repository
+        self._cache: dict[tuple[str, str], Asset] = {}
+
+    async def resolve(self, symbol: str, exchange: str) -> Asset:
+        """Look up an asset by symbol and exchange.
+
+        Args:
+            symbol: Trading symbol (uppercased internally).
+            exchange: Exchange name.
+
+        Returns:
+            The matching :class:`Asset`.
+
+        Raises:
+            ValueError: If the asset is not found.
+        """
+        key = (symbol.upper(), exchange)
+        if key in self._cache:
+            return self._cache[key]
+        asset = await self._repo.get_asset(symbol, exchange)
+        if asset is None:
+            raise ValueError(f"Asset not found: {symbol} on {exchange}")
+        self._cache[key] = asset
+        return asset
+
+    async def resolve_or_create(
+        self, symbol: str, exchange: str, defaults: dict[str, Any]
+    ) -> Asset:
+        """Look up or create an asset.
+
+        Args:
+            symbol: Trading symbol (uppercased internally).
+            exchange: Exchange name.
+            defaults: Default field values passed to
+                :class:`~core.models.data.Asset` if creating a new entry.
+
+        Returns:
+            The existing or newly created :class:`Asset`.
+
+        Raises:
+            RuntimeError: If asset creation fails.
+        """
+        key = (symbol.upper(), exchange)
+        if key in self._cache:
+            return self._cache[key]
+        asset = await self._repo.get_asset(symbol, exchange)
+        if asset is None:
+            new_asset = Asset(
+                symbol=symbol.upper(),
+                exchange=exchange,
+                **defaults,
+            )
+            asset_id = await self._repo.upsert_asset(new_asset)
+            asset = await self._repo.get_asset_by_id(asset_id)
+            if asset is None:
+                raise RuntimeError(f"Failed to create asset: {symbol}@{exchange}")
+        self._cache[key] = asset
+        return asset
+
+    def clear_cache(self) -> None:
+        """Clear the in-memory asset cache."""
+        self._cache.clear()

--- a/services/s01_data_ingestion/normalizers/asset_resolver.py
+++ b/services/s01_data_ingestion/normalizers/asset_resolver.py
@@ -32,10 +32,10 @@ class AssetResolver:
         Raises:
             ValueError: If the asset is not found.
         """
-        key = (symbol.upper(), exchange)
+        key = (symbol.upper(), exchange.upper())
         if key in self._cache:
             return self._cache[key]
-        asset = await self._repo.get_asset(symbol, exchange)
+        asset = await self._repo.get_asset(symbol.upper(), exchange.upper())
         if asset is None:
             raise ValueError(f"Asset not found: {symbol} on {exchange}")
         self._cache[key] = asset
@@ -48,7 +48,7 @@ class AssetResolver:
 
         Args:
             symbol: Trading symbol (uppercased internally).
-            exchange: Exchange name.
+            exchange: Exchange name (uppercased internally).
             defaults: Default field values passed to
                 :class:`~core.models.data.Asset` if creating a new entry.
 
@@ -58,14 +58,14 @@ class AssetResolver:
         Raises:
             RuntimeError: If asset creation fails.
         """
-        key = (symbol.upper(), exchange)
+        key = (symbol.upper(), exchange.upper())
         if key in self._cache:
             return self._cache[key]
-        asset = await self._repo.get_asset(symbol, exchange)
+        asset = await self._repo.get_asset(symbol.upper(), exchange.upper())
         if asset is None:
             new_asset = Asset(
                 symbol=symbol.upper(),
-                exchange=exchange,
+                exchange=exchange.upper(),
                 **defaults,
             )
             asset_id = await self._repo.upsert_asset(new_asset)

--- a/services/s01_data_ingestion/normalizers/base.py
+++ b/services/s01_data_ingestion/normalizers/base.py
@@ -1,0 +1,25 @@
+"""Abstract base for all APEX normalizer strategies.
+
+Implements the Strategy pattern (Gamma et al. 1994) for asset-agnostic
+data normalization.  Each concrete normalizer transforms a raw record
+type ``T_Raw`` into a typed output ``T_Out``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from core.models.data import Asset
+
+
+class NormalizerStrategy[T_Raw, T_Out](ABC):
+    """Base strategy for normalizing raw market data into typed output."""
+
+    @abstractmethod
+    def normalize(self, raw: T_Raw, asset: Asset) -> T_Out:
+        """Transform a single raw record into normalized format."""
+        ...
+
+    def normalize_batch(self, raw_batch: list[T_Raw], asset: Asset) -> list[T_Out]:
+        """Transform a batch. Override for performance-critical paths."""
+        return [self.normalize(r, asset) for r in raw_batch]

--- a/services/s01_data_ingestion/normalizers/binance_bar.py
+++ b/services/s01_data_ingestion/normalizers/binance_bar.py
@@ -1,0 +1,79 @@
+"""Binance kline (candlestick) bar normalizer.
+
+Transforms Binance REST/WS kline arrays into :class:`~core.models.data.Bar`
+instances for TimescaleDB persistence.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from core.models.data import Asset, Bar, BarSize, BarType
+from services.s01_data_ingestion.normalizers.base import NormalizerStrategy
+
+
+class BinanceBarNormalizer(NormalizerStrategy[list[Any], Bar]):
+    """Normalizes Binance kline arrays to :class:`Bar`.
+
+    Binance kline format (list indices):
+
+    * [0]  open_time_ms      (int)
+    * [1]  open              (str)
+    * [2]  high              (str)
+    * [3]  low               (str)
+    * [4]  close             (str)
+    * [5]  volume            (str)
+    * [6]  close_time_ms     (int)
+    * [7]  quote_asset_volume (str)
+    * [8]  number_of_trades  (int)
+    * [9]  taker_buy_base_asset_volume (str)
+    * [10] taker_buy_quote_asset_volume (str)
+    * [11] ignore            (str)
+
+    Args:
+        bar_size: The bar time-frame size (default M1).
+    """
+
+    def __init__(self, bar_size: BarSize = BarSize.M1) -> None:
+        self._bar_size = bar_size
+
+    def normalize(self, raw: list[Any], asset: Asset) -> Bar:
+        """Convert a single Binance kline array to a :class:`Bar`.
+
+        Args:
+            raw: A Binance kline array (12 elements).
+            asset: The resolved asset providing ``asset_id``.
+
+        Returns:
+            A fully populated :class:`Bar`.
+        """
+        open_time_ms = int(raw[0])
+        open_price = Decimal(str(raw[1]))
+        high_price = Decimal(str(raw[2]))
+        low_price = Decimal(str(raw[3]))
+        close_price = Decimal(str(raw[4]))
+        volume = Decimal(str(raw[5]))
+        quote_volume = Decimal(str(raw[7]))
+        trade_count = int(raw[8])
+
+        timestamp = datetime.fromtimestamp(open_time_ms / 1000, tz=UTC)
+
+        vwap: Decimal | None = None
+        if volume > 0:
+            vwap = quote_volume / volume
+
+        return Bar(
+            asset_id=asset.asset_id,
+            bar_type=BarType.TIME,
+            bar_size=self._bar_size,
+            timestamp=timestamp,
+            open=open_price,
+            high=high_price,
+            low=low_price,
+            close=close_price,
+            volume=volume,
+            trade_count=trade_count,
+            vwap=vwap,
+        )

--- a/services/s01_data_ingestion/normalizers/binance_tick.py
+++ b/services/s01_data_ingestion/normalizers/binance_tick.py
@@ -1,0 +1,105 @@
+"""Binance trade-stream tick normalizer.
+
+Refactored from the monolithic ``normalizer.py`` BinanceNormalizer.
+Produces :class:`~core.models.tick.NormalizedTick` from Binance combined-stream
+trade payloads.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from core.models.data import Asset
+from core.models.tick import Market, NormalizedTick, RawTick, TradeSide
+from services.s01_data_ingestion.normalizers.base import NormalizerStrategy
+from services.s01_data_ingestion.normalizers.session_tagger import SessionTagger
+
+
+class BinanceTickNormalizer(NormalizerStrategy[dict[str, Any], NormalizedTick]):
+    """Normalizes Binance combined-stream trade payloads to :class:`NormalizedTick`.
+
+    Expected raw-data keys (Binance trade stream ``data`` object):
+
+    * ``s`` - symbol (str)
+    * ``T`` - trade timestamp UTC ms (int)
+    * ``p`` - price (str)
+    * ``q`` - quantity / volume (str)
+    * ``m`` - is buyer the market maker (bool); ``True`` -> aggressor is SELL
+
+    Optional book-ticker keys:
+
+    * ``b`` - best bid price (str)
+    * ``a`` - best ask price (str)
+    """
+
+    _tagger = SessionTagger()
+
+    def normalize(self, raw: dict[str, Any], asset: Asset) -> NormalizedTick:
+        """Convert a Binance trade ``data`` dict to a :class:`NormalizedTick`.
+
+        Args:
+            raw: The ``data`` field from a Binance combined-stream message.
+            asset: The resolved asset (reserved for future use).
+
+        Returns:
+            A fully populated :class:`NormalizedTick` for the crypto market.
+        """
+        return self._normalize_raw(raw)
+
+    def normalize_legacy(self, raw_data: dict[str, Any]) -> NormalizedTick:
+        """Legacy API — normalize without requiring an Asset.
+
+        Preserves backward compatibility with code that calls
+        ``BinanceNormalizer().normalize(raw_data)``.
+        """
+        return self._normalize_raw(raw_data)
+
+    def _normalize_raw(self, raw_data: dict[str, Any]) -> NormalizedTick:
+        """Core normalization logic (shared by new and legacy APIs)."""
+        symbol: str = str(raw_data.get("s", "")).upper()
+
+        raw_ts = raw_data.get("T") or raw_data.get("t")
+        if not raw_ts:
+            raise ValueError(
+                f"Binance trade payload is missing timestamp fields 'T'/'t': {raw_data}"
+            )
+        timestamp_ms: int = int(raw_ts)
+
+        price = Decimal(str(raw_data["p"]))
+        volume = Decimal(str(raw_data["q"]))
+
+        is_maker_buy: bool = bool(raw_data.get("m", False))
+        side = TradeSide.SELL if is_maker_buy else TradeSide.BUY
+
+        bid: Decimal | None = Decimal(str(raw_data["b"])) if raw_data.get("b") else None
+        ask: Decimal | None = Decimal(str(raw_data["a"])) if raw_data.get("a") else None
+
+        ts_utc = datetime.fromtimestamp(timestamp_ms / 1000.0, tz=UTC)
+        session = self._tagger.tag(ts_utc)
+
+        raw_tick = RawTick(
+            symbol=symbol,
+            market=Market.CRYPTO,
+            timestamp_ms=timestamp_ms,
+            price=price,
+            volume=volume,
+            side=side,
+            bid=bid,
+            ask=ask,
+            raw_data=raw_data,
+        )
+
+        return NormalizedTick(
+            symbol=symbol,
+            market=Market.CRYPTO,
+            timestamp_ms=timestamp_ms,
+            price=price,
+            volume=volume,
+            side=side,
+            bid=bid,
+            ask=ask,
+            session=session,
+            source_tick=raw_tick,
+        )

--- a/services/s01_data_ingestion/normalizers/calendar_event.py
+++ b/services/s01_data_ingestion/normalizers/calendar_event.py
@@ -1,0 +1,19 @@
+"""Calendar / economic event normalizer stub.
+
+Implemented in Phase 2.8.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.models.data import Asset, EconomicEvent
+from services.s01_data_ingestion.normalizers.base import NormalizerStrategy
+
+
+class CalendarEventNormalizer(NormalizerStrategy[dict[str, Any], EconomicEvent]):
+    """Normalizes calendar event data. Implemented in Phase 2.8."""
+
+    def normalize(self, raw: dict[str, Any], asset: Asset) -> EconomicEvent:
+        """Not yet implemented."""
+        raise NotImplementedError("CalendarEventNormalizer: implemented in Phase 2.8")

--- a/services/s01_data_ingestion/normalizers/fred_macro.py
+++ b/services/s01_data_ingestion/normalizers/fred_macro.py
@@ -1,0 +1,19 @@
+"""FRED macroeconomic data normalizer stub.
+
+Implemented in Phase 2.7.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.models.data import Asset, MacroPoint
+from services.s01_data_ingestion.normalizers.base import NormalizerStrategy
+
+
+class FREDMacroNormalizer(NormalizerStrategy[dict[str, Any], MacroPoint]):
+    """Normalizes FRED macro data. Implemented in Phase 2.7."""
+
+    def normalize(self, raw: dict[str, Any], asset: Asset) -> MacroPoint:
+        """Not yet implemented."""
+        raise NotImplementedError("FREDMacroNormalizer: implemented in Phase 2.7")

--- a/services/s01_data_ingestion/normalizers/ibkr_bar.py
+++ b/services/s01_data_ingestion/normalizers/ibkr_bar.py
@@ -1,0 +1,19 @@
+"""Interactive Brokers bar normalizer stub.
+
+Implemented in Phase 2.6.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.models.data import Asset, Bar
+from services.s01_data_ingestion.normalizers.base import NormalizerStrategy
+
+
+class IBKRBarNormalizer(NormalizerStrategy[dict[str, Any], Bar]):
+    """Normalizes IBKR bar data. Implemented in Phase 2.6."""
+
+    def normalize(self, raw: dict[str, Any], asset: Asset) -> Bar:
+        """Not yet implemented."""
+        raise NotImplementedError("IBKRBarNormalizer: implemented in Phase 2.6")

--- a/services/s01_data_ingestion/normalizers/polygon_bar.py
+++ b/services/s01_data_ingestion/normalizers/polygon_bar.py
@@ -1,0 +1,19 @@
+"""Polygon.io bar normalizer stub.
+
+Implemented in Phase 2.5.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.models.data import Asset, Bar
+from services.s01_data_ingestion.normalizers.base import NormalizerStrategy
+
+
+class PolygonBarNormalizer(NormalizerStrategy[dict[str, Any], Bar]):
+    """Normalizes Polygon.io bar data. Implemented in Phase 2.5."""
+
+    def normalize(self, raw: dict[str, Any], asset: Asset) -> Bar:
+        """Not yet implemented."""
+        raise NotImplementedError("PolygonBarNormalizer: implemented in Phase 2.5")

--- a/services/s01_data_ingestion/normalizers/router.py
+++ b/services/s01_data_ingestion/normalizers/router.py
@@ -1,0 +1,44 @@
+"""Normalizer dispatcher for (connector, data_type) pairs.
+
+Routes incoming raw data to the appropriate :class:`NormalizerStrategy`
+registered for the given connector/data_type combination.
+"""
+
+from __future__ import annotations
+
+from core.models.data import Asset
+from services.s01_data_ingestion.normalizers.base import NormalizerStrategy
+
+
+class NormalizerRouter:
+    """Dispatches (connector, data_type) to the registered NormalizerStrategy."""
+
+    def __init__(self) -> None:
+        self._registry: dict[tuple[str, str], NormalizerStrategy[object, object]] = {}
+
+    def register(
+        self, connector: str, data_type: str, normalizer: NormalizerStrategy[object, object]
+    ) -> None:
+        """Register a normalizer for a (connector, data_type) pair."""
+        self._registry[(connector, data_type)] = normalizer
+
+    def get(self, connector: str, data_type: str) -> NormalizerStrategy[object, object]:
+        """Return the normalizer for a (connector, data_type) pair.
+
+        Raises:
+            KeyError: If no normalizer is registered for the pair.
+        """
+        key = (connector, data_type)
+        if key not in self._registry:
+            raise KeyError(f"No normalizer registered for {key}")
+        return self._registry[key]
+
+    def normalize(self, connector: str, data_type: str, raw: object, asset: Asset) -> object:
+        """Normalize a single raw record via the registered strategy."""
+        return self.get(connector, data_type).normalize(raw, asset)
+
+    def normalize_batch(
+        self, connector: str, data_type: str, raw_batch: list[object], asset: Asset
+    ) -> list[object]:
+        """Normalize a batch of raw records via the registered strategy."""
+        return self.get(connector, data_type).normalize_batch(raw_batch, asset)

--- a/services/s01_data_ingestion/normalizers/router.py
+++ b/services/s01_data_ingestion/normalizers/router.py
@@ -38,9 +38,7 @@ class NormalizerRouter:
             raise KeyError(f"No normalizer registered for {key}")
         return self._registry[key]
 
-    def normalize(
-        self, connector: str, data_type: str, raw: object, asset: Asset
-    ) -> object:
+    def normalize(self, connector: str, data_type: str, raw: object, asset: Asset) -> object:
         """Normalize a single raw record via the registered strategy."""
         return self.get(connector, data_type).normalize(raw, asset)
 

--- a/services/s01_data_ingestion/normalizers/router.py
+++ b/services/s01_data_ingestion/normalizers/router.py
@@ -6,6 +6,8 @@ registered for the given connector/data_type combination.
 
 from __future__ import annotations
 
+from typing import Any
+
 from core.models.data import Asset
 from services.s01_data_ingestion.normalizers.base import NormalizerStrategy
 
@@ -14,15 +16,18 @@ class NormalizerRouter:
     """Dispatches (connector, data_type) to the registered NormalizerStrategy."""
 
     def __init__(self) -> None:
-        self._registry: dict[tuple[str, str], NormalizerStrategy[object, object]] = {}
+        self._registry: dict[tuple[str, str], NormalizerStrategy[Any, Any]] = {}
 
     def register(
-        self, connector: str, data_type: str, normalizer: NormalizerStrategy[object, object]
+        self,
+        connector: str,
+        data_type: str,
+        normalizer: NormalizerStrategy[Any, Any],
     ) -> None:
         """Register a normalizer for a (connector, data_type) pair."""
         self._registry[(connector, data_type)] = normalizer
 
-    def get(self, connector: str, data_type: str) -> NormalizerStrategy[object, object]:
+    def get(self, connector: str, data_type: str) -> NormalizerStrategy[Any, Any]:
         """Return the normalizer for a (connector, data_type) pair.
 
         Raises:
@@ -33,7 +38,9 @@ class NormalizerRouter:
             raise KeyError(f"No normalizer registered for {key}")
         return self._registry[key]
 
-    def normalize(self, connector: str, data_type: str, raw: object, asset: Asset) -> object:
+    def normalize(
+        self, connector: str, data_type: str, raw: object, asset: Asset
+    ) -> object:
         """Normalize a single raw record via the registered strategy."""
         return self.get(connector, data_type).normalize(raw, asset)
 

--- a/services/s01_data_ingestion/normalizers/session_tagger.py
+++ b/services/s01_data_ingestion/normalizers/session_tagger.py
@@ -1,0 +1,85 @@
+"""Session tagger — shared across normalizers and backtesting.
+
+Re-exports :class:`SessionTagger` which was originally defined in the
+monolithic ``normalizer.py``.  This module is the canonical home going forward.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from core.models.tick import Session
+
+
+class SessionTagger:
+    """Tags a UTC :class:`datetime` with the appropriate :class:`Session` value.
+
+    Session windows (all times UTC):
+
+    * **Weekend**   - Saturday or Sunday (weekday >= 5)
+    * **US Prime**  - 14:30-15:30 (open prime) *or* 20:00-21:00 (close prime)
+    * **US Normal** - 14:30-21:00 outside the prime windows
+    * **London**    - 08:00-10:00
+    * **Asian**     - 00:00-02:00
+    * **After Hours / Unknown** - everything else
+    """
+
+    _US_OPEN_HM = (14, 30)
+    _US_CLOSE_HM = (21, 0)
+    _PRIME_OPEN_START_HM = (14, 30)
+    _PRIME_OPEN_END_HM = (15, 30)
+    _PRIME_CLOSE_START_HM = (20, 0)
+    _PRIME_CLOSE_END_HM = (21, 0)
+    _LONDON_START_HM = (8, 0)
+    _LONDON_END_HM = (10, 0)
+    _ASIAN_START_HM = (0, 0)
+    _ASIAN_END_HM = (2, 0)
+
+    @staticmethod
+    def _to_minutes(hour: int, minute: int) -> int:
+        """Convert (hour, minute) to total minutes since midnight."""
+        return hour * 60 + minute
+
+    def tag(self, ts: datetime) -> Session:
+        """Return the :class:`Session` for *ts* (must be UTC-aware or naive UTC).
+
+        Args:
+            ts: UTC timestamp to classify.
+
+        Returns:
+            The matching :class:`Session` value.
+        """
+        if ts.tzinfo is not None:
+            ts = ts.astimezone(UTC)
+
+        if ts.weekday() >= 5:
+            return Session.WEEKEND
+
+        total = self._to_minutes(ts.hour, ts.minute)
+
+        prime_open_start = self._to_minutes(*self._PRIME_OPEN_START_HM)
+        prime_open_end = self._to_minutes(*self._PRIME_OPEN_END_HM)
+        prime_close_start = self._to_minutes(*self._PRIME_CLOSE_START_HM)
+        prime_close_end = self._to_minutes(*self._PRIME_CLOSE_END_HM)
+        us_open = self._to_minutes(*self._US_OPEN_HM)
+        us_close = self._to_minutes(*self._US_CLOSE_HM)
+        london_start = self._to_minutes(*self._LONDON_START_HM)
+        london_end = self._to_minutes(*self._LONDON_END_HM)
+        asian_start = self._to_minutes(*self._ASIAN_START_HM)
+        asian_end = self._to_minutes(*self._ASIAN_END_HM)
+
+        if (prime_open_start <= total < prime_open_end) or (
+            prime_close_start <= total < prime_close_end
+        ):
+            return Session.US_PRIME
+
+        if us_open <= total < us_close:
+            return Session.US_NORMAL
+
+        if london_start <= total < london_end:
+            return Session.LONDON
+
+        if asian_start <= total < asian_end:
+            return Session.ASIAN
+
+        return Session.AFTER_HOURS

--- a/tests/unit/s01/test_asset_resolver.py
+++ b/tests/unit/s01/test_asset_resolver.py
@@ -1,0 +1,117 @@
+"""Unit tests for AssetResolver."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.models.data import Asset, AssetClass
+from services.s01_data_ingestion.normalizers.asset_resolver import AssetResolver
+
+
+def _make_asset(symbol: str = "BTCUSDT", exchange: str = "BINANCE") -> Asset:
+    """Create a test Asset."""
+    return Asset(
+        asset_id=uuid.uuid4(),
+        symbol=symbol,
+        exchange=exchange,
+        asset_class=AssetClass.CRYPTO,
+        currency="USD",
+    )
+
+
+def _mock_repo() -> MagicMock:
+    """Create a mock TimescaleRepository with async methods."""
+    repo = MagicMock()
+    repo.get_asset = AsyncMock()
+    repo.get_asset_by_id = AsyncMock()
+    repo.upsert_asset = AsyncMock()
+    return repo
+
+
+class TestAssetResolver:
+    """Tests for AssetResolver."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_found(self) -> None:
+        repo = _mock_repo()
+        asset = _make_asset()
+        repo.get_asset.return_value = asset
+
+        resolver = AssetResolver(repo)
+        result = await resolver.resolve("BTCUSDT", "BINANCE")
+
+        assert result is asset
+        repo.get_asset.assert_awaited_once_with("BTCUSDT", "BINANCE")
+
+    @pytest.mark.asyncio
+    async def test_resolve_not_found(self) -> None:
+        repo = _mock_repo()
+        repo.get_asset.return_value = None
+
+        resolver = AssetResolver(repo)
+        with pytest.raises(ValueError, match="Asset not found"):
+            await resolver.resolve("UNKNOWN", "BINANCE")
+
+    @pytest.mark.asyncio
+    async def test_resolve_cache_hit(self) -> None:
+        repo = _mock_repo()
+        asset = _make_asset()
+        repo.get_asset.return_value = asset
+
+        resolver = AssetResolver(repo)
+        await resolver.resolve("BTCUSDT", "BINANCE")
+        await resolver.resolve("BTCUSDT", "BINANCE")
+
+        # Should only hit repo once due to caching.
+        repo.get_asset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_resolve_or_create_existing(self) -> None:
+        repo = _mock_repo()
+        asset = _make_asset()
+        repo.get_asset.return_value = asset
+
+        resolver = AssetResolver(repo)
+        result = await resolver.resolve_or_create(
+            "BTCUSDT", "BINANCE", {"asset_class": "crypto", "currency": "USD"}
+        )
+
+        assert result is asset
+        repo.upsert_asset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_resolve_or_create_new(self) -> None:
+        repo = _mock_repo()
+        new_asset = _make_asset(symbol="ETHUSDT")
+        repo.get_asset.return_value = None
+        repo.upsert_asset.return_value = new_asset.asset_id
+        repo.get_asset_by_id.return_value = new_asset
+
+        resolver = AssetResolver(repo)
+        result = await resolver.resolve_or_create(
+            "ETHUSDT",
+            "BINANCE",
+            {"asset_class": AssetClass.CRYPTO, "currency": "USD"},
+        )
+
+        assert result is new_asset
+        repo.upsert_asset.assert_awaited_once()
+        repo.get_asset_by_id.assert_awaited_once_with(new_asset.asset_id)
+
+    @pytest.mark.asyncio
+    async def test_clear_cache(self) -> None:
+        repo = _mock_repo()
+        asset = _make_asset()
+        repo.get_asset.return_value = asset
+
+        resolver = AssetResolver(repo)
+        await resolver.resolve("BTCUSDT", "BINANCE")
+
+        resolver.clear_cache()
+        await resolver.resolve("BTCUSDT", "BINANCE")
+
+        # After clearing cache, should hit repo again.
+        assert repo.get_asset.await_count == 2

--- a/tests/unit/s01/test_normalizer_v2.py
+++ b/tests/unit/s01/test_normalizer_v2.py
@@ -1,0 +1,318 @@
+"""Unit tests for Normalizer v2 — Strategy pattern normalizers.
+
+Tests: NormalizerRouter, BinanceTickNormalizer, AlpacaTickNormalizer,
+BinanceBarNormalizer, stub normalizers, and backward compatibility.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.models.data import Asset, AssetClass, Bar, BarSize, BarType
+from core.models.tick import Market, NormalizedTick, Session, TradeSide
+from services.s01_data_ingestion.normalizers.alpaca_tick import AlpacaTickNormalizer
+from services.s01_data_ingestion.normalizers.base import NormalizerStrategy
+from services.s01_data_ingestion.normalizers.binance_bar import BinanceBarNormalizer
+from services.s01_data_ingestion.normalizers.binance_tick import BinanceTickNormalizer
+from services.s01_data_ingestion.normalizers.calendar_event import (
+    CalendarEventNormalizer,
+)
+from services.s01_data_ingestion.normalizers.fred_macro import FREDMacroNormalizer
+from services.s01_data_ingestion.normalizers.ibkr_bar import IBKRBarNormalizer
+from services.s01_data_ingestion.normalizers.polygon_bar import PolygonBarNormalizer
+from services.s01_data_ingestion.normalizers.router import NormalizerRouter
+
+
+def _make_asset(
+    symbol: str = "BTCUSDT",
+    exchange: str = "BINANCE",
+    asset_class: AssetClass = AssetClass.CRYPTO,
+) -> Asset:
+    """Create a test Asset instance."""
+    return Asset(
+        asset_id=uuid.uuid4(),
+        symbol=symbol,
+        exchange=exchange,
+        asset_class=asset_class,
+        currency="USD",
+    )
+
+
+# ── NormalizerRouter ─────────────────────────────────────────────────────────
+
+
+class TestNormalizerRouter:
+    """Tests for NormalizerRouter."""
+
+    def test_register_and_get(self) -> None:
+        router = NormalizerRouter()
+        normalizer = BinanceTickNormalizer()
+        router.register("binance", "tick", normalizer)
+        assert router.get("binance", "tick") is normalizer
+
+    def test_get_unregistered_raises(self) -> None:
+        router = NormalizerRouter()
+        with pytest.raises(KeyError, match="No normalizer registered"):
+            router.get("unknown", "tick")
+
+    def test_normalize_dispatches(self) -> None:
+        router = NormalizerRouter()
+        mock_normalizer = MagicMock(spec=NormalizerStrategy)
+        mock_normalizer.normalize.return_value = "result"
+        router.register("test", "data", mock_normalizer)
+        asset = _make_asset()
+        result = router.normalize("test", "data", {"key": "val"}, asset)
+        assert result == "result"
+        mock_normalizer.normalize.assert_called_once_with({"key": "val"}, asset)
+
+    def test_normalize_batch_dispatches(self) -> None:
+        router = NormalizerRouter()
+        mock_normalizer = MagicMock(spec=NormalizerStrategy)
+        mock_normalizer.normalize_batch.return_value = ["r1", "r2"]
+        router.register("test", "data", mock_normalizer)
+        asset = _make_asset()
+        result = router.normalize_batch("test", "data", [{"a": 1}, {"b": 2}], asset)
+        assert result == ["r1", "r2"]
+        mock_normalizer.normalize_batch.assert_called_once()
+
+
+# ── BinanceTickNormalizer ────────────────────────────────────────────────────
+
+
+class TestBinanceTickNormalizer:
+    """Tests for BinanceTickNormalizer."""
+
+    normalizer = BinanceTickNormalizer()
+    asset = _make_asset()
+
+    def _base_payload(self) -> dict[str, object]:
+        return {
+            "s": "BTCUSDT",
+            "T": 1704725100000,  # 2024-01-08 14:45:00 UTC
+            "p": "45000.50",
+            "q": "0.01",
+            "m": False,
+        }
+
+    def test_normalize_returns_normalized_tick(self) -> None:
+        tick = self.normalizer.normalize(self._base_payload(), self.asset)
+        assert isinstance(tick, NormalizedTick)
+        assert tick.symbol == "BTCUSDT"
+        assert tick.market == Market.CRYPTO
+        assert tick.price == Decimal("45000.50")
+        assert tick.volume == Decimal("0.01")
+        assert tick.side == TradeSide.BUY
+
+    def test_sell_side(self) -> None:
+        payload = {**self._base_payload(), "m": True}
+        tick = self.normalizer.normalize(payload, self.asset)
+        assert tick.side == TradeSide.SELL
+
+    def test_timestamp_ms(self) -> None:
+        tick = self.normalizer.normalize(self._base_payload(), self.asset)
+        assert tick.timestamp_ms == 1704725100000
+
+    def test_session_tagged(self) -> None:
+        tick = self.normalizer.normalize(self._base_payload(), self.asset)
+        assert tick.session == Session.US_PRIME
+
+    def test_bid_ask(self) -> None:
+        payload: dict[str, Any] = {
+            **self._base_payload(),
+            "b": "44999.0",
+            "a": "45001.0",
+        }
+        tick = self.normalizer.normalize(payload, self.asset)
+        assert tick.bid == Decimal("44999.0")
+        assert tick.ask == Decimal("45001.0")
+
+
+# ── AlpacaTickNormalizer ─────────────────────────────────────────────────────
+
+
+class TestAlpacaTickNormalizer:
+    """Tests for AlpacaTickNormalizer."""
+
+    normalizer = AlpacaTickNormalizer()
+    asset = _make_asset(symbol="AAPL", exchange="NYSE", asset_class=AssetClass.EQUITY)
+
+    def _base_payload(self) -> dict[str, object]:
+        return {
+            "S": "AAPL",
+            "t": "2024-01-08T14:30:00.000000000Z",
+            "p": 185.5,
+            "s": 100,
+        }
+
+    def test_normalize_returns_normalized_tick(self) -> None:
+        tick = self.normalizer.normalize(self._base_payload(), self.asset)
+        assert isinstance(tick, NormalizedTick)
+        assert tick.symbol == "AAPL"
+        assert tick.market == Market.EQUITY
+        assert tick.price == Decimal("185.5")
+        assert tick.volume == Decimal("100")
+        assert tick.side == TradeSide.UNKNOWN
+
+    def test_nanosecond_timestamp(self) -> None:
+        payload = {**self._base_payload(), "t": "2024-01-08T14:30:00.123456789Z"}
+        tick = self.normalizer.normalize(payload, self.asset)
+        assert tick.timestamp_ms > 0
+
+    def test_session_tagged(self) -> None:
+        tick = self.normalizer.normalize(self._base_payload(), self.asset)
+        assert tick.session == Session.US_PRIME
+
+
+# ── BinanceBarNormalizer ─────────────────────────────────────────────────────
+
+
+class TestBinanceBarNormalizer:
+    """Tests for BinanceBarNormalizer."""
+
+    normalizer = BinanceBarNormalizer()
+    asset = _make_asset()
+
+    def _kline(self) -> list[Any]:
+        return [
+            1609459200000,  # open_time_ms (2021-01-01 00:00:00 UTC)
+            "29000.0",  # open
+            "29500.0",  # high
+            "28800.0",  # low
+            "29200.0",  # close
+            "1500.5",  # volume
+            1609459259999,  # close_time_ms
+            "43514500.0",  # quote_volume
+            12345,  # num_trades
+            "750.2",  # taker_buy_base_vol
+            "21757250.0",  # taker_buy_quote_vol
+            "0",  # ignore
+        ]
+
+    def test_normalize_returns_bar(self) -> None:
+        bar = self.normalizer.normalize(self._kline(), self.asset)
+        assert isinstance(bar, Bar)
+
+    def test_ohlcv_prices(self) -> None:
+        bar = self.normalizer.normalize(self._kline(), self.asset)
+        assert bar.open == Decimal("29000.0")
+        assert bar.high == Decimal("29500.0")
+        assert bar.low == Decimal("28800.0")
+        assert bar.close == Decimal("29200.0")
+        assert bar.volume == Decimal("1500.5")
+
+    def test_trade_count(self) -> None:
+        bar = self.normalizer.normalize(self._kline(), self.asset)
+        assert bar.trade_count == 12345
+
+    def test_timestamp_utc_aware(self) -> None:
+        bar = self.normalizer.normalize(self._kline(), self.asset)
+        assert bar.timestamp.tzinfo is not None
+        assert bar.timestamp == datetime(2021, 1, 1, 0, 0, 0, tzinfo=UTC)
+
+    def test_vwap_calculated(self) -> None:
+        bar = self.normalizer.normalize(self._kline(), self.asset)
+        expected_vwap = Decimal("43514500.0") / Decimal("1500.5")
+        assert bar.vwap is not None
+        assert bar.vwap == expected_vwap
+
+    def test_vwap_none_when_zero_volume(self) -> None:
+        kline = self._kline()
+        kline[5] = "0"  # zero volume
+        kline[7] = "0"  # zero quote volume
+        bar = self.normalizer.normalize(kline, self.asset)
+        assert bar.vwap is None
+
+    def test_bar_type_and_size(self) -> None:
+        bar = self.normalizer.normalize(self._kline(), self.asset)
+        assert bar.bar_type == BarType.TIME
+        assert bar.bar_size == BarSize.M1
+
+    def test_custom_bar_size(self) -> None:
+        normalizer = BinanceBarNormalizer(bar_size=BarSize.H1)
+        bar = normalizer.normalize(self._kline(), self.asset)
+        assert bar.bar_size == BarSize.H1
+
+    def test_asset_id_assigned(self) -> None:
+        bar = self.normalizer.normalize(self._kline(), self.asset)
+        assert bar.asset_id == self.asset.asset_id
+
+
+# ── Stubs ────────────────────────────────────────────────────────────────────
+
+
+class TestStubs:
+    """Verify all stub normalizers raise NotImplementedError."""
+
+    asset = _make_asset()
+
+    def test_polygon_bar_raises(self) -> None:
+        with pytest.raises(NotImplementedError, match=r"Phase 2\.5"):
+            PolygonBarNormalizer().normalize({}, self.asset)
+
+    def test_ibkr_bar_raises(self) -> None:
+        with pytest.raises(NotImplementedError, match=r"Phase 2\.6"):
+            IBKRBarNormalizer().normalize({}, self.asset)
+
+    def test_fred_macro_raises(self) -> None:
+        with pytest.raises(NotImplementedError, match=r"Phase 2\.7"):
+            FREDMacroNormalizer().normalize({}, self.asset)
+
+    def test_calendar_event_raises(self) -> None:
+        with pytest.raises(NotImplementedError, match=r"Phase 2\.8"):
+            CalendarEventNormalizer().normalize({}, self.asset)
+
+
+# ── Backward Compatibility ───────────────────────────────────────────────────
+
+
+class TestBackwardCompatibility:
+    """Verify legacy imports from normalizer.py still work."""
+
+    def test_import_binance_normalizer(self) -> None:
+        from services.s01_data_ingestion.normalizer import BinanceNormalizer
+
+        norm = BinanceNormalizer()
+        payload: dict[str, Any] = {
+            "s": "BTCUSDT",
+            "T": 1704725100000,
+            "p": "45000.50",
+            "q": "0.01",
+            "m": False,
+        }
+        tick = norm.normalize(payload)
+        assert isinstance(tick, NormalizedTick)
+        assert tick.symbol == "BTCUSDT"
+        assert tick.price == Decimal("45000.50")
+
+    def test_import_alpaca_normalizer(self) -> None:
+        from services.s01_data_ingestion.normalizer import AlpacaNormalizer
+
+        norm = AlpacaNormalizer()
+        payload: dict[str, Any] = {
+            "S": "AAPL",
+            "t": "2024-01-08T14:30:00.000000000Z",
+            "p": 185.5,
+            "s": 100,
+        }
+        tick = norm.normalize(payload)
+        assert isinstance(tick, NormalizedTick)
+        assert tick.symbol == "AAPL"
+
+    def test_import_normalizer_factory(self) -> None:
+        from services.s01_data_ingestion.normalizer import NormalizerFactory
+
+        norm = NormalizerFactory.create(Market.CRYPTO)
+        assert isinstance(norm, object)
+
+    def test_import_session_tagger(self) -> None:
+        from services.s01_data_ingestion.normalizer import SessionTagger
+
+        tagger = SessionTagger()
+        ts = datetime(2024, 1, 8, 14, 30, tzinfo=UTC)
+        assert tagger.tag(ts) == Session.US_PRIME


### PR DESCRIPTION
Closes #38

## Summary
- Extensible Strategy-pattern normalizer replacing the monolithic BinanceNormalizer/AlpacaNormalizer
- **NormalizerStrategy** ABC with PEP 695 type parameters `[T_Raw, T_Out]`
- **NormalizerRouter** dispatches `(connector, data_type)` pairs to registered strategies
- **AssetResolver** maps `(symbol, exchange)` → `Asset` with in-memory cache
- **SessionTagger** extracted to shared module (used by backtesting + normalizers)

## Normalizers
| Name | Status | Input → Output |
|---|---|---|
| BinanceTickNormalizer | DONE | dict → NormalizedTick |
| AlpacaTickNormalizer | DONE | dict → NormalizedTick |
| BinanceBarNormalizer | DONE | kline list → Bar |
| PolygonBarNormalizer | STUB | Phase 2.5 |
| IBKRBarNormalizer | STUB | Phase 2.6 |
| FREDMacroNormalizer | STUB | Phase 2.7 |
| CalendarEventNormalizer | STUB | Phase 2.8 |

## Backward compatibility
`normalizer.py` re-exports all legacy classes (`BinanceNormalizer`, `AlpacaNormalizer`, `NormalizerFactory`, `SessionTagger`) — zero breaking changes.

## Checklist
- [x] mypy --strict clean
- [x] ruff clean
- [x] 810 tests green (775 existing + 35 new)
- [x] Legacy imports verified in tests

Refs: Gamma (1994), Martin (2017), Bouchaud (2018)