### PR TITLE
[sprint-2] Security & Config hardening: SecretStr + Decimal + mypy core.models

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -262,7 +262,7 @@ class Settings(BaseSettings):
     timescale_db: str = Field(default="apex", description="TimescaleDB database name")
     timescale_user: str = Field(default="apex", description="TimescaleDB user")
     timescale_password: SecretStr = Field(
-        default=SecretStr("apex_secret"), description="TimescaleDB password"
+        default=SecretStr(""), description="TimescaleDB password (must be set via env)"
     )
     timescale_pool_min: int = Field(default=2, description="Min asyncpg pool size")
     timescale_pool_max: int = Field(default=10, description="Max asyncpg pool size")

--- a/core/config.py
+++ b/core/config.py
@@ -38,8 +38,8 @@ class Settings(BaseSettings):
     trading_mode: TradingMode = Field(default=TradingMode.PAPER, description="paper or live")
 
     # ── Alpaca ────────────────────────────────────────────────────────────────
-    alpaca_api_key: str = Field(default="", description="Alpaca API key")
-    alpaca_api_secret: str = Field(default="", description="Alpaca API secret")
+    alpaca_api_key: SecretStr = Field(default=SecretStr(""), description="Alpaca API key")
+    alpaca_api_secret: SecretStr = Field(default=SecretStr(""), description="Alpaca API secret")
     alpaca_base_url: str = Field(
         default="https://paper-api.alpaca.markets",
         description="Alpaca REST base URL",
@@ -50,8 +50,8 @@ class Settings(BaseSettings):
     )
 
     # ── Binance ───────────────────────────────────────────────────────────────
-    binance_api_key: str = Field(default="", description="Binance API key")
-    binance_secret_key: str = Field(default="", description="Binance secret key")
+    binance_api_key: SecretStr = Field(default=SecretStr(""), description="Binance API key")
+    binance_secret_key: SecretStr = Field(default=SecretStr(""), description="Binance secret key")
     binance_testnet: bool = Field(default=True, description="Use Binance testnet")
     binance_rest_url: str = Field(
         default="https://testnet.binance.vision",
@@ -247,12 +247,12 @@ class Settings(BaseSettings):
         default="",
         validation_alias=AliasChoices("alert_smtp_user", "smtp_user"),
     )
-    alert_smtp_password: str = Field(
-        default="",
+    alert_smtp_password: SecretStr = Field(
+        default=SecretStr(""),
         validation_alias=AliasChoices("alert_smtp_password", "smtp_password"),
     )
-    twilio_sid: str | None = Field(default=None, description="Twilio account SID")
-    twilio_token: str | None = Field(default=None, description="Twilio auth token")
+    twilio_sid: SecretStr | None = Field(default=None, description="Twilio account SID")
+    twilio_token: SecretStr | None = Field(default=None, description="Twilio auth token")
     twilio_from_number: str = Field(default="", description="Twilio sender phone number")
     alert_phone_number: str = Field(default="", description="SMS recipient phone number")
 
@@ -261,7 +261,9 @@ class Settings(BaseSettings):
     timescale_port: int = Field(default=5432, description="TimescaleDB port")
     timescale_db: str = Field(default="apex", description="TimescaleDB database name")
     timescale_user: str = Field(default="apex", description="TimescaleDB user")
-    timescale_password: str = Field(default="apex_secret", description="TimescaleDB password")
+    timescale_password: SecretStr = Field(
+        default=SecretStr("apex_secret"), description="TimescaleDB password"
+    )
     timescale_pool_min: int = Field(default=2, description="Min asyncpg pool size")
     timescale_pool_max: int = Field(default=10, description="Max asyncpg pool size")
 
@@ -269,13 +271,13 @@ class Settings(BaseSettings):
     def timescale_dsn(self) -> str:
         """Build PostgreSQL DSN from individual components."""
         return (
-            f"postgresql://{self.timescale_user}:{self.timescale_password}"
+            f"postgresql://{self.timescale_user}:{self.timescale_password.get_secret_value()}"
             f"@{self.timescale_host}:{self.timescale_port}/{self.timescale_db}"
         )
 
     # ── Database (optional persistence layer) ─────────────────────────────────
-    db_password: str = Field(
-        default="",
+    db_password: SecretStr = Field(
+        default=SecretStr(""),
         description="Optional database password (consumed by docker-compose / scripts)",
     )
 

--- a/core/models/order.py
+++ b/core/models/order.py
@@ -207,12 +207,12 @@ class TradeRecord(BaseModel):
         return self.net_pnl > 0
 
     @property
-    def r_multiple(self) -> float | None:
+    def r_multiple(self) -> Decimal | None:
         """Return PnL as multiple of initial risk (R)."""
         risk = abs(self.entry_price - self.exit_price)
         if risk == 0 or self.size == 0:
             return None
-        return float(self.net_pnl / (risk * self.size))
+        return self.net_pnl / (risk * self.size)
 
 
 class NullOrder(BaseModel):

--- a/core/models/signal.py
+++ b/core/models/signal.py
@@ -194,10 +194,10 @@ class Signal(BaseModel):
         return self
 
     @property
-    def risk_reward(self) -> float | None:
+    def risk_reward(self) -> Decimal | None:
         """Compute risk/reward ratio using scalp target."""
         risk = abs(self.entry - self.stop_loss)
         reward = abs(self.take_profit[0] - self.entry)
         if risk == 0:
             return None
-        return float(reward / risk)
+        return reward / risk

--- a/docs/claude_memory/CONTEXT.md
+++ b/docs/claude_memory/CONTEXT.md
@@ -1,7 +1,7 @@
 # APEX Project Context Snapshot
 
-**Last updated**: 2026-04-11
-**Updated by**: Session 001
+**Last updated**: 2026-04-12
+**Updated by**: Session 003
 
 ---
 
@@ -51,9 +51,16 @@ Spec document: `docs/phases/PHASE_3_SPEC.md`
 
 - GEX validation requires options data (source TBD, may need paid API)
 - Whether all 6 features will pass IC threshold is unknown
-- P1 audit issues should be addressed in parallel (CI gates, float->Decimal, SecretStr)
+- Remaining P1 audit issues: CI gates, S01 connector Decimal migration (MacroPoint/FundamentalPoint model types)
+
+## Sprint Status
+
+| Sprint | PR | Issues | Status |
+|---|---|---|---|
+| Sprint 1 — Docs quick wins | #100 | #67, #78, #79, #80 | MERGED |
+| Sprint 2 — Security & Config | TBD | #66, #69, #71 | PR CREATED |
 
 ## Branch Status
 
 - `main` is clean, all tests passing
-- No active feature branches
+- `sprint2/security-config-hardening` — PR pending review

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -81,3 +81,58 @@ Each entry follows the template in `templates/SESSION_TEMPLATE.md`.
 - Begin Phase 3.1 (Feature Engineering Pipeline Foundation)
 - Continue Sprint 2 docs: ARCHITECTURE.md (#82), ACADEMIC_REFERENCES.md (#83), ONBOARDING.md (#84)
 - Address P1 audit issues (#64-#77) in parallel with Phase 3
+
+---
+
+## Session 003 — 2026-04-12
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-12 |
+| Mission | Sprint 2 — Security & Config hardening (#66, #69, #71) |
+| Agent Model | Claude Opus 4.6 |
+| Duration | ~1 hour |
+
+### Decisions Made
+
+1. Broker API keys (Alpaca, Binance), timescale_password, alert_smtp_password, twilio_sid/token, db_password all converted to SecretStr
+2. Removed mypy ignore_errors for core.models.* — zero errors surfaced (models were already well-typed)
+3. Kept float() in S05 RuleResult kwargs (serialization boundary: RuleResult accepts str|int|float|bool, not Decimal)
+4. Kept float() in CircuitBreakerSnapshot.daily_loss_pct (model field is typed float)
+5. Deferred S01 connector float→Decimal changes: MacroPoint.value and FundamentalPoint.value model fields are float by design (macro indicators/ratios, not financial prices/sizes/pnl)
+6. Deferred S07, S09, S10 float→Decimal (as planned — stats, trade metrics, JSON serialization)
+
+### Files Modified
+
+- `core/config.py` — SecretStr for 8 secret fields, timescale_dsn uses .get_secret_value()
+- `core/models/order.py` — TradeRecord.r_multiple returns Decimal instead of float
+- `core/models/signal.py` — Signal.risk_reward returns Decimal instead of float
+- `pyproject.toml` — removed core.models.* from mypy ignore_errors
+- `services/s01_data_ingestion/service.py` — .get_secret_value() for alpaca keys
+- `services/s01_data_ingestion/connectors/alpaca_historical.py` — .get_secret_value()
+- `services/s06_execution/service.py` — .get_secret_value() for alpaca + binance keys
+- `services/s10_monitor/alert_engine.py` — .get_secret_value() for smtp_password, twilio_sid/token
+- `services/s05_risk_manager/position_rules.py` — Decimal computation (float only at kwargs)
+- `services/s05_risk_manager/circuit_breaker.py` — Decimal computation in _evaluate_triggers
+- `services/s05_risk_manager/exposure_monitor.py` — Decimal computation (float only at kwargs)
+- `tests/unit/test_config.py` — updated assertions for SecretStr
+
+### Files Deferred (with reason)
+
+- S01 connectors (FRED, ECB, BoJ, EDGAR, SimFin): model fields MacroPoint.value and FundamentalPoint.value are typed float — changing requires model migration
+- S07 quant_analytics: float() for statistical computations (Hurst, GARCH) — not financial
+- S09 trade_analyzer: dedicated metrics sprint
+- S10 command_api: 20+ float() for JSON serialization — not financial
+
+### Quality Gates
+
+- ruff check: clean
+- ruff format: 317 files formatted
+- mypy --strict: 319 files, 0 errors
+- pytest: 1228 unit tests passed, 0 failures
+
+### Next Steps
+
+- Phase 3.1 implementation
+- Sprint 3: remaining P1 audit issues
+- S01 connector Decimal migration (requires MacroPoint/FundamentalPoint model changes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [
-    "core.models.*",
     "core.config",
     "tests.*",
     "services.s10_monitor.dashboard",

--- a/services/s01_data_ingestion/connectors/alpaca_historical.py
+++ b/services/s01_data_ingestion/connectors/alpaca_historical.py
@@ -70,8 +70,8 @@ class AlpacaHistoricalConnector(DataConnector):
 
     def __init__(self, settings: Settings) -> None:
         self._client = StockHistoricalDataClient(
-            api_key=settings.alpaca_api_key,
-            secret_key=settings.alpaca_api_secret,
+            api_key=settings.alpaca_api_key.get_secret_value(),
+            secret_key=settings.alpaca_api_secret.get_secret_value(),
         )
         self._semaphore = asyncio.Semaphore(10)
 

--- a/services/s01_data_ingestion/service.py
+++ b/services/s01_data_ingestion/service.py
@@ -65,8 +65,8 @@ class DataIngestionService(BaseService):
         self._alpaca_feed = AlpacaFeed(
             symbols=_DEFAULT_EQUITY_SYMBOLS,
             on_tick=self._on_alpaca_tick,
-            api_key=settings.alpaca_api_key,
-            secret_key=settings.alpaca_api_secret,
+            api_key=settings.alpaca_api_key.get_secret_value(),
+            secret_key=settings.alpaca_api_secret.get_secret_value(),
             url=settings.alpaca_data_url,
         )
 

--- a/services/s05_risk_manager/cb_event_guard.py
+++ b/services/s05_risk_manager/cb_event_guard.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 import structlog
 from redis.asyncio import Redis
@@ -111,7 +112,7 @@ class CBEventGuard:
         return False
 
     @staticmethod
-    def get_post_event_size_multiplier() -> float:
+    def get_post_event_size_multiplier() -> Decimal:
         """Return the size multiplier applied during post-event scalp windows.
 
         Returns:

--- a/services/s05_risk_manager/circuit_breaker.py
+++ b/services/s05_risk_manager/circuit_breaker.py
@@ -203,13 +203,13 @@ class CircuitBreaker:
         """Pure function: evaluate all triggers. Returns BlockReason or None."""
         # 1. Daily drawdown
         if starting_capital > Decimal("0"):
-            daily_loss_pct = float(-current_daily_pnl / starting_capital)
+            daily_loss_pct = -current_daily_pnl / starting_capital
             if daily_loss_pct > MAX_DAILY_LOSS_PCT:
                 return BlockReason.DAILY_DRAWDOWN_EXCEEDED
 
         # 2. 30-minute intraday loss
         if starting_capital > Decimal("0"):
-            intraday_pct = float(-intraday_loss_30m / starting_capital)
+            intraday_pct = -intraday_loss_30m / starting_capital
             if intraday_pct > MAX_INTRADAY_LOSS_30M_PCT:
                 return BlockReason.INTRADAY_LOSS_EXCEEDED
 
@@ -237,6 +237,7 @@ class CircuitBreaker:
         """Trip the breaker to OPEN, persist snapshot, and return it."""
         now = datetime.now(UTC)
         daily_loss_pct = (
+            # float() needed: CircuitBreakerSnapshot.daily_loss_pct is float
             float(-daily_pnl / starting_capital) if starting_capital > Decimal("0") else 0.0
         )
         new_snap = CircuitBreakerSnapshot(

--- a/services/s05_risk_manager/exposure_monitor.py
+++ b/services/s05_risk_manager/exposure_monitor.py
@@ -93,7 +93,7 @@ def check_total_exposure(
             block_reason=BlockReason.MAX_TOTAL_EXPOSURE,
             reason=f"total exposure {exposure_pct:.1%} > max {MAX_TOTAL_EXPOSURE_PCT:.0%}",
             exposure_pct=float(exposure_pct),
-            max_exposure=MAX_TOTAL_EXPOSURE_PCT,
+            max_exposure=float(MAX_TOTAL_EXPOSURE_PCT),
         )
     return RuleResult.ok(rule_name="check_total_exposure", reason=f"{exposure_pct:.1%} of capital")
 

--- a/services/s05_risk_manager/exposure_monitor.py
+++ b/services/s05_risk_manager/exposure_monitor.py
@@ -85,14 +85,14 @@ def check_total_exposure(
     existing_notional = sum(p.size * p.entry_price for p in positions)
     new_notional = order.size * order.entry
     total_notional = existing_notional + new_notional
-    exposure_pct = float(total_notional / capital)
+    exposure_pct = total_notional / capital
 
     if exposure_pct > MAX_TOTAL_EXPOSURE_PCT:
         return RuleResult.fail(
             rule_name="check_total_exposure",
             block_reason=BlockReason.MAX_TOTAL_EXPOSURE,
             reason=f"total exposure {exposure_pct:.1%} > max {MAX_TOTAL_EXPOSURE_PCT:.0%}",
-            exposure_pct=exposure_pct,
+            exposure_pct=float(exposure_pct),
             max_exposure=MAX_TOTAL_EXPOSURE_PCT,
         )
     return RuleResult.ok(rule_name="check_total_exposure", reason=f"{exposure_pct:.1%} of capital")
@@ -121,7 +121,7 @@ def check_per_class_exposure(
         p.size * p.entry_price for p in positions if _asset_class(p.symbol) == new_class
     )
     class_notional += order.size * order.entry
-    class_pct = float(class_notional / capital)
+    class_pct = class_notional / capital
 
     if class_pct > MAX_CLASS_EXPOSURE_PCT:
         return RuleResult.fail(
@@ -129,7 +129,7 @@ def check_per_class_exposure(
             block_reason=BlockReason.MAX_CLASS_EXPOSURE,
             reason=f"{new_class} exposure {class_pct:.1%} > max {MAX_CLASS_EXPOSURE_PCT:.0%}",
             asset_class=new_class,
-            class_pct=class_pct,
+            class_pct=float(class_pct),
         )
     return RuleResult.ok(
         rule_name="check_per_class_exposure", reason=f"{new_class} {class_pct:.1%}"

--- a/services/s05_risk_manager/models.py
+++ b/services/s05_risk_manager/models.py
@@ -155,23 +155,23 @@ class Position(BaseModel):
 
 # ── Risk Constants (all from DEVELOPMENT_PLAN.md Section 6) ────────────────────
 
-MAX_DAILY_LOSS_PCT: Final[float] = 0.03  # 3% daily drawdown → trip CB
-MAX_INTRADAY_LOSS_30M_PCT: Final[float] = 0.02  # 2% in 30min → trip CB
-VIX_SPIKE_THRESHOLD_PCT: Final[float] = 0.20  # VIX +20% in 1h → trip CB
+MAX_DAILY_LOSS_PCT: Final[Decimal] = Decimal("0.03")  # 3% daily drawdown → trip CB
+MAX_INTRADAY_LOSS_30M_PCT: Final[Decimal] = Decimal("0.02")  # 2% in 30min → trip CB
+VIX_SPIKE_THRESHOLD_PCT: Final[float] = 0.20  # VIX +20% in 1h → trip CB (float: VIX is float)
 SERVICE_DOWN_SECONDS: Final[int] = 60  # Data/Signal down > 60s → trip
 CB_BLOCK_MINUTES_BEFORE: Final[int] = 45  # Block window before CB event
 CB_SCALP_MINUTES_AFTER: Final[int] = 15  # Post-event reduced scalp window
-CB_SCALP_SIZE_MULTIPLIER: Final[float] = 0.50  # Half size post-event
+CB_SCALP_SIZE_MULTIPLIER: Final[Decimal] = Decimal("0.50")  # Half size post-event
 MAX_POSITIONS: Final[int] = 6  # Max simultaneous open positions
-MAX_TOTAL_EXPOSURE_PCT: Final[float] = 0.20  # 20% of capital max notional
-MAX_CLASS_EXPOSURE_PCT: Final[float] = 0.12  # 12% per asset class
-MAX_RISK_PER_TRADE_PCT: Final[float] = 0.005  # 0.5% capital risk per trade
-MAX_POSITION_SIZE_PCT: Final[float] = 0.10  # 10% of capital max size
-MIN_RR_RATIO: Final[float] = 1.5  # Min reward/risk to enter
-CRYPTO_SIZE_MULTIPLIER: Final[float] = 0.70  # Crypto vol adjustment × 0.70
-MIN_META_CONFIDENCE_TO_TRADE: Final[float] = 0.52  # Below → hard block
-MIN_KELLY_FRACTION: Final[float] = 0.01  # Below after modulation → block
-CORRELATION_BLOCK_THRESHOLD: Final[float] = 0.75  # rho > 0.75 with open pos → block
+MAX_TOTAL_EXPOSURE_PCT: Final[Decimal] = Decimal("0.20")  # 20% of capital max notional
+MAX_CLASS_EXPOSURE_PCT: Final[Decimal] = Decimal("0.12")  # 12% per asset class
+MAX_RISK_PER_TRADE_PCT: Final[Decimal] = Decimal("0.005")  # 0.5% capital risk per trade
+MAX_POSITION_SIZE_PCT: Final[Decimal] = Decimal("0.10")  # 10% of capital max size
+MIN_RR_RATIO: Final[Decimal] = Decimal("1.5")  # Min reward/risk to enter
+CRYPTO_SIZE_MULTIPLIER: Final[Decimal] = Decimal("0.70")  # Crypto vol adjustment × 0.70
+MIN_META_CONFIDENCE_TO_TRADE: Final[float] = 0.52  # Below → hard block (float: confidence is float)
+MIN_KELLY_FRACTION: Final[float] = 0.01  # Below after modulation → block (float: kelly is float)
+CORRELATION_BLOCK_THRESHOLD: Final[float] = 0.75  # rho > 0.75 (float: correlation is float)
 HALF_OPEN_RECOVERY_MINUTES: Final[int] = 30  # Cooldown before HALF_OPEN attempt
 REDIS_CB_KEY: Final[str] = "risk:circuit_breaker:state"
 REDIS_CB_TTL: Final[int] = 86400  # 24h TTL for CB state

--- a/services/s05_risk_manager/position_rules.py
+++ b/services/s05_risk_manager/position_rules.py
@@ -83,13 +83,13 @@ def check_min_rr(order: OrderCandidate) -> RuleResult:
             reason="zero SL distance",
         )
     tp_distance = abs(order.target_scalp - order.entry)
-    rr = float(tp_distance / sl_distance)
+    rr = tp_distance / sl_distance
     if rr < MIN_RR_RATIO:
         return RuleResult.fail(
             rule_name="check_min_rr",
             block_reason=BlockReason.MIN_RR_NOT_MET,
             reason=f"RR {rr:.3f} < minimum {MIN_RR_RATIO}",
-            rr=rr,
+            rr=float(rr),
         )
     return RuleResult.ok(rule_name="check_min_rr", reason=f"RR {rr:.3f}")
 

--- a/services/s05_risk_manager/position_rules.py
+++ b/services/s05_risk_manager/position_rules.py
@@ -104,7 +104,7 @@ def check_max_risk_per_trade(order: OrderCandidate, capital: Decimal) -> RuleRes
         return RuleResult.ok(rule_name="check_max_risk_per_trade", reason="capital=0 skipped")
     sl_distance = abs(order.entry - order.stop_loss)
     monetary_risk = sl_distance * order.size
-    max_risk = capital * Decimal(str(MAX_RISK_PER_TRADE_PCT))
+    max_risk = capital * MAX_RISK_PER_TRADE_PCT
     if monetary_risk > max_risk:
         return RuleResult.fail(
             rule_name="check_max_risk_per_trade",
@@ -121,7 +121,7 @@ def check_max_size(order: OrderCandidate, capital: Decimal) -> RuleResult:
     if capital <= Decimal("0"):
         return RuleResult.ok(rule_name="check_max_size", reason="capital=0 skipped")
     notional = order.size * order.entry
-    max_notional = capital * Decimal(str(MAX_POSITION_SIZE_PCT))
+    max_notional = capital * MAX_POSITION_SIZE_PCT
     if notional > max_notional:
         return RuleResult.fail(
             rule_name="check_max_size",
@@ -136,7 +136,7 @@ def check_max_size(order: OrderCandidate, capital: Decimal) -> RuleResult:
 def apply_crypto_multiplier(order: OrderCandidate) -> tuple[Decimal, RuleResult]:
     """Apply CRYPTO_SIZE_MULTIPLIER (0.70) for crypto symbols."""
     if _is_crypto(order.symbol):
-        adjusted = order.size * Decimal(str(CRYPTO_SIZE_MULTIPLIER))
+        adjusted = order.size * CRYPTO_SIZE_MULTIPLIER
         return adjusted, RuleResult.ok(
             rule_name="apply_crypto_multiplier",
             reason=f"crypto x {CRYPTO_SIZE_MULTIPLIER}",

--- a/services/s05_risk_manager/service.py
+++ b/services/s05_risk_manager/service.py
@@ -205,7 +205,7 @@ class RiskManagerService(BaseService):
         current_size, r_sess = apply_session_multiplier(candidate, session)
         rule_results.append(r_sess)
         if in_scalp_window:
-            current_size = current_size * Decimal(str(CB_SCALP_SIZE_MULTIPLIER))
+            current_size = current_size * CB_SCALP_SIZE_MULTIPLIER
             rationale.append(f"post_event_scalp x{CB_SCALP_SIZE_MULTIPLIER}")
 
         # STEP 5: Exposure Monitor

--- a/services/s06_execution/service.py
+++ b/services/s06_execution/service.py
@@ -75,14 +75,14 @@ class ExecutionService(BaseService):
 
         if settings.trading_mode == TradingMode.LIVE:
             self._alpaca = AlpacaBroker(
-                api_key=settings.alpaca_api_key,
-                secret_key=settings.alpaca_api_secret,
+                api_key=settings.alpaca_api_key.get_secret_value(),
+                secret_key=settings.alpaca_api_secret.get_secret_value(),
                 base_url=settings.alpaca_base_url,
                 paper=False,
             )
             self._binance = BinanceBroker(
-                api_key=settings.binance_api_key,
-                secret_key=settings.binance_secret_key,
+                api_key=settings.binance_api_key.get_secret_value(),
+                secret_key=settings.binance_secret_key.get_secret_value(),
                 base_url=settings.binance_rest_url,
                 testnet=False,
             )

--- a/services/s10_monitor/alert_engine.py
+++ b/services/s10_monitor/alert_engine.py
@@ -59,7 +59,10 @@ class AlertEngine:
         """Synchronous SMTP send (runs in executor)."""
         with smtplib.SMTP(self._settings.alert_smtp_host, self._settings.alert_smtp_port) as server:
             server.starttls()
-            server.login(self._settings.alert_smtp_user, self._settings.alert_smtp_password)
+            server.login(
+                self._settings.alert_smtp_user,
+                self._settings.alert_smtp_password.get_secret_value(),
+            )
             server.send_message(msg)
 
     async def send_sms(self, message: str) -> None:
@@ -70,9 +73,7 @@ class AlertEngine:
         """
         if not self._settings.twilio_sid or not self._settings.twilio_token:
             return
-        url = (
-            f"https://api.twilio.com/2010-04-01/Accounts/{self._settings.twilio_sid}/Messages.json"
-        )
+        url = f"https://api.twilio.com/2010-04-01/Accounts/{self._settings.twilio_sid.get_secret_value()}/Messages.json"
         data = {
             "To": self._settings.alert_phone_number,
             "From": self._settings.twilio_from_number,
@@ -83,7 +84,10 @@ class AlertEngine:
                 async with session.post(
                     url,
                     data=data,
-                    auth=aiohttp.BasicAuth(self._settings.twilio_sid, self._settings.twilio_token),
+                    auth=aiohttp.BasicAuth(
+                        self._settings.twilio_sid.get_secret_value(),
+                        self._settings.twilio_token.get_secret_value(),
+                    ),
                 ) as resp:
                     if resp.status not in (200, 201):
                         logger.warning("SMS send failed", status=resp.status)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -18,13 +18,14 @@ class TestAlpacaSettings:
         mp.setenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
         mp.setenv("ALPACA_DATA_URL", "wss://stream.data.alpaca.markets/v2/iex")
         s = Settings(_env_file=None)  # type: ignore[call-arg]
-        assert s.alpaca_api_key == "PK_TEST_123"
-        assert s.alpaca_api_secret == "SK_TEST_456"
+        assert isinstance(s.alpaca_api_key, SecretStr)
+        assert s.alpaca_api_key.get_secret_value() == "PK_TEST_123"
+        assert s.alpaca_api_secret.get_secret_value() == "SK_TEST_456"
         assert "paper-api" in s.alpaca_base_url
 
     def test_alpaca_defaults(self) -> None:
         s = Settings(_env_file=None)  # type: ignore[call-arg]
-        assert s.alpaca_api_key == ""
+        assert s.alpaca_api_key.get_secret_value() == ""
         assert "paper-api" in s.alpaca_base_url
 
 


### PR DESCRIPTION
Closes #66, closes #69, closes #71

## Summary

Sprint 2 of post-audit cleanup. Three coordinated security and type-safety fixes:

### #71 — SecretStr for broker keys (P1 SECURITY)
- Alpaca API key + secret → `SecretStr`
- Binance API key + secret → `SecretStr`
- `timescale_password`, `alert_smtp_password`, `twilio_sid`, `twilio_token`, `db_password` → `SecretStr`
- All call sites updated to `.get_secret_value()` (S01, S06, S10)

### #69 — Remove mypy ignore_errors for core.models.*
- Removed `core.models.*` from `[[tool.mypy.overrides]]` ignore list
- Zero mypy errors surfaced — models were already well-typed
- Zero new `type: ignore` comments added
- `core.config`, `tests.*`, `services.s10_monitor.dashboard` kept in ignore list

### #66 — float() → Decimal for financial values
- `TradeRecord.r_multiple` now returns `Decimal | None` (was `float | None`)
- `Signal.risk_reward` now returns `Decimal | None` (was `float | None`)
- S05 `position_rules.py`: Decimal computation paths for RR, risk, notional
- S05 `circuit_breaker.py`: Decimal in `_evaluate_triggers` for daily/intraday loss
- S05 `exposure_monitor.py`: Decimal for exposure % computation
- `float()` kept only at serialization boundaries (RuleResult kwargs, CircuitBreakerSnapshot field)

### Deferred (with reason)
- **S01 connectors** (FRED, ECB, BoJ, EDGAR, SimFin): `MacroPoint.value` and `FundamentalPoint.value` model fields are typed `float` — requires model migration
- **S07 quant_analytics**: `float()` for statistical computations (Hurst, GARCH) — not financial
- **S09 trade_analyzer**: dedicated metrics sprint
- **S10 command_api**: 20+ `float()` for JSON serialization — not financial

## Quality gates
- [x] ruff check: clean
- [x] ruff format: 317 files
- [x] mypy --strict: 319 files, 0 errors
- [x] pytest: 1228 tests passing, zero regressions

## Test plan
- [x] `pytest tests/unit/test_config.py` — SecretStr assertions updated and passing
- [x] `mypy . --strict` — zero errors after removing core.models.* ignore
- [x] `pytest tests/unit/` — full suite, 1228 tests, 0 failures
- [x] Verified no secrets leak in string representations (SecretStr masks by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)