### PR TITLE
[sprint-3] CI hardening: CVEs + coverage gate + omit narrowing

### DIFF
--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Build Rust wheels
         run: |
           pip install "maturin>=1.9.4"
-          (cd rust/apex_mc   && maturin build --release) || true
-          (cd rust/apex_risk && maturin build --release) || true
-          python -m pip install ./rust/target/wheels/*.whl 2>/dev/null || true
+          (cd rust/apex_mc   && maturin build --release)
+          (cd rust/apex_risk && maturin build --release)
+          python -m pip install ./rust/target/wheels/*.whl
 
       - name: Generate test fixture (if missing)
         run: |
@@ -43,6 +43,7 @@ jobs:
       - name: Run backtest regression
         run: PYTHONPATH="."  python scripts/backtest_regression.py --fixture tests/fixtures/30d_btcusdt_1m.parquet
         env:
+          # TODO: Align with CLAUDE.md targets (Sharpe >= 0.8, DD <= 0.08) in Phase 5
           BACKTEST_MIN_SHARPE: "0.5"
           BACKTEST_MAX_DD: "0.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,10 @@ jobs:
           pytest tests/unit/ -v \
             --cov=services --cov=core --cov=backtesting \
             --cov-report=xml --cov-report=term-missing \
-            --cov-fail-under=40 --timeout=30
+            --cov-fail-under=75 --timeout=30
+            # TODO: Raise to 85% (CLAUDE.md target) progressively in future sprints.
+            # Current gate reflects post-omit-narrowing baseline (80%). Next bumps should
+            # happen after new test sprints in Phase 3.x.
       - uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
@@ -124,6 +127,9 @@ jobs:
         run: python scripts/generate_test_fixtures.py
       - name: Backtest regression gate
         env:
+          # TODO: Align with CLAUDE.md targets (Sharpe >= 0.8, DD <= 0.08) in Phase 5
+          # Current thresholds reflect scaffolding-era data. Raise after Phase 3
+          # feature validation completes.
           BACKTEST_MIN_SHARPE: "0.5"
           BACKTEST_MAX_DD: "0.12"
         run: |

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ type:
 test-unit:
 	$(PYTHON) -m pytest tests/unit/ -v \
 		--cov=services --cov=core --cov=backtesting \
-		--cov-report=term-missing --cov-fail-under=40 --timeout=30
+		--cov-report=term-missing --cov-fail-under=75 --timeout=30
 
 test-integration:
 	$(PYTHON) -m pytest tests/integration/ -v --timeout=60

--- a/docs/claude_memory/CONTEXT.md
+++ b/docs/claude_memory/CONTEXT.md
@@ -1,7 +1,7 @@
 # APEX Project Context Snapshot
 
 **Last updated**: 2026-04-12
-**Updated by**: Session 003
+**Updated by**: Session 004
 
 ---
 
@@ -58,9 +58,11 @@ Spec document: `docs/phases/PHASE_3_SPEC.md`
 | Sprint | PR | Issues | Status |
 |---|---|---|---|
 | Sprint 1 — Docs quick wins | #100 | #67, #78, #79, #80 | MERGED |
-| Sprint 2 — Security & Config | TBD | #66, #69, #71 | PR CREATED |
+| Sprint 2 — Security & Config | #101 | #66, #69, #71 | MERGED |
+| Sprint 3 — CI hardening | TBD | #64, #65, #68, #70 | PR PENDING |
 
 ## Branch Status
 
 - `main` is clean, all tests passing
-- `sprint2/security-config-hardening` — PR pending review
+- `sprint3/ci-hardening` — PR pending review
+- Follow-up issue #102 created for backtest-gate continue-on-error removal

--- a/docs/claude_memory/DECISIONS.md
+++ b/docs/claude_memory/DECISIONS.md
@@ -61,3 +61,51 @@ via IC measurement, not strategy backtesting.
 - IC measurement requires Polars + NumPy + scipy.stats.spearmanr, all free.
 - vectorbt's value proposition is backtesting, which is Phase 5's scope.
 - $400/year is significant for a personal project; defer until ROI is clearer.
+
+---
+
+## D003 — Coverage Gate Incremental Raise to 75% (2026-04-12)
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-12 |
+| Session | 004 |
+| Decision | Raise CI coverage gate from 40% to 75% (not directly to 85%) |
+| Status | ACCEPTED |
+
+### Context
+
+CLAUDE.md documents an 85% coverage target. The CI gate was at 40% — a significant
+drift. After narrowing the overly broad omit list (removing S01 and S10 wildcards),
+the true baseline coverage measured at 80% on 6,861 LOC.
+
+### Justification
+
+- Jumping directly to 85% would make CI fragile — any new file without tests would break it
+- 75% gives 5% headroom below the 80% baseline, absorbing normal fluctuation
+- Incremental progression is safer: 40% → 75% → 80% → 85% over future sprints
+- Each bump should coincide with a test-writing sprint, not just gate increases
+
+---
+
+## D004 — Backtest Thresholds Deferred to Phase 5 (2026-04-12)
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-12 |
+| Session | 004 |
+| Decision | Keep backtest thresholds at Sharpe 0.5 / DD 12% and continue-on-error: true |
+| Status | ACCEPTED |
+
+### Context
+
+CLAUDE.md specifies Sharpe >= 0.8 and DD <= 8%. The CI backtest-gate uses relaxed
+thresholds (0.5/12%) and is non-blocking due to a known Sharpe calculation bug in
+full_report().
+
+### Justification
+
+- Raising thresholds without fixing the Sharpe bug would create false failures
+- Making the gate blocking while full_report() is buggy would break CI
+- Follow-up issue #102 created to track the fix
+- Thresholds should be raised in Phase 5 after feature validation confirms data quality

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -136,3 +136,52 @@ Each entry follows the template in `templates/SESSION_TEMPLATE.md`.
 - Phase 3.1 implementation
 - Sprint 3: remaining P1 audit issues
 - S01 connector Decimal migration (requires MacroPoint/FundamentalPoint model changes)
+
+---
+
+## Session 004 — 2026-04-12
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-12 |
+| Mission | Sprint 3 — CI hardening (#64, #65, #68, #70) |
+| Agent Model | Claude Opus 4.6 |
+| Duration | ~30 minutes |
+
+### Decisions Made
+
+1. Coverage omit narrowed: removed `services/s01_data_ingestion/*.py` wildcard and `services/s10_monitor/*` wildcard, replaced with specific network/UI modules only
+2. Coverage gate raised from 40% to 75% (baseline measured at 80% post-narrowing)
+3. Backtest thresholds (Sharpe 0.5, DD 12%) retained — deferred to Phase 5 pending full_report() Sharpe bug fix
+4. `continue-on-error: true` retained on backtest-gate — follow-up issue #102 created
+5. 9 transitive deps pinned in requirements.txt to patch 19 CVEs
+6. Removed `|| true` from backtest.yml Rust wheel builds (was swallowing failures)
+
+### Files Modified
+
+- `requirements.txt` — added 9 CVE-patched transitive dep pins
+- `pyproject.toml` — narrowed coverage omit from wildcards to specific files
+- `.github/workflows/ci.yml` — coverage gate 40%→75%, backtest TODO comments
+- `.github/workflows/backtest.yml` — removed `|| true` on Rust builds, added threshold TODO
+
+### Coverage Baseline
+
+| Metric | Before | After |
+|---|---|---|
+| With omit config | 83% (6,550 LOC) | 80% (6,861 LOC) |
+| Without any omit | 66% (9,277 LOC) | — |
+| CI gate | 40% | 75% |
+
+### Quality Gates
+
+- ruff check: clean
+- ruff format: 317 files unchanged
+- mypy --strict: 319 files, 0 errors
+- pytest: 1228 unit tests passed, coverage 79.60%
+- pip-audit: 0 project CVEs (2 in pip itself, env-managed)
+
+### Next Steps
+
+- Phase 3.1 implementation
+- Follow-up issue #102: fix full_report() Sharpe then enforce backtest-gate
+- Continue raising coverage toward 85% with new test sprints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,9 +124,13 @@ omit = [
     # Backtest engine and data loader (integration-only, not unit tests)
     "backtesting/engine.py",
     "backtesting/data_loader.py",
-    # Data feeds and brokers (require live API connections)
-    "services/s01_data_ingestion/*.py",
-    "services/s06_execution/broker_*.py",
+    # S01: only live connectors and serving entry point (not the whole package)
+    "services/s01_data_ingestion/connectors/alpaca_live.py",
+    "services/s01_data_ingestion/connectors/binance_live.py",
+    "services/s01_data_ingestion/serving/main.py",
+    # Brokers (require live API connections)
+    "services/s06_execution/broker_alpaca.py",
+    "services/s06_execution/broker_binance.py",
     "services/s06_execution/order_manager.py",
     # Complex signal modules not yet unit-tested
     "services/s02_signal_engine/crowd_behavior.py",
@@ -142,7 +146,10 @@ omit = [
     # Macro intel - geopolitical and sector rotation (data-source dependent)
     "services/s08_macro_intelligence/geopolitical.py",
     "services/s08_macro_intelligence/sector_rotation.py",
-    "services/s10_monitor/*",
+    # S10: specific UI/API modules only (not wildcard)
+    "services/s10_monitor/dashboard.py",
+    "services/s10_monitor/command_api.py",
+    "services/s10_monitor/alert_engine.py",
 ]
 branch = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,6 @@ omit = [
     "backtesting/engine.py",
     "backtesting/data_loader.py",
     # S01: only live connectors and serving entry point (not the whole package)
-    "services/s01_data_ingestion/connectors/alpaca_live.py",
     "services/s01_data_ingestion/connectors/binance_live.py",
     "services/s01_data_ingestion/serving/main.py",
     # Brokers (require live API connections)

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,13 @@ opentelemetry-exporter-otlp-proto-grpc>=1.24.0
 croniter>=2.0.0,<4.0.0
 types-PyYAML>=6.0.0
 types-croniter>=2.0.0
+# --- Transitive deps pinned for CVE remediation (Sprint 3, #68) ---
+urllib3>=2.6.3
+tornado>=6.5.5
+requests>=2.33.0
+pillow>=12.1.1
+protobuf>=6.33.5
+pygments>=2.20.0
+streamlit>=1.54.0
+curl-cffi>=0.15.0
+wheel>=0.46.2


### PR DESCRIPTION
Closes #64 #65 #68 #70

## Summary
Sprint 3 of post-audit cleanup. Four coordinated CI fixes.

## Changes

### #68 — 19 CVEs patched
9 transitive packages pinned in requirements.txt with CVE-safe minimums:
urllib3>=2.6.3, tornado>=6.5.5, requests>=2.33.0, pillow>=12.1.1,
protobuf>=6.33.5, pygments>=2.20.0, streamlit>=1.54.0, curl-cffi>=0.15.0,
wheel>=0.46.2. pip-audit: 0 project vulnerabilities remaining.

### #70 — Coverage omit narrowed
- Removed wildcards `services/s01_data_ingestion/*.py` and `services/s10_monitor/*`
- Replaced with specific network-dependent / UI modules only
- Coverage baseline: 83% (6,550 LOC) → 80% (6,861 LOC) — more honest measurement

### #64 — Coverage gate raised
- CI gate: 40% → 75%
- TODO documented for further bumps toward CLAUDE.md 85% target in future sprints

### #65 — Backtest gate thresholds
- Thresholds documented with TODO: Sharpe 0.5 / DD 12% retained
- Deferral to Phase 5 when full_report() Sharpe bug is fixed
- Follow-up issue #102 created for continue-on-error removal

### Bonus — backtest.yml Rust error swallowing
- Removed `|| true` on Rust wheel builds that silently swallowed failures

## Quality gates
- [x] ruff clean
- [x] mypy --strict (319 files, 0 errors)
- [x] pytest 1228 tests passing
- [x] coverage >= 75% (actual: 79.60%)
- [x] pip-audit clean (0 project CVEs)

Refs #64 #65 #68 #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)