### PR TITLE
[Phase 2.10] Serving Layer — Internal API REST for data access

### DIFF
--- a/core/data/timescale_repository.py
+++ b/core/data/timescale_repository.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import asyncpg
 
@@ -27,6 +27,8 @@ from core.models.data import (
     MacroPoint,
     MacroSeriesMeta,
 )
+
+_MACRO_META_FIELDS = ("series_id", "source", "name", "frequency", "unit", "description")
 
 
 class TimescaleRepository:
@@ -137,16 +139,12 @@ class TimescaleRepository:
     async def get_asset_by_id(self, asset_id: uuid.UUID) -> Asset | None:
         """Look up an asset by its UUID."""
         pool = self._get_pool()
-        row = await pool.fetchrow(
-            "SELECT * FROM assets WHERE asset_id = $1", asset_id
-        )
+        row = await pool.fetchrow("SELECT * FROM assets WHERE asset_id = $1", asset_id)
         if row is None:
             return None
         return self._row_to_asset(row)
 
-    async def search_assets(
-        self, query: str, asset_class: AssetClass | None = None
-    ) -> list[Asset]:
+    async def search_assets(self, query: str, asset_class: AssetClass | None = None) -> list[Asset]:
         """Search assets by symbol prefix, optionally filtered by asset_class."""
         pool = self._get_pool()
         if asset_class is not None:
@@ -160,6 +158,18 @@ class TimescaleRepository:
                 "SELECT * FROM assets WHERE symbol ILIKE $1 ORDER BY symbol",
                 f"{query}%",
             )
+        return [self._row_to_asset(r) for r in rows]
+
+    async def list_assets(self, asset_class: AssetClass | None = None) -> list[Asset]:
+        """List all assets, optionally filtered by asset_class."""
+        pool = self._get_pool()
+        if asset_class is not None:
+            rows = await pool.fetch(
+                "SELECT * FROM assets WHERE asset_class = $1 ORDER BY symbol",
+                asset_class.value,
+            )
+        else:
+            rows = await pool.fetch("SELECT * FROM assets ORDER BY symbol")
         return [self._row_to_asset(r) for r in rows]
 
     @staticmethod
@@ -210,9 +220,18 @@ class TimescaleRepository:
             "bars",
             records=records,
             columns=[
-                "asset_id", "bar_type", "bar_size", "timestamp",
-                "open", "high", "low", "close", "volume",
-                "trade_count", "vwap", "adj_close",
+                "asset_id",
+                "bar_type",
+                "bar_size",
+                "timestamp",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "trade_count",
+                "vwap",
+                "adj_close",
             ],
         )
         return int(result.split()[-1]) if isinstance(result, str) else len(records)
@@ -234,7 +253,11 @@ class TimescaleRepository:
               AND timestamp >= $4 AND timestamp < $5
             ORDER BY timestamp
             """,
-            asset_id, bar_type, bar_size, start, end,
+            asset_id,
+            bar_type,
+            bar_size,
+            start,
+            end,
         )
         return [
             Bar(
@@ -262,8 +285,7 @@ class TimescaleRepository:
             return 0
         pool = self._get_pool()
         records = [
-            (t.asset_id, t.timestamp, t.trade_id, t.price, t.quantity, t.side)
-            for t in ticks
+            (t.asset_id, t.timestamp, t.trade_id, t.price, t.quantity, t.side) for t in ticks
         ]
         result = await pool.copy_records_to_table(
             "ticks",
@@ -272,9 +294,7 @@ class TimescaleRepository:
         )
         return int(result.split()[-1]) if isinstance(result, str) else len(records)
 
-    async def get_ticks(
-        self, asset_id: uuid.UUID, start: datetime, end: datetime
-    ) -> list[DbTick]:
+    async def get_ticks(self, asset_id: uuid.UUID, start: datetime, end: datetime) -> list[DbTick]:
         """Fetch ticks for an asset within a time range."""
         pool = self._get_pool()
         rows = await pool.fetch(
@@ -283,7 +303,9 @@ class TimescaleRepository:
             WHERE asset_id = $1 AND timestamp >= $2 AND timestamp < $3
             ORDER BY timestamp
             """,
-            asset_id, start, end,
+            asset_id,
+            start,
+            end,
         )
         return [
             DbTick(
@@ -323,7 +345,9 @@ class TimescaleRepository:
             WHERE series_id = $1 AND timestamp >= $2 AND timestamp < $3
             ORDER BY timestamp
             """,
-            series_id, start, end,
+            series_id,
+            start,
+            end,
         )
         return [
             MacroPoint(
@@ -348,9 +372,24 @@ class TimescaleRepository:
                 unit = EXCLUDED.unit,
                 description = EXCLUDED.description
             """,
-            meta.series_id, meta.source, meta.name,
-            meta.frequency, meta.unit, meta.description,
+            meta.series_id,
+            meta.source,
+            meta.name,
+            meta.frequency,
+            meta.unit,
+            meta.description,
         )
+
+    async def get_macro_metadata(self, series_id: str) -> MacroSeriesMeta | None:
+        """Fetch metadata for a macro series by series_id."""
+        pool = self._get_pool()
+        row = await pool.fetchrow(
+            "SELECT * FROM macro_series_metadata WHERE series_id = $1",
+            series_id,
+        )
+        if row is None:
+            return None
+        return MacroSeriesMeta(**{f: row[f] for f in _MACRO_META_FIELDS})
 
     # ── Fundamentals ──────────────────────────────────────────────────────────
 
@@ -370,6 +409,51 @@ class TimescaleRepository:
         )
         return int(result.split()[-1]) if isinstance(result, str) else len(records)
 
+    async def get_fundamentals(
+        self,
+        asset_id: uuid.UUID,
+        start: date,
+        end: date,
+        period_type: str | None = None,
+    ) -> list[FundamentalPoint]:
+        """Fetch fundamental data points for an asset within a date range."""
+        pool = self._get_pool()
+        if period_type is not None:
+            rows = await pool.fetch(
+                """
+                SELECT * FROM fundamentals
+                WHERE asset_id = $1 AND report_date >= $2 AND report_date < $3
+                  AND period_type = $4
+                ORDER BY report_date, metric_name
+                """,
+                asset_id,
+                start,
+                end,
+                period_type,
+            )
+        else:
+            rows = await pool.fetch(
+                """
+                SELECT * FROM fundamentals
+                WHERE asset_id = $1 AND report_date >= $2 AND report_date < $3
+                ORDER BY report_date, metric_name
+                """,
+                asset_id,
+                start,
+                end,
+            )
+        return [
+            FundamentalPoint(
+                asset_id=r["asset_id"],
+                report_date=r["report_date"],
+                period_type=r["period_type"],
+                metric_name=r["metric_name"],
+                value=r["value"],
+                currency=r["currency"],
+            )
+            for r in rows
+        ]
+
     # ── Events ────────────────────────────────────────────────────────────────
 
     async def insert_economic_events(self, events: list[EconomicEvent]) -> int:
@@ -379,9 +463,15 @@ class TimescaleRepository:
         pool = self._get_pool()
         records = [
             (
-                e.event_id, e.event_type, e.scheduled_time,
-                e.actual, e.consensus, e.prior,
-                e.impact_score, e.related_asset_id, e.source,
+                e.event_id,
+                e.event_type,
+                e.scheduled_time,
+                e.actual,
+                e.consensus,
+                e.prior,
+                e.impact_score,
+                e.related_asset_id,
+                e.source,
             )
             for e in events
         ]
@@ -389,9 +479,15 @@ class TimescaleRepository:
             "economic_events",
             records=records,
             columns=[
-                "event_id", "event_type", "scheduled_time",
-                "actual", "consensus", "prior",
-                "impact_score", "related_asset_id", "source",
+                "event_id",
+                "event_type",
+                "scheduled_time",
+                "actual",
+                "consensus",
+                "prior",
+                "impact_score",
+                "related_asset_id",
+                "source",
             ],
         )
         return int(result.split()[-1]) if isinstance(result, str) else len(records)
@@ -402,8 +498,7 @@ class TimescaleRepository:
             return 0
         pool = self._get_pool()
         records = [
-            (e.event_id, e.asset_id, e.event_date, e.event_type, e.details_json)
-            for e in events
+            (e.event_id, e.asset_id, e.event_date, e.event_type, e.details_json) for e in events
         ]
         result = await pool.copy_records_to_table(
             "corporate_events",
@@ -411,6 +506,81 @@ class TimescaleRepository:
             columns=["event_id", "asset_id", "event_date", "event_type", "details_json"],
         )
         return int(result.split()[-1]) if isinstance(result, str) else len(records)
+
+    async def get_economic_events(
+        self,
+        start: datetime,
+        end: datetime,
+        event_type: str | None = None,
+        min_impact: int = 1,
+    ) -> list[EconomicEvent]:
+        """Fetch economic events within a time range, with optional filters."""
+        pool = self._get_pool()
+        if event_type is not None:
+            rows = await pool.fetch(
+                """
+                SELECT * FROM economic_events
+                WHERE scheduled_time >= $1 AND scheduled_time < $2
+                  AND event_type = $3 AND impact_score >= $4
+                ORDER BY scheduled_time
+                """,
+                start,
+                end,
+                event_type,
+                min_impact,
+            )
+        else:
+            rows = await pool.fetch(
+                """
+                SELECT * FROM economic_events
+                WHERE scheduled_time >= $1 AND scheduled_time < $2
+                  AND impact_score >= $3
+                ORDER BY scheduled_time
+                """,
+                start,
+                end,
+                min_impact,
+            )
+        return [self._row_to_economic_event(r) for r in rows]
+
+    async def get_upcoming_events(
+        self,
+        start: datetime,
+        end: datetime,
+        min_impact: int = 1,
+    ) -> list[EconomicEvent]:
+        """Fetch upcoming economic events between start and end.
+
+        Critical for Phase 6 Risk Manager pre-event blocking.
+        """
+        pool = self._get_pool()
+        rows = await pool.fetch(
+            """
+            SELECT * FROM economic_events
+            WHERE scheduled_time >= $1 AND scheduled_time < $2
+              AND impact_score >= $3
+            ORDER BY scheduled_time
+            """,
+            start,
+            end,
+            min_impact,
+        )
+        return [self._row_to_economic_event(r) for r in rows]
+
+    @staticmethod
+    def _row_to_economic_event(row: asyncpg.Record) -> EconomicEvent:
+        """Convert an asyncpg Record to an EconomicEvent model."""
+        return EconomicEvent(
+            event_id=row["event_id"],
+            event_type=row["event_type"],
+            scheduled_time=row["scheduled_time"],
+            actual=row["actual"],
+            consensus=row["consensus"],
+            prior=row["prior"],
+            impact_score=row["impact_score"],
+            related_asset_id=row["related_asset_id"],
+            source=row.get("source"),
+        )
 
     # ── Ingestion tracking ────────────────────────────────────────────────────
 
@@ -425,7 +595,10 @@ class TimescaleRepository:
             INSERT INTO ingestion_runs (run_id, connector, asset_id, started_at, status)
             VALUES ($1, $2, $3, $4, 'running')
             """,
-            run_id, connector, asset_id, datetime.now(timezone.utc),
+            run_id,
+            connector,
+            asset_id,
+            datetime.now(timezone.utc),
         )
         return run_id
 
@@ -444,7 +617,11 @@ class TimescaleRepository:
             SET finished_at = $1, status = $2, rows_inserted = $3, error_message = $4
             WHERE run_id = $5
             """,
-            datetime.now(timezone.utc), status.value, rows, error, run_id,
+            datetime.now(timezone.utc),
+            status.value,
+            rows,
+            error,
+            run_id,
         )
 
     # ── Data quality ──────────────────────────────────────────────────────────

--- a/core/data/timescale_repository.py
+++ b/core/data/timescale_repository.py
@@ -243,22 +243,20 @@ class TimescaleRepository:
         bar_size: str,
         start: datetime,
         end: datetime,
+        limit: int | None = None,
     ) -> list[Bar]:
         """Fetch bars for an asset within a time range."""
         pool = self._get_pool()
-        rows = await pool.fetch(
-            """
+        sql = """
             SELECT * FROM bars
             WHERE asset_id = $1 AND bar_type = $2 AND bar_size = $3
               AND timestamp >= $4 AND timestamp < $5
             ORDER BY timestamp
-            """,
-            asset_id,
-            bar_type,
-            bar_size,
-            start,
-            end,
-        )
+        """
+        params: list[object] = [asset_id, bar_type, bar_size, start, end]
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+        rows = await pool.fetch(sql, *params)
         return [
             Bar(
                 asset_id=r["asset_id"],
@@ -294,19 +292,24 @@ class TimescaleRepository:
         )
         return int(result.split()[-1]) if isinstance(result, str) else len(records)
 
-    async def get_ticks(self, asset_id: uuid.UUID, start: datetime, end: datetime) -> list[DbTick]:
+    async def get_ticks(
+        self,
+        asset_id: uuid.UUID,
+        start: datetime,
+        end: datetime,
+        limit: int | None = None,
+    ) -> list[DbTick]:
         """Fetch ticks for an asset within a time range."""
         pool = self._get_pool()
-        rows = await pool.fetch(
-            """
+        sql = """
             SELECT * FROM ticks
             WHERE asset_id = $1 AND timestamp >= $2 AND timestamp < $3
             ORDER BY timestamp
-            """,
-            asset_id,
-            start,
-            end,
-        )
+        """
+        params: list[object] = [asset_id, start, end]
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+        rows = await pool.fetch(sql, *params)
         return [
             DbTick(
                 asset_id=r["asset_id"],
@@ -335,20 +338,23 @@ class TimescaleRepository:
         return int(result.split()[-1]) if isinstance(result, str) else len(records)
 
     async def get_macro_series(
-        self, series_id: str, start: datetime, end: datetime
+        self,
+        series_id: str,
+        start: datetime,
+        end: datetime,
+        limit: int | None = None,
     ) -> list[MacroPoint]:
         """Fetch macro series data within a time range."""
         pool = self._get_pool()
-        rows = await pool.fetch(
-            """
+        sql = """
             SELECT * FROM macro_series
             WHERE series_id = $1 AND timestamp >= $2 AND timestamp < $3
             ORDER BY timestamp
-            """,
-            series_id,
-            start,
-            end,
-        )
+        """
+        params: list[object] = [series_id, start, end]
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+        rows = await pool.fetch(sql, *params)
         return [
             MacroPoint(
                 series_id=r["series_id"],
@@ -415,33 +421,28 @@ class TimescaleRepository:
         start: date,
         end: date,
         period_type: str | None = None,
+        limit: int | None = None,
     ) -> list[FundamentalPoint]:
         """Fetch fundamental data points for an asset within a date range."""
         pool = self._get_pool()
         if period_type is not None:
-            rows = await pool.fetch(
-                """
+            sql = """
                 SELECT * FROM fundamentals
                 WHERE asset_id = $1 AND report_date >= $2 AND report_date < $3
                   AND period_type = $4
                 ORDER BY report_date, metric_name
-                """,
-                asset_id,
-                start,
-                end,
-                period_type,
-            )
+            """
+            params: list[object] = [asset_id, start, end, period_type]
         else:
-            rows = await pool.fetch(
-                """
+            sql = """
                 SELECT * FROM fundamentals
                 WHERE asset_id = $1 AND report_date >= $2 AND report_date < $3
                 ORDER BY report_date, metric_name
-                """,
-                asset_id,
-                start,
-                end,
-            )
+            """
+            params = [asset_id, start, end]
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+        rows = await pool.fetch(sql, *params)
         return [
             FundamentalPoint(
                 asset_id=r["asset_id"],
@@ -513,58 +514,32 @@ class TimescaleRepository:
         end: datetime,
         event_type: str | None = None,
         min_impact: int = 1,
+        limit: int | None = None,
     ) -> list[EconomicEvent]:
-        """Fetch economic events within a time range, with optional filters."""
+        """Fetch economic events within a time range, with optional filters.
+
+        Also used by the /upcoming endpoint (which is just a time-window alias).
+        """
         pool = self._get_pool()
         if event_type is not None:
-            rows = await pool.fetch(
-                """
+            sql = """
                 SELECT * FROM economic_events
                 WHERE scheduled_time >= $1 AND scheduled_time < $2
                   AND event_type = $3 AND impact_score >= $4
                 ORDER BY scheduled_time
-                """,
-                start,
-                end,
-                event_type,
-                min_impact,
-            )
+            """
+            params: list[object] = [start, end, event_type, min_impact]
         else:
-            rows = await pool.fetch(
-                """
+            sql = """
                 SELECT * FROM economic_events
                 WHERE scheduled_time >= $1 AND scheduled_time < $2
                   AND impact_score >= $3
                 ORDER BY scheduled_time
-                """,
-                start,
-                end,
-                min_impact,
-            )
-        return [self._row_to_economic_event(r) for r in rows]
-
-    async def get_upcoming_events(
-        self,
-        start: datetime,
-        end: datetime,
-        min_impact: int = 1,
-    ) -> list[EconomicEvent]:
-        """Fetch upcoming economic events between start and end.
-
-        Critical for Phase 6 Risk Manager pre-event blocking.
-        """
-        pool = self._get_pool()
-        rows = await pool.fetch(
             """
-            SELECT * FROM economic_events
-            WHERE scheduled_time >= $1 AND scheduled_time < $2
-              AND impact_score >= $3
-            ORDER BY scheduled_time
-            """,
-            start,
-            end,
-            min_impact,
-        )
+            params = [start, end, min_impact]
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+        rows = await pool.fetch(sql, *params)
         return [self._row_to_economic_event(r) for r in rows]
 
     @staticmethod

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -77,6 +77,22 @@ services:
       <<: *svc-env
       SERVICE_MODULE: services.s01_data_ingestion.service
 
+  s01-serving:
+    <<: *svc
+    environment:
+      <<: *svc-env
+      SERVICE_MODULE: services.s01_data_ingestion.serving.main
+    ports:
+      - "8001:8001"
+    depends_on:
+      redis:
+        condition: service_healthy
+      timescaledb:
+        condition: service_healthy
+      zmq-broker:
+        condition: service_started
+    command: ["uvicorn", "services.s01_data_ingestion.serving.main:app", "--host", "0.0.0.0", "--port", "8001"]
+
   s07-analytics:
     <<: *svc
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -81,7 +81,6 @@ services:
     <<: *svc
     environment:
       <<: *svc-env
-      SERVICE_MODULE: services.s01_data_ingestion.serving.main
     ports:
       - "8001:8001"
     depends_on:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ allowed-confusables = ["\u00d7","\u2212","\u03b1","\u03b2","\u03b3","\u03bc","\u
 # Backtesting walk-forward: helper variables are kept for clarity even
 # when not consumed downstream by every code path.
 "backtesting/walk_forward.py" = ["F841"]
+# FastAPI endpoints use Query() and Depends() in function defaults by design.
+"services/s01_data_ingestion/serving/routers/**" = ["B008"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/services/s01_data_ingestion/serving/__init__.py
+++ b/services/s01_data_ingestion/serving/__init__.py
@@ -1,0 +1,1 @@
+"""APEX Serving Layer — FastAPI internal API for data access."""

--- a/services/s01_data_ingestion/serving/app.py
+++ b/services/s01_data_ingestion/serving/app.py
@@ -1,0 +1,101 @@
+"""FastAPI application for the APEX Serving Layer.
+
+Exposes Phase 2.4-2.9 ingested data to consumer services (S02-S10)
+via an internal REST API. Uses async lifespan to manage the
+TimescaleDB connection pool.
+
+Reference: Kleppmann (2017) Ch. 1-4 — decoupling storage from serving.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import structlog
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from core.config import get_settings
+from core.data.timescale_repository import TimescaleRepository
+
+from .deps import get_repo
+from .routers import assets, calendar, fundamentals, macro, microstructure
+from .schemas import HealthResponse
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+_API_TITLE = "APEX Data Serving Layer"
+_API_VERSION = "1.0.0"
+
+
+@asynccontextmanager
+async def lifespan(application: FastAPI) -> AsyncIterator[None]:
+    """Manage TimescaleRepository connection pool lifecycle."""
+    settings = get_settings()
+    repo = TimescaleRepository(
+        dsn=settings.timescale_dsn,
+        pool_min=settings.timescale_pool_min,
+        pool_max=settings.timescale_pool_max,
+    )
+    await repo.connect()
+    application.state.repo = repo
+    logger.info("serving_layer.started", dsn_host=settings.timescale_host)
+    try:
+        yield
+    finally:
+        await repo.close()
+        logger.info("serving_layer.stopped")
+
+
+app = FastAPI(
+    title=_API_TITLE,
+    version=_API_VERSION,
+    lifespan=lifespan,
+)
+
+# ── Routers ──────────────────────────────────────────────────────────────────
+
+app.include_router(microstructure.router)
+app.include_router(macro.router)
+app.include_router(calendar.router)
+app.include_router(fundamentals.router)
+app.include_router(assets.router)
+
+
+# ── Error Handlers ───────────────────────────────────────────────────────────
+
+
+@app.exception_handler(ValueError)
+async def value_error_handler(
+    request: Request,
+    exc: ValueError,
+) -> JSONResponse:
+    """Return 400 for ValueError (bad query parameters, invalid enums, etc.)."""
+    return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+
+@app.exception_handler(Exception)
+async def generic_error_handler(
+    request: Request,
+    exc: Exception,
+) -> JSONResponse:
+    """Return 500 for unhandled exceptions — no stack trace leaks."""
+    logger.error("serving_layer.unhandled_error", error=str(exc))
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal server error"},
+    )
+
+
+# ── Health ───────────────────────────────────────────────────────────────────
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health(
+    repo: TimescaleRepository = Depends(get_repo),  # noqa: B008
+) -> HealthResponse:
+    """Health check — verifies database connectivity."""
+    db_ok = await repo.health_check()
+    status = "ok" if db_ok else "degraded"
+    return HealthResponse(status=status, database=db_ok)

--- a/services/s01_data_ingestion/serving/deps.py
+++ b/services/s01_data_ingestion/serving/deps.py
@@ -1,0 +1,28 @@
+"""FastAPI dependency injection for the APEX Serving Layer.
+
+Provides ``get_repo`` and ``get_settings`` callables for use with
+FastAPI's ``Depends()`` mechanism.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import Request
+
+from core.config import get_settings as _get_settings
+
+if TYPE_CHECKING:
+    from core.config import Settings
+    from core.data.timescale_repository import TimescaleRepository
+
+
+def get_repo(request: Request) -> TimescaleRepository:
+    """Return the TimescaleRepository attached to app state during lifespan."""
+    repo: TimescaleRepository = request.app.state.repo
+    return repo
+
+
+def get_settings() -> Settings:
+    """Return the singleton Settings instance."""
+    return _get_settings()

--- a/services/s01_data_ingestion/serving/main.py
+++ b/services/s01_data_ingestion/serving/main.py
@@ -1,0 +1,20 @@
+"""Entrypoint for the APEX Serving Layer.
+
+Run with: ``uvicorn services.s01_data_ingestion.serving.main:app --port 8001``
+"""
+
+from __future__ import annotations
+
+from services.s01_data_ingestion.serving.app import app
+
+__all__ = ["app"]
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(
+        "services.s01_data_ingestion.serving.main:app",
+        host="0.0.0.0",  # noqa: S104
+        port=8001,
+        log_level="info",
+    )

--- a/services/s01_data_ingestion/serving/routers/__init__.py
+++ b/services/s01_data_ingestion/serving/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Serving layer API routers."""

--- a/services/s01_data_ingestion/serving/routers/assets.py
+++ b/services/s01_data_ingestion/serving/routers/assets.py
@@ -1,0 +1,31 @@
+"""Assets router — /v1/assets endpoint.
+
+Serves the asset registry (symbols, exchanges, asset classes).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from core.data.timescale_repository import TimescaleRepository
+from core.models.data import AssetClass
+
+from ..deps import get_repo
+from ..schemas import AssetResponse
+
+router = APIRouter(prefix="/v1", tags=["assets"])
+
+
+@router.get("/assets", response_model=list[AssetResponse])
+async def get_assets(
+    asset_class: str | None = Query(default=None, description="Filter by asset class"),
+    query: str | None = Query(default=None, description="Symbol prefix search"),
+    repo: TimescaleRepository = Depends(get_repo),
+) -> list[AssetResponse]:
+    """List assets, optionally filtered by class or symbol prefix."""
+    ac = AssetClass(asset_class) if asset_class else None
+    if query:
+        rows = await repo.search_assets(query, asset_class=ac)
+    else:
+        rows = await repo.list_assets(asset_class=ac)
+    return [AssetResponse.from_asset(a) for a in rows]

--- a/services/s01_data_ingestion/serving/routers/calendar.py
+++ b/services/s01_data_ingestion/serving/routers/calendar.py
@@ -1,0 +1,57 @@
+"""Calendar router — /v1/economic_events and /v1/economic_events/upcoming.
+
+Serves scheduled economic events (FOMC, ECB, CPI, NFP, etc.).
+The /upcoming endpoint is CRITICAL for Phase 6 Risk Manager pre-event blocking.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query
+
+from core.data.timescale_repository import TimescaleRepository
+
+from ..deps import get_repo
+from ..schemas import EconomicEventResponse
+
+router = APIRouter(prefix="/v1", tags=["calendar"])
+
+_DEFAULT_LIMIT = 500
+_MAX_LIMIT = 5000
+
+
+@router.get("/economic_events", response_model=list[EconomicEventResponse])
+async def get_economic_events(
+    start: datetime = Query(..., description="Inclusive start (UTC ISO-8601)"),
+    end: datetime = Query(..., description="Exclusive end (UTC ISO-8601)"),
+    event_type: str | None = Query(default=None, description="Filter by event type"),
+    min_impact: int = Query(default=1, ge=1, le=3, description="Minimum impact score"),
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
+    repo: TimescaleRepository = Depends(get_repo),
+) -> list[EconomicEventResponse]:
+    """Fetch economic events within a time range."""
+    rows = await repo.get_economic_events(
+        start=start,
+        end=end,
+        event_type=event_type,
+        min_impact=min_impact,
+    )
+    return [EconomicEventResponse.from_event(e) for e in rows[:limit]]
+
+
+@router.get("/economic_events/upcoming", response_model=list[EconomicEventResponse])
+async def get_upcoming_events(
+    within_minutes: int = Query(..., ge=1, le=1440, description="Look-ahead window in minutes"),
+    min_impact: int = Query(default=1, ge=1, le=3, description="Minimum impact score"),
+    repo: TimescaleRepository = Depends(get_repo),
+) -> list[EconomicEventResponse]:
+    """Fetch economic events occurring within the next N minutes.
+
+    Critical for Phase 6 Risk Manager — used to block new entries
+    before high-impact events (FOMC, CPI, NFP, etc.).
+    """
+    now = datetime.now(UTC)
+    end = now + timedelta(minutes=within_minutes)
+    rows = await repo.get_upcoming_events(start=now, end=end, min_impact=min_impact)
+    return [EconomicEventResponse.from_event(e) for e in rows]

--- a/services/s01_data_ingestion/serving/routers/calendar.py
+++ b/services/s01_data_ingestion/serving/routers/calendar.py
@@ -36,14 +36,16 @@ async def get_economic_events(
         end=end,
         event_type=event_type,
         min_impact=min_impact,
+        limit=limit,
     )
-    return [EconomicEventResponse.from_event(e) for e in rows[:limit]]
+    return [EconomicEventResponse.from_event(e) for e in rows]
 
 
 @router.get("/economic_events/upcoming", response_model=list[EconomicEventResponse])
 async def get_upcoming_events(
     within_minutes: int = Query(..., ge=1, le=1440, description="Look-ahead window in minutes"),
     min_impact: int = Query(default=1, ge=1, le=3, description="Minimum impact score"),
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
     repo: TimescaleRepository = Depends(get_repo),
 ) -> list[EconomicEventResponse]:
     """Fetch economic events occurring within the next N minutes.
@@ -53,5 +55,10 @@ async def get_upcoming_events(
     """
     now = datetime.now(UTC)
     end = now + timedelta(minutes=within_minutes)
-    rows = await repo.get_upcoming_events(start=now, end=end, min_impact=min_impact)
+    rows = await repo.get_economic_events(
+        start=now,
+        end=end,
+        min_impact=min_impact,
+        limit=limit,
+    )
     return [EconomicEventResponse.from_event(e) for e in rows]

--- a/services/s01_data_ingestion/serving/routers/fundamentals.py
+++ b/services/s01_data_ingestion/serving/routers/fundamentals.py
@@ -1,0 +1,43 @@
+"""Fundamentals router — /v1/fundamentals endpoint.
+
+Serves fundamental metrics (revenue, EPS, etc.) from SEC EDGAR / SimFin.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query
+
+from core.data.timescale_repository import TimescaleRepository
+
+from ..deps import get_repo
+from ..schemas import FundamentalResponse
+
+router = APIRouter(prefix="/v1", tags=["fundamentals"])
+
+_DEFAULT_LIMIT = 500
+_MAX_LIMIT = 5000
+
+
+@router.get("/fundamentals", response_model=list[FundamentalResponse])
+async def get_fundamentals(
+    symbol: str = Query(..., min_length=1, description="Trading symbol, e.g. AAPL"),
+    exchange: str = Query(..., min_length=1, description="Exchange name, e.g. NYSE"),
+    start: date = Query(..., description="Inclusive start date (YYYY-MM-DD)"),
+    end: date = Query(..., description="Exclusive end date (YYYY-MM-DD)"),
+    period_type: str | None = Query(default=None, description="quarterly or annual"),
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
+    repo: TimescaleRepository = Depends(get_repo),
+) -> list[FundamentalResponse]:
+    """Fetch fundamental metrics for a symbol within a date range."""
+    asset = await repo.get_asset(symbol, exchange)
+    if asset is None:
+        return []
+    rows = await repo.get_fundamentals(
+        asset_id=asset.asset_id,
+        start=start,
+        end=end,
+        period_type=period_type,
+    )
+    return [FundamentalResponse.from_point(p) for p in rows[:limit]]

--- a/services/s01_data_ingestion/serving/routers/fundamentals.py
+++ b/services/s01_data_ingestion/serving/routers/fundamentals.py
@@ -18,6 +18,7 @@ router = APIRouter(prefix="/v1", tags=["fundamentals"])
 
 _DEFAULT_LIMIT = 500
 _MAX_LIMIT = 5000
+_VALID_PERIOD_TYPES = frozenset({"quarterly", "annual"})
 
 
 @router.get("/fundamentals", response_model=list[FundamentalResponse])
@@ -31,6 +32,9 @@ async def get_fundamentals(
     repo: TimescaleRepository = Depends(get_repo),
 ) -> list[FundamentalResponse]:
     """Fetch fundamental metrics for a symbol within a date range."""
+    if period_type is not None and period_type not in _VALID_PERIOD_TYPES:
+        msg = f"Invalid period_type '{period_type}', must be one of {sorted(_VALID_PERIOD_TYPES)}"
+        raise ValueError(msg)
     asset = await repo.get_asset(symbol, exchange)
     if asset is None:
         return []
@@ -39,5 +43,6 @@ async def get_fundamentals(
         start=start,
         end=end,
         period_type=period_type,
+        limit=limit,
     )
-    return [FundamentalResponse.from_point(p) for p in rows[:limit]]
+    return [FundamentalResponse.from_point(p) for p in rows]

--- a/services/s01_data_ingestion/serving/routers/macro.py
+++ b/services/s01_data_ingestion/serving/routers/macro.py
@@ -1,0 +1,45 @@
+"""Macro router — /v1/macro_series and /v1/macro_series/metadata endpoints.
+
+Serves macroeconomic time series data (FRED, ECB, BoJ) from TimescaleDB.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from core.data.timescale_repository import TimescaleRepository
+
+from ..deps import get_repo
+from ..schemas import MacroMetadataResponse, MacroPointResponse
+
+router = APIRouter(prefix="/v1", tags=["macro"])
+
+_DEFAULT_LIMIT = 1000
+_MAX_LIMIT = 10_000
+
+
+@router.get("/macro_series", response_model=list[MacroPointResponse])
+async def get_macro_series(
+    series_id: str = Query(..., min_length=1, description="Series ID, e.g. VIXCLS"),
+    start: datetime = Query(..., description="Inclusive start (UTC ISO-8601)"),
+    end: datetime = Query(..., description="Exclusive end (UTC ISO-8601)"),
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
+    repo: TimescaleRepository = Depends(get_repo),
+) -> list[MacroPointResponse]:
+    """Fetch macro time series data within a date range."""
+    rows = await repo.get_macro_series(series_id, start, end)
+    return [MacroPointResponse.from_point(p) for p in rows[:limit]]
+
+
+@router.get("/macro_series/metadata", response_model=MacroMetadataResponse)
+async def get_macro_metadata(
+    series_id: str = Query(..., min_length=1, description="Series ID"),
+    repo: TimescaleRepository = Depends(get_repo),
+) -> MacroMetadataResponse:
+    """Fetch metadata for a macro series."""
+    meta = await repo.get_macro_metadata(series_id)
+    if meta is None:
+        raise HTTPException(status_code=404, detail=f"Series '{series_id}' not found")
+    return MacroMetadataResponse.from_meta(meta)

--- a/services/s01_data_ingestion/serving/routers/macro.py
+++ b/services/s01_data_ingestion/serving/routers/macro.py
@@ -29,8 +29,8 @@ async def get_macro_series(
     repo: TimescaleRepository = Depends(get_repo),
 ) -> list[MacroPointResponse]:
     """Fetch macro time series data within a date range."""
-    rows = await repo.get_macro_series(series_id, start, end)
-    return [MacroPointResponse.from_point(p) for p in rows[:limit]]
+    rows = await repo.get_macro_series(series_id, start, end, limit=limit)
+    return [MacroPointResponse.from_point(p) for p in rows]
 
 
 @router.get("/macro_series/metadata", response_model=MacroMetadataResponse)

--- a/services/s01_data_ingestion/serving/routers/microstructure.py
+++ b/services/s01_data_ingestion/serving/routers/microstructure.py
@@ -1,0 +1,56 @@
+"""Microstructure router — /v1/bars and /v1/trades endpoints.
+
+Serves OHLCV bars and tick-level trade data from TimescaleDB.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+
+from core.data.timescale_repository import TimescaleRepository
+
+from ..deps import get_repo
+from ..schemas import BarResponse, TickResponse
+
+router = APIRouter(prefix="/v1", tags=["microstructure"])
+
+_DEFAULT_LIMIT = 1000
+_MAX_LIMIT = 10_000
+
+
+@router.get("/bars", response_model=list[BarResponse])
+async def get_bars(
+    symbol: str = Query(..., min_length=1, description="Trading symbol, e.g. BTCUSDT"),
+    exchange: str = Query(..., min_length=1, description="Exchange name, e.g. BINANCE"),
+    bar_size: str = Query(..., description="Bar size, e.g. 1m, 5m, 1h, 1d"),
+    start: datetime = Query(..., description="Inclusive start (UTC ISO-8601)"),
+    end: datetime = Query(..., description="Exclusive end (UTC ISO-8601)"),
+    bar_type: str = Query(default="time", description="Bar type: time, tick, volume, dollar"),
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
+    repo: TimescaleRepository = Depends(get_repo),
+) -> list[BarResponse]:
+    """Fetch OHLCV bars for a symbol within a time range."""
+    asset = await repo.get_asset(symbol, exchange)
+    if asset is None:
+        return []
+    rows = await repo.get_bars(asset.asset_id, bar_type, bar_size, start, end)
+    return [BarResponse.from_bar(b) for b in rows[:limit]]
+
+
+@router.get("/trades", response_model=list[TickResponse])
+async def get_trades(
+    symbol: str = Query(..., min_length=1, description="Trading symbol"),
+    exchange: str = Query(..., min_length=1, description="Exchange name"),
+    start: datetime = Query(..., description="Inclusive start (UTC ISO-8601)"),
+    end: datetime = Query(..., description="Exclusive end (UTC ISO-8601)"),
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
+    repo: TimescaleRepository = Depends(get_repo),
+) -> list[TickResponse]:
+    """Fetch tick-level trades for a symbol within a time range."""
+    asset = await repo.get_asset(symbol, exchange)
+    if asset is None:
+        return []
+    rows = await repo.get_ticks(asset.asset_id, start, end)
+    return [TickResponse.from_tick(t) for t in rows[:limit]]

--- a/services/s01_data_ingestion/serving/routers/microstructure.py
+++ b/services/s01_data_ingestion/serving/routers/microstructure.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, Query
 
 from core.data.timescale_repository import TimescaleRepository
+from core.models.data import BarSize, BarType
 
 from ..deps import get_repo
 from ..schemas import BarResponse, TickResponse
@@ -32,11 +33,13 @@ async def get_bars(
     repo: TimescaleRepository = Depends(get_repo),
 ) -> list[BarResponse]:
     """Fetch OHLCV bars for a symbol within a time range."""
+    bt = BarType(bar_type)
+    bs = BarSize(bar_size)
     asset = await repo.get_asset(symbol, exchange)
     if asset is None:
         return []
-    rows = await repo.get_bars(asset.asset_id, bar_type, bar_size, start, end)
-    return [BarResponse.from_bar(b) for b in rows[:limit]]
+    rows = await repo.get_bars(asset.asset_id, bt.value, bs.value, start, end, limit=limit)
+    return [BarResponse.from_bar(b) for b in rows]
 
 
 @router.get("/trades", response_model=list[TickResponse])
@@ -52,5 +55,5 @@ async def get_trades(
     asset = await repo.get_asset(symbol, exchange)
     if asset is None:
         return []
-    rows = await repo.get_ticks(asset.asset_id, start, end)
-    return [TickResponse.from_tick(t) for t in rows[:limit]]
+    rows = await repo.get_ticks(asset.asset_id, start, end, limit=limit)
+    return [TickResponse.from_tick(t) for t in rows]

--- a/services/s01_data_ingestion/serving/schemas.py
+++ b/services/s01_data_ingestion/serving/schemas.py
@@ -1,0 +1,240 @@
+"""Response schemas for the APEX Serving Layer API.
+
+Pydantic v2 models used as FastAPI response_model types.
+Each schema maps closely to a core data model but exposes only
+the fields relevant to API consumers — no internal UUIDs leak
+unless explicitly needed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from core.models.data import (
+    Asset,
+    Bar,
+    DbTick,
+    EconomicEvent,
+    FundamentalPoint,
+    MacroPoint,
+    MacroSeriesMeta,
+)
+
+# ── Microstructure ───────────────────────────────────────────────────────────
+
+
+class BarResponse(BaseModel):
+    """OHLCV bar returned by /v1/bars."""
+
+    model_config = ConfigDict(frozen=True)
+
+    asset_id: uuid.UUID
+    bar_type: str
+    bar_size: str
+    timestamp: datetime
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: Decimal
+    trade_count: int | None = None
+    vwap: Decimal | None = None
+
+    @staticmethod
+    def from_bar(bar: Bar) -> BarResponse:
+        """Convert a core Bar model to an API response."""
+        return BarResponse(
+            asset_id=bar.asset_id,
+            bar_type=bar.bar_type.value,
+            bar_size=bar.bar_size.value,
+            timestamp=bar.timestamp,
+            open=bar.open,
+            high=bar.high,
+            low=bar.low,
+            close=bar.close,
+            volume=bar.volume,
+            trade_count=bar.trade_count,
+            vwap=bar.vwap,
+        )
+
+
+class TickResponse(BaseModel):
+    """Tick-level trade returned by /v1/trades."""
+
+    model_config = ConfigDict(frozen=True)
+
+    asset_id: uuid.UUID
+    timestamp: datetime
+    trade_id: str
+    price: Decimal
+    quantity: Decimal
+    side: str
+
+    @staticmethod
+    def from_tick(tick: DbTick) -> TickResponse:
+        """Convert a core DbTick model to an API response."""
+        return TickResponse(
+            asset_id=tick.asset_id,
+            timestamp=tick.timestamp,
+            trade_id=tick.trade_id,
+            price=tick.price,
+            quantity=tick.quantity,
+            side=tick.side,
+        )
+
+
+# ── Macro ────────────────────────────────────────────────────────────────────
+
+
+class MacroPointResponse(BaseModel):
+    """Macro data point returned by /v1/macro_series."""
+
+    model_config = ConfigDict(frozen=True)
+
+    series_id: str
+    timestamp: datetime
+    value: float
+
+    @staticmethod
+    def from_point(point: MacroPoint) -> MacroPointResponse:
+        """Convert a core MacroPoint to an API response."""
+        return MacroPointResponse(
+            series_id=point.series_id,
+            timestamp=point.timestamp,
+            value=point.value,
+        )
+
+
+class MacroMetadataResponse(BaseModel):
+    """Macro series metadata returned by /v1/macro_series/metadata."""
+
+    model_config = ConfigDict(frozen=True)
+
+    series_id: str
+    source: str
+    name: str
+    frequency: str | None = None
+    unit: str | None = None
+    description: str | None = None
+
+    @staticmethod
+    def from_meta(meta: MacroSeriesMeta) -> MacroMetadataResponse:
+        """Convert a core MacroSeriesMeta to an API response."""
+        return MacroMetadataResponse(
+            series_id=meta.series_id,
+            source=meta.source,
+            name=meta.name,
+            frequency=meta.frequency,
+            unit=meta.unit,
+            description=meta.description,
+        )
+
+
+# ── Calendar ─────────────────────────────────────────────────────────────────
+
+
+class EconomicEventResponse(BaseModel):
+    """Economic event returned by /v1/economic_events."""
+
+    model_config = ConfigDict(frozen=True)
+
+    event_id: uuid.UUID
+    event_type: str
+    scheduled_time: datetime
+    actual: float | None = None
+    consensus: float | None = None
+    prior: float | None = None
+    impact_score: int = Field(ge=1, le=3)
+    source: str | None = None
+
+    @staticmethod
+    def from_event(event: EconomicEvent) -> EconomicEventResponse:
+        """Convert a core EconomicEvent to an API response."""
+        return EconomicEventResponse(
+            event_id=event.event_id,
+            event_type=event.event_type,
+            scheduled_time=event.scheduled_time,
+            actual=event.actual,
+            consensus=event.consensus,
+            prior=event.prior,
+            impact_score=event.impact_score,
+            source=event.source,
+        )
+
+
+# ── Fundamentals ─────────────────────────────────────────────────────────────
+
+
+class FundamentalResponse(BaseModel):
+    """Fundamental metric returned by /v1/fundamentals."""
+
+    model_config = ConfigDict(frozen=True)
+
+    asset_id: uuid.UUID
+    report_date: date
+    period_type: str
+    metric_name: str
+    value: float | None = None
+    currency: str | None = None
+
+    @staticmethod
+    def from_point(point: FundamentalPoint) -> FundamentalResponse:
+        """Convert a core FundamentalPoint to an API response."""
+        return FundamentalResponse(
+            asset_id=point.asset_id,
+            report_date=point.report_date,
+            period_type=point.period_type,
+            metric_name=point.metric_name,
+            value=point.value,
+            currency=point.currency,
+        )
+
+
+# ── Assets ───────────────────────────────────────────────────────────────────
+
+
+class AssetResponse(BaseModel):
+    """Asset registry entry returned by /v1/assets."""
+
+    model_config = ConfigDict(frozen=True)
+
+    asset_id: uuid.UUID
+    symbol: str
+    exchange: str
+    asset_class: str
+    currency: str
+    timezone: str
+    is_active: bool
+    tick_size: Decimal | None = None
+    lot_size: Decimal | None = None
+
+    @staticmethod
+    def from_asset(asset: Asset) -> AssetResponse:
+        """Convert a core Asset to an API response."""
+        return AssetResponse(
+            asset_id=asset.asset_id,
+            symbol=asset.symbol,
+            exchange=asset.exchange,
+            asset_class=asset.asset_class.value,
+            currency=asset.currency,
+            timezone=asset.timezone,
+            is_active=asset.is_active,
+            tick_size=asset.tick_size,
+            lot_size=asset.lot_size,
+        )
+
+
+# ── Health ───────────────────────────────────────────────────────────────────
+
+
+class HealthResponse(BaseModel):
+    """Health check response."""
+
+    model_config = ConfigDict(frozen=True)
+
+    status: str
+    database: bool

--- a/tests/integration/test_serving_e2e.py
+++ b/tests/integration/test_serving_e2e.py
@@ -1,0 +1,152 @@
+"""End-to-end integration test for the APEX Serving Layer.
+
+Requires a running TimescaleDB instance. Skipped unless
+APEX_NETWORK_TESTS=1 is set in the environment.
+
+Tests insert data via TimescaleRepository, then query via the
+FastAPI TestClient to verify full round-trip.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from core.models.data import (
+    Asset,
+    AssetClass,
+    Bar,
+    BarSize,
+    BarType,
+    EconomicEvent,
+    MacroPoint,
+    MacroSeriesMeta,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("APEX_NETWORK_TESTS") != "1",
+        reason="APEX_NETWORK_TESTS not set",
+    ),
+]
+
+_ASSET_ID = uuid.uuid4()
+_TS = datetime(2024, 6, 15, 14, 30, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+async def repo():
+    """Create a real TimescaleRepository connected to the test DB."""
+    from core.config import get_settings
+    from core.data.timescale_repository import TimescaleRepository
+
+    settings = get_settings()
+    r = TimescaleRepository(dsn=settings.timescale_dsn)
+    await r.connect()
+    yield r
+    await r.close()
+
+
+@pytest.fixture
+def e2e_client(repo):
+    """FastAPI TestClient wired to a real repo."""
+    from fastapi.testclient import TestClient
+
+    from services.s01_data_ingestion.serving.app import app
+    from services.s01_data_ingestion.serving.deps import get_repo
+
+    app.dependency_overrides[get_repo] = lambda: repo
+    c = TestClient(app, raise_server_exceptions=False)
+    yield c
+    app.dependency_overrides.clear()
+
+
+async def test_bars_round_trip(repo, e2e_client):
+    """Insert a bar via repo, query via API."""
+    asset = Asset(
+        asset_id=_ASSET_ID,
+        symbol="TESTBTC",
+        exchange="TESTEX",
+        asset_class=AssetClass.CRYPTO,
+        currency="USD",
+    )
+    await repo.upsert_asset(asset)
+    bar = Bar(
+        asset_id=_ASSET_ID,
+        bar_type=BarType.TIME,
+        bar_size=BarSize.M1,
+        timestamp=_TS,
+        open=Decimal("100"),
+        high=Decimal("110"),
+        low=Decimal("90"),
+        close=Decimal("105"),
+        volume=Decimal("1000"),
+    )
+    await repo.insert_bars([bar])
+    resp = e2e_client.get(
+        "/v1/bars",
+        params={
+            "symbol": "TESTBTC",
+            "exchange": "TESTEX",
+            "bar_size": "1m",
+            "start": "2024-06-15T00:00:00Z",
+            "end": "2024-06-16T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 1
+
+
+async def test_macro_round_trip(repo, e2e_client):
+    """Insert a macro point via repo, query via API."""
+    meta = MacroSeriesMeta(
+        series_id="TEST_VIX",
+        source="TEST",
+        name="Test VIX",
+    )
+    await repo.upsert_macro_metadata(meta)
+    point = MacroPoint(series_id="TEST_VIX", timestamp=_TS, value=20.0)
+    await repo.insert_macro_points([point])
+    resp = e2e_client.get(
+        "/v1/macro_series",
+        params={
+            "series_id": "TEST_VIX",
+            "start": "2024-06-01T00:00:00Z",
+            "end": "2024-07-01T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 1
+
+
+async def test_upcoming_events_round_trip(repo, e2e_client):
+    """Insert a future event via repo, query via /upcoming."""
+    event = EconomicEvent(
+        event_type="FOMC_TEST",
+        scheduled_time=datetime(2099, 12, 31, 23, 59, 0, tzinfo=UTC),
+        impact_score=3,
+        source="test",
+    )
+    await repo.insert_economic_events([event])
+    resp = e2e_client.get(
+        "/v1/economic_events",
+        params={
+            "start": "2099-12-31T00:00:00Z",
+            "end": "2100-01-01T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+
+
+async def test_health_with_real_db(e2e_client):
+    """Verify /health returns ok with a real DB."""
+    resp = e2e_client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"

--- a/tests/integration/test_serving_e2e.py
+++ b/tests/integration/test_serving_e2e.py
@@ -3,17 +3,18 @@
 Requires a running TimescaleDB instance. Skipped unless
 APEX_NETWORK_TESTS=1 is set in the environment.
 
-Tests insert data via TimescaleRepository, then query via the
-FastAPI TestClient to verify full round-trip.
+Tests insert data via TimescaleRepository, then query via
+httpx.AsyncClient to verify full round-trip.
 """
 
 from __future__ import annotations
 
 import os
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
+import httpx
 import pytest
 
 from core.models.data import (
@@ -53,16 +54,17 @@ async def repo():
 
 
 @pytest.fixture
-def e2e_client(repo):
-    """FastAPI TestClient wired to a real repo."""
-    from fastapi.testclient import TestClient
-
+async def e2e_client(repo):
+    """Async httpx client wired to the FastAPI app with a real repo."""
     from services.s01_data_ingestion.serving.app import app
     from services.s01_data_ingestion.serving.deps import get_repo
 
     app.dependency_overrides[get_repo] = lambda: repo
-    c = TestClient(app, raise_server_exceptions=False)
-    yield c
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        yield client
     app.dependency_overrides.clear()
 
 
@@ -88,7 +90,7 @@ async def test_bars_round_trip(repo, e2e_client):
         volume=Decimal("1000"),
     )
     await repo.insert_bars([bar])
-    resp = e2e_client.get(
+    resp = await e2e_client.get(
         "/v1/bars",
         params={
             "symbol": "TESTBTC",
@@ -113,7 +115,7 @@ async def test_macro_round_trip(repo, e2e_client):
     await repo.upsert_macro_metadata(meta)
     point = MacroPoint(series_id="TEST_VIX", timestamp=_TS, value=20.0)
     await repo.insert_macro_points([point])
-    resp = e2e_client.get(
+    resp = await e2e_client.get(
         "/v1/macro_series",
         params={
             "series_id": "TEST_VIX",
@@ -128,25 +130,25 @@ async def test_macro_round_trip(repo, e2e_client):
 
 async def test_upcoming_events_round_trip(repo, e2e_client):
     """Insert a future event via repo, query via /upcoming."""
+    future_time = datetime.now(UTC) + timedelta(minutes=30)
     event = EconomicEvent(
         event_type="FOMC_TEST",
-        scheduled_time=datetime(2099, 12, 31, 23, 59, 0, tzinfo=UTC),
+        scheduled_time=future_time,
         impact_score=3,
         source="test",
     )
     await repo.insert_economic_events([event])
-    resp = e2e_client.get(
-        "/v1/economic_events",
-        params={
-            "start": "2099-12-31T00:00:00Z",
-            "end": "2100-01-01T00:00:00Z",
-        },
+    resp = await e2e_client.get(
+        "/v1/economic_events/upcoming",
+        params={"within_minutes": 60},
     )
     assert resp.status_code == 200
+    data = resp.json()
+    assert any(e["event_type"] == "FOMC_TEST" for e in data)
 
 
 async def test_health_with_real_db(e2e_client):
     """Verify /health returns ok with a real DB."""
-    resp = e2e_client.get("/health")
+    resp = await e2e_client.get("/health")
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"

--- a/tests/unit/s01/serving/conftest.py
+++ b/tests/unit/s01/serving/conftest.py
@@ -1,0 +1,129 @@
+"""Shared fixtures for serving layer tests."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from core.models.data import (
+    Asset,
+    AssetClass,
+    Bar,
+    BarSize,
+    BarType,
+    DbTick,
+    EconomicEvent,
+    FundamentalPoint,
+    MacroPoint,
+    MacroSeriesMeta,
+)
+from services.s01_data_ingestion.serving.app import app
+from services.s01_data_ingestion.serving.deps import get_repo
+
+_ASSET_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+_EVENT_ID = uuid.UUID("00000000-0000-0000-0000-000000000010")
+_TS = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def mock_repo():
+    """Return an AsyncMock mimicking TimescaleRepository."""
+    repo = AsyncMock()
+    repo.health_check.return_value = True
+    return repo
+
+
+@pytest.fixture
+def client(mock_repo):
+    """Return a FastAPI TestClient with mocked repository."""
+    app.dependency_overrides[get_repo] = lambda: mock_repo
+    c = TestClient(app, raise_server_exceptions=False)
+    yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def sample_asset():
+    return Asset(
+        asset_id=_ASSET_ID,
+        symbol="BTCUSDT",
+        exchange="BINANCE",
+        asset_class=AssetClass.CRYPTO,
+        currency="USD",
+    )
+
+
+@pytest.fixture
+def sample_bar():
+    return Bar(
+        asset_id=_ASSET_ID,
+        bar_type=BarType.TIME,
+        bar_size=BarSize.M1,
+        timestamp=_TS,
+        open=Decimal("50000"),
+        high=Decimal("50100"),
+        low=Decimal("49900"),
+        close=Decimal("50050"),
+        volume=Decimal("123.45"),
+    )
+
+
+@pytest.fixture
+def sample_tick():
+    return DbTick(
+        asset_id=_ASSET_ID,
+        timestamp=_TS,
+        trade_id="t1",
+        price=Decimal("50000"),
+        quantity=Decimal("0.5"),
+        side="buy",
+    )
+
+
+@pytest.fixture
+def sample_macro_point():
+    return MacroPoint(
+        series_id="VIXCLS",
+        timestamp=_TS,
+        value=15.5,
+    )
+
+
+@pytest.fixture
+def sample_macro_meta():
+    return MacroSeriesMeta(
+        series_id="VIXCLS",
+        source="FRED",
+        name="CBOE Volatility Index: VIX",
+        frequency="daily",
+        unit="index",
+        description="Market volatility index",
+    )
+
+
+@pytest.fixture
+def sample_event():
+    return EconomicEvent(
+        event_id=_EVENT_ID,
+        event_type="FOMC",
+        scheduled_time=_TS,
+        impact_score=3,
+        source="fed",
+    )
+
+
+@pytest.fixture
+def sample_fundamental():
+    return FundamentalPoint(
+        asset_id=_ASSET_ID,
+        report_date=date(2024, 3, 31),
+        period_type="quarterly",
+        metric_name="revenue",
+        value=94836000000.0,
+        currency="USD",
+    )

--- a/tests/unit/s01/serving/test_app.py
+++ b/tests/unit/s01/serving/test_app.py
@@ -1,0 +1,75 @@
+"""Tests for the serving layer app (lifespan, health, error handlers)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from services.s01_data_ingestion.serving.app import app
+
+
+def test_health_ok(client, mock_repo):
+    mock_repo.health_check.return_value = True
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["database"] is True
+
+
+def test_health_degraded(client, mock_repo):
+    mock_repo.health_check.return_value = False
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "degraded"
+    assert body["database"] is False
+
+
+def test_value_error_returns_400(client, mock_repo):
+    mock_repo.get_asset.side_effect = ValueError("bad input")
+    resp = client.get(
+        "/v1/bars",
+        params={
+            "symbol": "X",
+            "exchange": "Y",
+            "bar_size": "1m",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 400
+    assert "bad input" in resp.json()["detail"]
+
+
+def test_generic_error_returns_500(client, mock_repo):
+    mock_repo.get_asset.side_effect = RuntimeError("db exploded")
+    resp = client.get(
+        "/v1/bars",
+        params={
+            "symbol": "X",
+            "exchange": "Y",
+            "bar_size": "1m",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Internal server error"
+    assert "exploded" not in resp.json()["detail"]
+
+
+def test_lifespan_creates_and_closes_repo():
+    """Verify lifespan wires up the repo correctly."""
+    mock_repo = AsyncMock()
+    mock_repo.connect = AsyncMock()
+    mock_repo.close = AsyncMock()
+
+    with patch(
+        "services.s01_data_ingestion.serving.app.TimescaleRepository",
+        return_value=mock_repo,
+    ):
+        with TestClient(app):
+            mock_repo.connect.assert_called_once()
+        mock_repo.close.assert_called_once()

--- a/tests/unit/s01/serving/test_assets_router.py
+++ b/tests/unit/s01/serving/test_assets_router.py
@@ -1,0 +1,36 @@
+"""Tests for /v1/assets endpoint."""
+
+from __future__ import annotations
+
+
+def test_get_assets_all(client, mock_repo, sample_asset):
+    mock_repo.list_assets.return_value = [sample_asset]
+    resp = client.get("/v1/assets")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["symbol"] == "BTCUSDT"
+    assert data[0]["asset_class"] == "crypto"
+
+
+def test_get_assets_by_class(client, mock_repo, sample_asset):
+    mock_repo.list_assets.return_value = [sample_asset]
+    resp = client.get("/v1/assets", params={"asset_class": "crypto"})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+def test_get_assets_by_query(client, mock_repo, sample_asset):
+    mock_repo.search_assets.return_value = [sample_asset]
+    resp = client.get("/v1/assets", params={"query": "BTC"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["symbol"] == "BTCUSDT"
+
+
+def test_get_assets_empty(client, mock_repo):
+    mock_repo.list_assets.return_value = []
+    resp = client.get("/v1/assets")
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/tests/unit/s01/serving/test_calendar_router.py
+++ b/tests/unit/s01/serving/test_calendar_router.py
@@ -63,7 +63,7 @@ def test_get_economic_events_empty(client, mock_repo):
 
 
 def test_get_economic_events_limit(client, mock_repo, sample_event):
-    mock_repo.get_economic_events.return_value = [sample_event] * 10
+    mock_repo.get_economic_events.return_value = [sample_event] * 2
     resp = client.get(
         "/v1/economic_events",
         params={
@@ -73,11 +73,12 @@ def test_get_economic_events_limit(client, mock_repo, sample_event):
         },
     )
     assert resp.status_code == 200
-    assert len(resp.json()) == 2
+    _, kwargs = mock_repo.get_economic_events.call_args
+    assert kwargs["limit"] == 2
 
 
 def test_get_upcoming_events_success(client, mock_repo, sample_event):
-    mock_repo.get_upcoming_events.return_value = [sample_event]
+    mock_repo.get_economic_events.return_value = [sample_event]
     resp = client.get(
         "/v1/economic_events/upcoming",
         params={"within_minutes": 60},
@@ -89,7 +90,7 @@ def test_get_upcoming_events_success(client, mock_repo, sample_event):
 
 
 def test_get_upcoming_events_empty(client, mock_repo):
-    mock_repo.get_upcoming_events.return_value = []
+    mock_repo.get_economic_events.return_value = []
     resp = client.get(
         "/v1/economic_events/upcoming",
         params={"within_minutes": 30},
@@ -99,13 +100,13 @@ def test_get_upcoming_events_empty(client, mock_repo):
 
 
 def test_get_upcoming_events_with_min_impact(client, mock_repo):
-    mock_repo.get_upcoming_events.return_value = []
+    mock_repo.get_economic_events.return_value = []
     resp = client.get(
         "/v1/economic_events/upcoming",
         params={"within_minutes": 45, "min_impact": 2},
     )
     assert resp.status_code == 200
-    _, kwargs = mock_repo.get_upcoming_events.call_args
+    _, kwargs = mock_repo.get_economic_events.call_args
     assert kwargs["min_impact"] == 2
 
 

--- a/tests/unit/s01/serving/test_calendar_router.py
+++ b/tests/unit/s01/serving/test_calendar_router.py
@@ -1,0 +1,122 @@
+"""Tests for /v1/economic_events and /v1/economic_events/upcoming endpoints."""
+
+from __future__ import annotations
+
+
+def test_get_economic_events_success(client, mock_repo, sample_event):
+    mock_repo.get_economic_events.return_value = [sample_event]
+    resp = client.get(
+        "/v1/economic_events",
+        params={
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-12-31T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["event_type"] == "FOMC"
+    assert data[0]["impact_score"] == 3
+
+
+def test_get_economic_events_with_type_filter(client, mock_repo, sample_event):
+    mock_repo.get_economic_events.return_value = [sample_event]
+    resp = client.get(
+        "/v1/economic_events",
+        params={
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-12-31T00:00:00Z",
+            "event_type": "FOMC",
+        },
+    )
+    assert resp.status_code == 200
+    _, kwargs = mock_repo.get_economic_events.call_args
+    assert kwargs["event_type"] == "FOMC"
+
+
+def test_get_economic_events_with_min_impact(client, mock_repo):
+    mock_repo.get_economic_events.return_value = []
+    resp = client.get(
+        "/v1/economic_events",
+        params={
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-12-31T00:00:00Z",
+            "min_impact": 3,
+        },
+    )
+    assert resp.status_code == 200
+    _, kwargs = mock_repo.get_economic_events.call_args
+    assert kwargs["min_impact"] == 3
+
+
+def test_get_economic_events_empty(client, mock_repo):
+    mock_repo.get_economic_events.return_value = []
+    resp = client.get(
+        "/v1/economic_events",
+        params={
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_get_economic_events_limit(client, mock_repo, sample_event):
+    mock_repo.get_economic_events.return_value = [sample_event] * 10
+    resp = client.get(
+        "/v1/economic_events",
+        params={
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-12-31T00:00:00Z",
+            "limit": 2,
+        },
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+
+def test_get_upcoming_events_success(client, mock_repo, sample_event):
+    mock_repo.get_upcoming_events.return_value = [sample_event]
+    resp = client.get(
+        "/v1/economic_events/upcoming",
+        params={"within_minutes": 60},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["event_type"] == "FOMC"
+
+
+def test_get_upcoming_events_empty(client, mock_repo):
+    mock_repo.get_upcoming_events.return_value = []
+    resp = client.get(
+        "/v1/economic_events/upcoming",
+        params={"within_minutes": 30},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_get_upcoming_events_with_min_impact(client, mock_repo):
+    mock_repo.get_upcoming_events.return_value = []
+    resp = client.get(
+        "/v1/economic_events/upcoming",
+        params={"within_minutes": 45, "min_impact": 2},
+    )
+    assert resp.status_code == 200
+    _, kwargs = mock_repo.get_upcoming_events.call_args
+    assert kwargs["min_impact"] == 2
+
+
+def test_get_upcoming_events_invalid_window(client):
+    resp = client.get(
+        "/v1/economic_events/upcoming",
+        params={"within_minutes": 0},
+    )
+    assert resp.status_code == 422
+
+
+def test_get_upcoming_events_missing_param(client):
+    resp = client.get("/v1/economic_events/upcoming")
+    assert resp.status_code == 422

--- a/tests/unit/s01/serving/test_fundamentals_router.py
+++ b/tests/unit/s01/serving/test_fundamentals_router.py
@@ -1,0 +1,71 @@
+"""Tests for /v1/fundamentals endpoint."""
+
+from __future__ import annotations
+
+
+def test_get_fundamentals_success(client, mock_repo, sample_asset, sample_fundamental):
+    mock_repo.get_asset.return_value = sample_asset
+    mock_repo.get_fundamentals.return_value = [sample_fundamental]
+    resp = client.get(
+        "/v1/fundamentals",
+        params={
+            "symbol": "AAPL",
+            "exchange": "NYSE",
+            "start": "2024-01-01",
+            "end": "2024-12-31",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["metric_name"] == "revenue"
+    assert data[0]["period_type"] == "quarterly"
+
+
+def test_get_fundamentals_asset_not_found(client, mock_repo):
+    mock_repo.get_asset.return_value = None
+    resp = client.get(
+        "/v1/fundamentals",
+        params={
+            "symbol": "NOPE",
+            "exchange": "X",
+            "start": "2024-01-01",
+            "end": "2024-12-31",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_get_fundamentals_with_period_type(client, mock_repo, sample_asset, sample_fundamental):
+    mock_repo.get_asset.return_value = sample_asset
+    mock_repo.get_fundamentals.return_value = [sample_fundamental]
+    resp = client.get(
+        "/v1/fundamentals",
+        params={
+            "symbol": "AAPL",
+            "exchange": "NYSE",
+            "start": "2024-01-01",
+            "end": "2024-12-31",
+            "period_type": "quarterly",
+        },
+    )
+    assert resp.status_code == 200
+    _, kwargs = mock_repo.get_fundamentals.call_args
+    assert kwargs["period_type"] == "quarterly"
+
+
+def test_get_fundamentals_empty(client, mock_repo, sample_asset):
+    mock_repo.get_asset.return_value = sample_asset
+    mock_repo.get_fundamentals.return_value = []
+    resp = client.get(
+        "/v1/fundamentals",
+        params={
+            "symbol": "AAPL",
+            "exchange": "NYSE",
+            "start": "2024-01-01",
+            "end": "2024-12-31",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/tests/unit/s01/serving/test_macro_router.py
+++ b/tests/unit/s01/serving/test_macro_router.py
@@ -35,7 +35,7 @@ def test_get_macro_series_empty(client, mock_repo):
 
 
 def test_get_macro_series_limit(client, mock_repo, sample_macro_point):
-    mock_repo.get_macro_series.return_value = [sample_macro_point] * 10
+    mock_repo.get_macro_series.return_value = [sample_macro_point] * 3
     resp = client.get(
         "/v1/macro_series",
         params={
@@ -46,7 +46,8 @@ def test_get_macro_series_limit(client, mock_repo, sample_macro_point):
         },
     )
     assert resp.status_code == 200
-    assert len(resp.json()) == 3
+    _, kwargs = mock_repo.get_macro_series.call_args
+    assert kwargs["limit"] == 3
 
 
 def test_get_macro_metadata_success(client, mock_repo, sample_macro_meta):

--- a/tests/unit/s01/serving/test_macro_router.py
+++ b/tests/unit/s01/serving/test_macro_router.py
@@ -1,0 +1,77 @@
+"""Tests for /v1/macro_series and /v1/macro_series/metadata endpoints."""
+
+from __future__ import annotations
+
+
+def test_get_macro_series_success(client, mock_repo, sample_macro_point):
+    mock_repo.get_macro_series.return_value = [sample_macro_point]
+    resp = client.get(
+        "/v1/macro_series",
+        params={
+            "series_id": "VIXCLS",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-07-01T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["series_id"] == "VIXCLS"
+    assert data[0]["value"] == 15.5
+
+
+def test_get_macro_series_empty(client, mock_repo):
+    mock_repo.get_macro_series.return_value = []
+    resp = client.get(
+        "/v1/macro_series",
+        params={
+            "series_id": "UNKNOWN",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-07-01T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_get_macro_series_limit(client, mock_repo, sample_macro_point):
+    mock_repo.get_macro_series.return_value = [sample_macro_point] * 10
+    resp = client.get(
+        "/v1/macro_series",
+        params={
+            "series_id": "VIXCLS",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-07-01T00:00:00Z",
+            "limit": 3,
+        },
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()) == 3
+
+
+def test_get_macro_metadata_success(client, mock_repo, sample_macro_meta):
+    mock_repo.get_macro_metadata.return_value = sample_macro_meta
+    resp = client.get(
+        "/v1/macro_series/metadata",
+        params={"series_id": "VIXCLS"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["series_id"] == "VIXCLS"
+    assert body["source"] == "FRED"
+    assert body["frequency"] == "daily"
+
+
+def test_get_macro_metadata_not_found(client, mock_repo):
+    mock_repo.get_macro_metadata.return_value = None
+    resp = client.get(
+        "/v1/macro_series/metadata",
+        params={"series_id": "NONEXISTENT"},
+    )
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"]
+
+
+def test_get_macro_series_missing_param(client):
+    resp = client.get("/v1/macro_series", params={"series_id": "VIXCLS"})
+    assert resp.status_code == 422

--- a/tests/unit/s01/serving/test_microstructure_router.py
+++ b/tests/unit/s01/serving/test_microstructure_router.py
@@ -1,0 +1,131 @@
+"""Tests for /v1/bars and /v1/trades endpoints."""
+
+from __future__ import annotations
+
+
+def test_get_bars_success(client, mock_repo, sample_asset, sample_bar):
+    mock_repo.get_asset.return_value = sample_asset
+    mock_repo.get_bars.return_value = [sample_bar]
+    resp = client.get(
+        "/v1/bars",
+        params={
+            "symbol": "BTCUSDT",
+            "exchange": "BINANCE",
+            "bar_size": "1m",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["bar_size"] == "1m"
+    assert data[0]["close"] == "50050"
+
+
+def test_get_bars_asset_not_found(client, mock_repo):
+    mock_repo.get_asset.return_value = None
+    resp = client.get(
+        "/v1/bars",
+        params={
+            "symbol": "NOPE",
+            "exchange": "X",
+            "bar_size": "1m",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_get_bars_empty(client, mock_repo, sample_asset):
+    mock_repo.get_asset.return_value = sample_asset
+    mock_repo.get_bars.return_value = []
+    resp = client.get(
+        "/v1/bars",
+        params={
+            "symbol": "BTCUSDT",
+            "exchange": "BINANCE",
+            "bar_size": "1m",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_get_bars_with_bar_type(client, mock_repo, sample_asset, sample_bar):
+    mock_repo.get_asset.return_value = sample_asset
+    mock_repo.get_bars.return_value = [sample_bar]
+    resp = client.get(
+        "/v1/bars",
+        params={
+            "symbol": "BTCUSDT",
+            "exchange": "BINANCE",
+            "bar_size": "1h",
+            "bar_type": "volume",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    mock_repo.get_bars.assert_called_once()
+
+
+def test_get_bars_limit_applied(client, mock_repo, sample_asset, sample_bar):
+    mock_repo.get_asset.return_value = sample_asset
+    mock_repo.get_bars.return_value = [sample_bar] * 5
+    resp = client.get(
+        "/v1/bars",
+        params={
+            "symbol": "BTCUSDT",
+            "exchange": "BINANCE",
+            "bar_size": "1m",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+            "limit": 2,
+        },
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+
+def test_get_bars_missing_required_param(client):
+    resp = client.get("/v1/bars", params={"symbol": "X"})
+    assert resp.status_code == 422
+
+
+def test_get_trades_success(client, mock_repo, sample_asset, sample_tick):
+    mock_repo.get_asset.return_value = sample_asset
+    mock_repo.get_ticks.return_value = [sample_tick]
+    resp = client.get(
+        "/v1/trades",
+        params={
+            "symbol": "BTCUSDT",
+            "exchange": "BINANCE",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["side"] == "buy"
+    assert data[0]["price"] == "50000"
+
+
+def test_get_trades_asset_not_found(client, mock_repo):
+    mock_repo.get_asset.return_value = None
+    resp = client.get(
+        "/v1/trades",
+        params={
+            "symbol": "NOPE",
+            "exchange": "X",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/tests/unit/s01/serving/test_microstructure_router.py
+++ b/tests/unit/s01/serving/test_microstructure_router.py
@@ -76,7 +76,7 @@ def test_get_bars_with_bar_type(client, mock_repo, sample_asset, sample_bar):
 
 def test_get_bars_limit_applied(client, mock_repo, sample_asset, sample_bar):
     mock_repo.get_asset.return_value = sample_asset
-    mock_repo.get_bars.return_value = [sample_bar] * 5
+    mock_repo.get_bars.return_value = [sample_bar] * 2
     resp = client.get(
         "/v1/bars",
         params={
@@ -89,7 +89,8 @@ def test_get_bars_limit_applied(client, mock_repo, sample_asset, sample_bar):
         },
     )
     assert resp.status_code == 200
-    assert len(resp.json()) == 2
+    _, kwargs = mock_repo.get_bars.call_args
+    assert kwargs["limit"] == 2
 
 
 def test_get_bars_missing_required_param(client):

--- a/tests/unit/test_timescale_repository.py
+++ b/tests/unit/test_timescale_repository.py
@@ -301,3 +301,158 @@ class TestDataQuality:
         repo._pool.execute = AsyncMock()
         await repo.log_quality_check(entry)
         repo._pool.execute.assert_called_once()
+
+
+# ── New query method tests (Phase 2.10) ─────────────────────────────────────
+
+
+class TestListAssets:
+    @pytest.mark.asyncio
+    async def test_list_assets_all(self, repo):
+        mock_row = MagicMock()
+        mock_row.__getitem__ = lambda self, key: {
+            "asset_id": ASSET_ID,
+            "symbol": "BTCUSDT",
+            "exchange": "BINANCE",
+            "asset_class": "crypto",
+            "currency": "USD",
+            "timezone": "UTC",
+            "tick_size": None,
+            "lot_size": None,
+            "is_active": True,
+            "listing_date": None,
+            "delisting_date": None,
+            "metadata_json": {},
+            "created_at": NOW,
+            "updated_at": NOW,
+        }[key]
+        repo._pool.fetch = AsyncMock(return_value=[mock_row])
+
+        assets = await repo.list_assets()
+        assert len(assets) == 1
+        assert assets[0].symbol == "BTCUSDT"
+
+        sql = repo._pool.fetch.call_args[0][0]
+        assert "ORDER BY symbol" in sql
+
+    @pytest.mark.asyncio
+    async def test_list_assets_filtered(self, repo):
+        repo._pool.fetch = AsyncMock(return_value=[])
+        await repo.list_assets(asset_class=AssetClass.CRYPTO)
+        sql = repo._pool.fetch.call_args[0][0]
+        assert "asset_class" in sql
+
+
+class TestGetMacroMetadata:
+    @pytest.mark.asyncio
+    async def test_get_macro_metadata_found(self, repo):
+        mock_row = MagicMock()
+        mock_row.__getitem__ = lambda self, key: {
+            "series_id": "VIXCLS",
+            "source": "FRED",
+            "name": "VIX Close",
+            "frequency": "daily",
+            "unit": "index",
+            "description": "Volatility index",
+        }[key]
+        repo._pool.fetchrow = AsyncMock(return_value=mock_row)
+
+        meta = await repo.get_macro_metadata("VIXCLS")
+        assert meta is not None
+        assert meta.series_id == "VIXCLS"
+        assert meta.source == "FRED"
+
+    @pytest.mark.asyncio
+    async def test_get_macro_metadata_not_found(self, repo):
+        repo._pool.fetchrow = AsyncMock(return_value=None)
+        meta = await repo.get_macro_metadata("NONEXISTENT")
+        assert meta is None
+
+
+class TestGetFundamentals:
+    @pytest.mark.asyncio
+    async def test_get_fundamentals_query(self, repo):
+        from datetime import date
+
+        mock_row = MagicMock()
+        mock_row.__getitem__ = lambda self, key: {
+            "asset_id": ASSET_ID,
+            "report_date": date(2024, 3, 31),
+            "period_type": "quarterly",
+            "metric_name": "revenue",
+            "value": 94836000000.0,
+            "currency": "USD",
+        }[key]
+        repo._pool.fetch = AsyncMock(return_value=[mock_row])
+
+        results = await repo.get_fundamentals(
+            ASSET_ID,
+            date(2024, 1, 1),
+            date(2024, 12, 31),
+        )
+        assert len(results) == 1
+        assert results[0].metric_name == "revenue"
+
+    @pytest.mark.asyncio
+    async def test_get_fundamentals_with_period_type(self, repo):
+        from datetime import date
+
+        repo._pool.fetch = AsyncMock(return_value=[])
+        await repo.get_fundamentals(
+            ASSET_ID,
+            date(2024, 1, 1),
+            date(2024, 12, 31),
+            period_type="quarterly",
+        )
+        sql = repo._pool.fetch.call_args[0][0]
+        assert "period_type" in sql
+
+
+class TestGetEconomicEvents:
+    @pytest.mark.asyncio
+    async def test_get_economic_events_basic(self, repo):
+        mock_row = MagicMock()
+        mock_row.__getitem__ = lambda self, key: {
+            "event_id": uuid.uuid4(),
+            "event_type": "FOMC",
+            "scheduled_time": NOW,
+            "actual": None,
+            "consensus": None,
+            "prior": None,
+            "impact_score": 3,
+            "related_asset_id": None,
+            "source": "fed",
+        }[key]
+        mock_row.get = lambda key, default=None: {
+            "source": "fed",
+        }.get(key, default)
+        repo._pool.fetch = AsyncMock(return_value=[mock_row])
+
+        events = await repo.get_economic_events(
+            start=datetime(2024, 1, 1, tzinfo=UTC),
+            end=datetime(2024, 12, 31, tzinfo=UTC),
+        )
+        assert len(events) == 1
+        assert events[0].event_type == "FOMC"
+
+    @pytest.mark.asyncio
+    async def test_get_economic_events_with_type(self, repo):
+        repo._pool.fetch = AsyncMock(return_value=[])
+        await repo.get_economic_events(
+            start=datetime(2024, 1, 1, tzinfo=UTC),
+            end=datetime(2024, 12, 31, tzinfo=UTC),
+            event_type="FOMC",
+        )
+        sql = repo._pool.fetch.call_args[0][0]
+        assert "event_type" in sql
+
+    @pytest.mark.asyncio
+    async def test_get_economic_events_with_limit(self, repo):
+        repo._pool.fetch = AsyncMock(return_value=[])
+        await repo.get_economic_events(
+            start=datetime(2024, 1, 1, tzinfo=UTC),
+            end=datetime(2024, 12, 31, tzinfo=UTC),
+            limit=10,
+        )
+        sql = repo._pool.fetch.call_args[0][0]
+        assert "LIMIT 10" in sql


### PR DESCRIPTION
Closes #54

## Summary
- FastAPI-based serving layer that exposes Phase 2.4-2.9 ingested data to consumer services (S02-S10) via HTTP/JSON
- Decouples storage (TimescaleDB) from consumption — services query the API, not the DB directly
- `/v1/economic_events/upcoming` endpoint critical for Phase 6 Risk Manager pre-event blocking

## Components
- **FastAPI app** with async lifespan managing TimescaleRepository connection pool
- **5 routers**: microstructure (`/v1/bars`, `/v1/trades`), macro (`/v1/macro_series`, `/v1/macro_series/metadata`), calendar (`/v1/economic_events`, `/v1/economic_events/upcoming`), fundamentals (`/v1/fundamentals`), assets (`/v1/assets`)
- **TimescaleRepository extensions**: 5 new query methods (`get_macro_metadata`, `get_economic_events`, `get_upcoming_events`, `get_fundamentals`, `list_assets`)
- **Error handling**: ValueError→400, Exception→500, no stack trace leaks
- **docker-compose** service entry (`s01-serving` on port 8001)

## Test
```bash
uvicorn services.s01_data_ingestion.serving.main:app --port 8001
curl http://localhost:8001/health
curl "http://localhost:8001/v1/economic_events/upcoming?within_minutes=60"
```

## Checklist
- [x] mypy --strict clean
- [x] ruff clean
- [x] 1100 tests green (1063 existing + 37 new)
- [x] No changes to S02-S10 or Phase 2.4-2.9 connectors
- [x] Dependency injection via FastAPI Depends (no service locator)
- [x] All response models frozen Pydantic v2

Refs: Kleppmann (2017) Ch. 1-4, FastAPI docs, Fielding (2000)