### PR TITLE
[sprint-5] Architecture refactors: Broker ABC (#72) + SignalPipeline (#73)

### DIFF
--- a/docs/claude_memory/CONTEXT.md
+++ b/docs/claude_memory/CONTEXT.md
@@ -1,7 +1,7 @@
 # APEX Project Context Snapshot
 
 **Last updated**: 2026-04-12
-**Updated by**: Session 005
+**Updated by**: Session 006
 
 ---
 
@@ -11,13 +11,13 @@
 |---|---|
 | Active Phase | Phase 3 — Feature Validation Harness (DESIGN COMPLETE) |
 | Previous Phase | Phase 2 — Universal Data Infrastructure (DONE) |
-| Total tests | 1,283 (1,228 unit + 55 integration) |
-| Production LOC | 31,149 |
-| Test LOC | 17,501 |
-| mypy strict | 0 errors (319 files) |
+| Total tests | 1,314 (1,259 unit + 55 integration) |
+| Production LOC | ~32,000 |
+| Test LOC | ~18,300 |
+| mypy strict | 0 errors (324 files) |
 | Services scaffolded | 10/10 (S01-S10) |
 | S01 fully implemented | Yes (78 files, 9,583 LOC) |
-| ADRs accepted | 7 (ZMQ topology, Quant Methodology, Data Schema + 4 Sprint 4/5) |
+| ADRs accepted | 9 (+ D008 Broker ABC, D009 SignalPipeline) |
 
 ## Audit Status
 
@@ -60,7 +60,8 @@ Spec document: `docs/phases/PHASE_3_SPEC.md`
 | Sprint 1 — Docs quick wins | #100 | #67, #78, #79, #80 | MERGED |
 | Sprint 2 — Security & Config | #101 | #66, #69, #71 | MERGED |
 | Sprint 3 — CI hardening | #103 | #64, #65, #68, #70 | MERGED |
-| Sprint 4 — Architecture refactors | TBD | #74, #75, #76, #77 | PR PENDING |
+| Sprint 4 — Architecture refactors | #104 | #74, #75, #76, #77 | MERGED |
+| Sprint 5 — Architecture heavy refactors | TBD | #72, #73 | PR PENDING |
 
 ## P1 Issue Progress
 
@@ -74,15 +75,17 @@ Spec document: `docs/phases/PHASE_3_SPEC.md`
 | #69 Decimal | Sprint 2 | CLOSED |
 | #70 CI linting | Sprint 3 | CLOSED |
 | #71 Config | Sprint 2 | CLOSED |
-| #74 S03 dead code | Sprint 4 | PR PENDING |
-| #75 S04 OCP | Sprint 4 | PR PENDING |
-| #76 S05 DIP | Sprint 4 | PR PENDING |
-| #77 S01 layering | Sprint 4 | PR PENDING |
+| #74 S03 dead code | Sprint 4 | CLOSED |
+| #75 S04 OCP | Sprint 4 | CLOSED |
+| #76 S05 DIP | Sprint 4 | CLOSED |
+| #77 S01 layering | Sprint 4 | CLOSED |
+| #72 S06 Broker ABC | Sprint 5 | PR PENDING |
+| #73 S02 SignalPipeline | Sprint 5 | PR PENDING |
 
-11/14 P1 closed (will be 11/14 after Sprint 4 merge → remaining: #72, #73, #63).
+13/14 P1 closed (remaining: #63 S01 connector Decimal migration).
 
 ## Branch Status
 
-- `main` is clean, all tests passing (Sprint 3 merged)
-- `sprint4/architecture-refactors` — PR pending
+- `main` is clean, all tests passing (Sprint 4 merged via PR #104)
+- `sprint5/architecture-heavy-refactors` — PR pending (#72, #73)
 - Follow-up issue #102 created for backtest-gate continue-on-error removal

--- a/docs/claude_memory/DECISIONS.md
+++ b/docs/claude_memory/DECISIONS.md
@@ -188,3 +188,68 @@ way to get the Redis client.
 - `.client` property is the natural public API complement to `connect()`
 - `_ensure_connected()` kept as deprecated delegate for backward compat
 - All 4 call sites (S05, S06, S10×2) migrated to `state.client`
+
+---
+
+## D008 — S06 Broker ABC + BrokerFactory (2026-04-12)
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-12 |
+| Session | 006 |
+| Decision | Extract Broker ABC from 3 concrete brokers; route via BrokerFactory |
+| Status | ACCEPTED |
+
+### Context
+
+S06 Execution had 3 brokers (Alpaca, Binance, PaperTrader) with no common interface.
+ExecutionService imported all 3 concrete classes and used if/elif branching to route
+orders (DIP + OCP violation, issue #72).
+
+### Alternatives Considered
+
+1. **Protocol-based**: Define a `SupportsOrderPlacement` Protocol. Lighter-weight but
+   doesn't enforce lifecycle methods (connect/disconnect).
+2. **ABC (chosen)**: `Broker` ABC with `connect/disconnect/is_connected/place_order/cancel_order`.
+   Strongly typed, enforces contract at class definition time.
+
+### Justification
+
+- `place_order(ApprovedOrder) -> ExecutedOrder | None` unifies sync (paper) and async
+  (live) fill models: paper returns ExecutedOrder, live returns None.
+- BrokerFactory centralises routing: paper mode always returns PaperTrader, live mode
+  routes by crypto suffix. Adding IBKR = 1 new file + 1 factory entry.
+- ExecutionService._execute() reduced from 35 lines with 4 branches to 5 lines.
+- Raw venue-specific methods preserved as `_submit_raw_order()` for direct access.
+
+---
+
+## D009 — S02 SignalPipeline Stepwise Decomposition (2026-04-12)
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-12 |
+| Session | 006 |
+| Decision | Decompose _process_tick into SignalPipeline with PipelineState dataclass |
+| Status | ACCEPTED |
+
+### Context
+
+S02 SignalEngine._process_tick was ~270 lines performing 7 distinct operations on the
+hottest path in the system (every tick). Impossible to unit-test any step in isolation
+(SRP violation, issue #73).
+
+### Alternatives Considered
+
+1. **Simple helper methods on SignalEngine**: Extract 7 private methods. Simple but
+   still couples all state to the service class; no reusable state object.
+2. **PipelineState + SignalPipeline (chosen)**: Separate class with shared mutable state
+   dataclass. Each step reads/writes explicit fields.
+
+### Justification
+
+- PipelineState makes inter-step data flow explicit and inspectable
+- Each step is independently unit-testable with minimal fixtures
+- SignalPipeline can be reused (e.g. backtesting engine could call individual steps)
+- SignalEngine._process_tick reduced to 3 lines: pipeline.run() + publish
+- 16 new unit tests covering all 7 pipeline steps

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -249,3 +249,54 @@ Each entry follows the template in `templates/SESSION_TEMPLATE.md`.
 - Phase 3.1 implementation
 - Continue P1 audit issues (Sprint 5+)
 - Follow-up issue #102: fix full_report() Sharpe then enforce backtest-gate
+
+---
+
+## Session 006 — 2026-04-12
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-12 |
+| Mission | Sprint 5 — Architecture heavy refactors (#72, #73) |
+| Agent Model | Claude Opus 4.6 |
+| Duration | ~1.5 hours |
+
+### Decisions Made
+
+1. Broker ABC (`broker_base.py`): `place_order(ApprovedOrder) -> ExecutedOrder | None` unifies sync (paper=ExecutedOrder) and async (live=None) fill models (D008)
+2. BrokerFactory with lazy singleton pattern: paper mode → PaperTrader, live crypto → BinanceBroker, live equity → AlpacaBroker
+3. Raw venue methods renamed to `_submit_raw_order()` (Alpaca, Binance) to avoid ABC method name collision while preserving venue-specific access
+4. PaperTrader accepts optional `StateStore` for tick fetching in `place_order()`; `PaperTrader()` (no args) remains backward compatible
+5. SignalPipeline with PipelineState dataclass: 7 steps with explicit inter-step data flow (D009)
+6. Pipeline constants (_OFI_THRESHOLD, _SL_ATR_MULT, etc.) moved from service.py to pipeline.py
+
+### Files Created
+
+- `services/s06_execution/broker_base.py` — Broker ABC + exceptions
+- `services/s06_execution/broker_factory.py` — BrokerFactory
+- `services/s02_signal_engine/pipeline.py` — SignalPipeline + PipelineState
+- `tests/unit/s06/test_broker_base.py` — 15 tests (ABC, is_connected, factory)
+- `tests/unit/s02/test_signal_pipeline.py` — 16 tests (all 7 pipeline steps)
+
+### Files Modified
+
+- `services/s06_execution/broker_alpaca.py` — inherits Broker, is_connected, place_order(ApprovedOrder)
+- `services/s06_execution/broker_binance.py` — inherits Broker, is_connected, place_order(ApprovedOrder), _order_symbols tracking
+- `services/s06_execution/paper_trader.py` — inherits Broker, connect/disconnect no-ops, place_order, _get_or_build_tick
+- `services/s06_execution/service.py` — refactored to use BrokerFactory, _execute() simplified from 35 to 5 lines
+- `services/s02_signal_engine/service.py` — _process_tick now 3 lines delegating to pipeline.run()
+
+### Quality Gates
+
+- ruff check: clean
+- ruff format: 322 files
+- mypy --strict: 324 files, 0 errors
+- pytest: 1259 unit tests passed (+31 new), coverage 79.68%
+- Integration tests: 21 passed, 27 skipped (no network/Docker), 7 TimescaleDB errors (pre-existing)
+- Zero behavior regression
+
+### Next Steps
+
+- Phase 3.1 implementation
+- Remaining P1 issue: #63 (S01 connector Decimal migration)
+- Follow-up issue #102: fix full_report() Sharpe then enforce backtest-gate

--- a/services/s02_signal_engine/pipeline.py
+++ b/services/s02_signal_engine/pipeline.py
@@ -120,8 +120,6 @@ class SignalPipeline:
         tech_store: dict[str, TechnicalAnalyzer],
         vpin_store: dict[str, VPINCalculator],
         adv_counter: dict[str, int],
-        prev_ema_8: dict[str, Decimal | None],
-        prev_ema_21: dict[str, Decimal | None],
         mtf: MTFAligner,
         scorer: SignalScorer,
         state: StateStore,
@@ -130,8 +128,6 @@ class SignalPipeline:
         self._tech_store = tech_store
         self._vpin_store = vpin_store
         self._adv_counter = adv_counter
-        self._prev_ema_8 = prev_ema_8
-        self._prev_ema_21 = prev_ema_21
         self._mtf = mtf
         self._scorer = scorer
         self._state = state
@@ -217,7 +213,6 @@ class SignalPipeline:
         """
         assert ps.micro is not None
         assert ps.tech is not None
-        symbol = ps.symbol
         tech = ps.tech
         micro = ps.micro
 
@@ -227,11 +222,8 @@ class SignalPipeline:
             period=20, std=2.0, timeframe="5m"
         )
 
-        # EMA 5m (for cross detection state persistence)
         ps.ema_8 = tech.ema(period=8, timeframe="5m")
         ps.ema_21 = tech.ema(period=21, timeframe="5m")
-        self._prev_ema_8[symbol] = ps.ema_8
-        self._prev_ema_21[symbol] = ps.ema_21
 
         # EMA 1m and 15m (for MTF alignment scorer)
         ps.ema_8_1m = tech.ema(period=8, timeframe="1m")

--- a/services/s02_signal_engine/pipeline.py
+++ b/services/s02_signal_engine/pipeline.py
@@ -1,0 +1,495 @@
+"""Signal pipeline — decomposes _process_tick into testable steps.
+
+Each step operates on a shared :class:`PipelineState` dataclass, making it
+possible to unit-test every stage in isolation without standing up the full
+service.
+
+Reference:
+    Robert C. Martin (2008) Clean Code Ch. 3 — "Functions should do one
+    thing. They should do it well. They should do it only."
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+from core.logger import get_logger
+from core.models.signal import (
+    Direction,
+    MTFContext,
+    Signal,
+    SignalType,
+    TechnicalFeatures,
+)
+from core.models.tick import NormalizedTick
+from core.state import StateStore
+from services.s02_signal_engine.microstructure import MicrostructureAnalyzer
+from services.s02_signal_engine.mtf_aligner import MTFAligner
+from services.s02_signal_engine.signal_scorer import SignalComponent, SignalScorer
+from services.s02_signal_engine.technical import TechnicalAnalyzer
+from services.s02_signal_engine.vpin import VPINCalculator
+
+logger = get_logger("s02_signal_engine.pipeline")
+
+# OFI magnitude threshold for triggering an OFI signal.
+_OFI_THRESHOLD: float = 0.3
+
+# ATR multiples for stop-loss and take-profit levels.
+_SL_ATR_MULT: Decimal = Decimal("1.5")
+_TP1_ATR_MULT: Decimal = Decimal("2.0")
+_TP2_ATR_MULT: Decimal = Decimal("3.0")
+
+# Fallback stop-loss distance when ATR is unavailable (0.2% of entry price).
+_ATR_FALLBACK_PCT: Decimal = Decimal("0.002")
+
+# Minimum stop-loss floor when the computed stop-loss turns non-positive.
+_FALLBACK_SL_PCT: Decimal = Decimal("0.001")
+
+# Number of triggers needed for full confidence.
+_MAX_TRIGGERS_FOR_CONFIDENCE: float = 4.0
+
+# How many ticks between ADV refreshes from Redis (≈5 min at 1 tick/s).
+_ADV_REFRESH_EVERY: int = 300
+
+
+@dataclass
+class PipelineState:
+    """Mutable state passed between pipeline steps."""
+
+    tick: NormalizedTick
+    symbol: str = ""
+
+    # Step 1: analyzers (set during ensure_initialized)
+    micro: MicrostructureAnalyzer | None = None
+    tech: TechnicalAnalyzer | None = None
+
+    # Step 2: VPIN
+    vpin_blocked: bool = False
+
+    # Step 3: indicators
+    ofi_val: float = 0.0
+    rsi_1m: float | None = None
+    bb_upper: Decimal | None = None
+    bb_middle: Decimal | None = None
+    bb_lower: Decimal | None = None
+    ema_8: Decimal | None = None
+    ema_21: Decimal | None = None
+    ema_8_1m: Decimal | None = None
+    ema_21_1m: Decimal | None = None
+    ema_8_15m: Decimal | None = None
+    ema_21_15m: Decimal | None = None
+    vwap_val: Decimal | None = None
+
+    # Step 4: scorer
+    components: list[SignalComponent] = field(default_factory=list)
+    final_strength: float = 0.0
+    triggers: list[str] = field(default_factory=list)
+    direction: Direction | None = None
+
+    # Step 5: price levels
+    stop_loss: Decimal = Decimal("0")
+    take_profit: list[Decimal] = field(default_factory=list)
+    atr_val: Decimal = Decimal("0")
+
+    # Step 6: MTF context
+    strength: float = 0.0
+    confidence: float = 0.0
+    mtf_ctx: MTFContext | None = None
+    features: TechnicalFeatures | None = None
+
+    # Step 7: signal
+    signal: Signal | None = None
+
+    def __post_init__(self) -> None:
+        self.symbol = self.tick.symbol
+
+
+class SignalPipeline:
+    """Encapsulates the tick-to-signal transformation in discrete steps.
+
+    Each step reads and writes fields on a shared :class:`PipelineState`.
+    The full pipeline is executed via :meth:`run`.
+    """
+
+    def __init__(
+        self,
+        *,
+        micro_store: dict[str, MicrostructureAnalyzer],
+        tech_store: dict[str, TechnicalAnalyzer],
+        vpin_store: dict[str, VPINCalculator],
+        adv_counter: dict[str, int],
+        prev_ema_8: dict[str, Decimal | None],
+        prev_ema_21: dict[str, Decimal | None],
+        mtf: MTFAligner,
+        scorer: SignalScorer,
+        state: StateStore,
+    ) -> None:
+        self._micro_store = micro_store
+        self._tech_store = tech_store
+        self._vpin_store = vpin_store
+        self._adv_counter = adv_counter
+        self._prev_ema_8 = prev_ema_8
+        self._prev_ema_21 = prev_ema_21
+        self._mtf = mtf
+        self._scorer = scorer
+        self._state = state
+
+    # ── Step 1: Lazy-init ────────────────────────────────────────────────────
+
+    def ensure_initialized(self, ps: PipelineState) -> None:
+        """Lazy-initialize per-symbol analyzers on first tick.
+
+        Args:
+            ps: Current pipeline state.
+        """
+        symbol = ps.symbol
+        if symbol not in self._micro_store:
+            self._micro_store[symbol] = MicrostructureAnalyzer(symbol)
+        if symbol not in self._tech_store:
+            self._tech_store[symbol] = TechnicalAnalyzer(symbol)
+        if symbol not in self._vpin_store:
+            self._vpin_store[symbol] = VPINCalculator(default_bucket_size=1000.0)
+            self._adv_counter[symbol] = 0
+
+        ps.micro = self._micro_store[symbol]
+        ps.tech = self._tech_store[symbol]
+
+        ps.micro.update(ps.tick)
+        ps.tech.update(ps.tick)
+
+    # ── Step 2: VPIN refresh ─────────────────────────────────────────────────
+
+    async def refresh_vpin(self, ps: PipelineState) -> None:
+        """Update VPIN estimate and gate on extreme toxicity.
+
+        Sets ``ps.vpin_blocked = True`` if toxicity is extreme, aborting
+        the pipeline.
+
+        Args:
+            ps: Current pipeline state.
+        """
+        symbol = ps.symbol
+        self._adv_counter[symbol] = self._adv_counter.get(symbol, 0) + 1
+        if self._adv_counter[symbol] >= _ADV_REFRESH_EVERY:
+            self._adv_counter[symbol] = 0
+            try:
+                adv_data = await self._state.get(f"analytics:adv:{symbol}")
+                if isinstance(adv_data, dict):
+                    adv_val = float(adv_data.get("adv_1d", 0) or 0)
+                    if adv_val > 0:
+                        self._vpin_store[symbol].update_adv(adv_val)
+            except Exception as exc:
+                logger.debug(
+                    "ADV refresh failed, keeping default bucket_size",
+                    symbol=symbol,
+                    error=str(exc),
+                )
+
+        self._vpin_store[symbol].update(ps.tick)
+        vpin_metrics = self._vpin_store[symbol].compute()
+
+        await self._state.set(
+            f"vpin:{symbol}",
+            {
+                "vpin": vpin_metrics.vpin,
+                "toxicity_level": vpin_metrics.toxicity_level,
+                "size_multiplier": vpin_metrics.size_multiplier,
+                "effective_bucket_size": vpin_metrics.effective_bucket_size,
+                "adv_source": vpin_metrics.adv_source,
+                "buy_volume_pct": vpin_metrics.buy_volume_pct,
+            },
+            ttl=60,
+        )
+
+        if vpin_metrics.toxicity_level == "extreme":
+            logger.warning("vpin_extreme_block", symbol=symbol, vpin=vpin_metrics.vpin)
+            ps.vpin_blocked = True
+
+    # ── Step 3: Compute indicators ───────────────────────────────────────────
+
+    def compute_indicators(self, ps: PipelineState) -> None:
+        """Compute all indicator families from analyzer state.
+
+        Args:
+            ps: Current pipeline state.
+        """
+        assert ps.micro is not None
+        assert ps.tech is not None
+        symbol = ps.symbol
+        tech = ps.tech
+        micro = ps.micro
+
+        ps.ofi_val = micro.ofi()
+        ps.rsi_1m = tech.rsi(period=14, timeframe="1m")
+        ps.bb_upper, ps.bb_middle, ps.bb_lower = tech.bollinger_bands(
+            period=20, std=2.0, timeframe="5m"
+        )
+
+        # EMA 5m (for cross detection state persistence)
+        ps.ema_8 = tech.ema(period=8, timeframe="5m")
+        ps.ema_21 = tech.ema(period=21, timeframe="5m")
+        self._prev_ema_8[symbol] = ps.ema_8
+        self._prev_ema_21[symbol] = ps.ema_21
+
+        # EMA 1m and 15m (for MTF alignment scorer)
+        ps.ema_8_1m = tech.ema(period=8, timeframe="1m")
+        ps.ema_21_1m = tech.ema(period=21, timeframe="1m")
+        ps.ema_8_15m = tech.ema(period=8, timeframe="15m")
+        ps.ema_21_15m = tech.ema(period=21, timeframe="15m")
+        ps.vwap_val = tech.vwap()
+
+    # ── Step 4: Build scorer components ──────────────────────────────────────
+
+    def build_components(self, ps: PipelineState) -> None:
+        """Assemble scorer input components from computed indicators.
+
+        Args:
+            ps: Current pipeline state.
+        """
+        assert ps.tech is not None
+        assert ps.micro is not None
+        tech = ps.tech
+        entry_price = ps.tick.price
+
+        # Microstructure: OFI normalised to [-1, +1]
+        ofi_val = ps.ofi_val
+        ofi_score = max(-1.0, min(1.0, ofi_val / max(abs(ofi_val), 1e-6))) if ofi_val != 0 else 0.0
+
+        # Bollinger score
+        if ps.bb_upper is not None and ps.bb_lower is not None and ps.bb_middle is not None:
+            bb_score = tech.compute_bollinger_score(
+                price=float(entry_price),
+                upper=float(ps.bb_upper),
+                lower=float(ps.bb_lower),
+                middle=float(ps.bb_middle),
+                bandwidth_pct=50.0,
+            )
+        else:
+            bb_score = 0.0
+
+        # EMA MTF alignment score
+        if (
+            ps.ema_8_1m is not None
+            and ps.ema_21_1m is not None
+            and ps.ema_8_15m is not None
+            and ps.ema_21_15m is not None
+        ):
+            price_above_vwap = ps.vwap_val is not None and entry_price > ps.vwap_val
+            ema_alignment_score = self._mtf.compute_alignment_score(
+                ema_fast_1m=float(ps.ema_8_1m),
+                ema_slow_1m=float(ps.ema_21_1m),
+                ema_fast_15m=float(ps.ema_8_15m),
+                ema_slow_15m=float(ps.ema_21_15m),
+                price_above_vwap=price_above_vwap,
+            )
+        else:
+            ema_alignment_score = 0.0
+
+        # RSI divergence score
+        rsi_div = tech.rsi_divergence(timeframe="5m")
+        rsi_divergence_score = (
+            1.0 if rsi_div == "bullish" else (-1.0 if rsi_div == "bearish" else 0.0)
+        )
+
+        # VWAP score
+        if ps.vwap_val is not None and ps.vwap_val > Decimal("0"):
+            raw_vwap = float((entry_price - ps.vwap_val) / ps.vwap_val)
+            vwap_score = max(-1.0, min(1.0, -raw_vwap * 20.0))
+        else:
+            vwap_score = 0.0
+
+        ps.components = [
+            SignalComponent(
+                name="microstructure",
+                score=ofi_score,
+                weight=0.35,
+                triggered=abs(ofi_val) > _OFI_THRESHOLD,
+                metadata={"ofi": ofi_val, "cvd": ps.micro.cvd()},
+            ),
+            SignalComponent(
+                name="bollinger",
+                score=bb_score,
+                weight=0.25,
+                triggered=abs(bb_score) > 0.15,
+                metadata={"squeeze": tech.bb_squeeze(timeframe="5m")},
+            ),
+            SignalComponent(
+                name="ema_mtf",
+                score=ema_alignment_score,
+                weight=0.20,
+                triggered=abs(ema_alignment_score) > 0.10,
+            ),
+            SignalComponent(
+                name="rsi_divergence",
+                score=rsi_divergence_score,
+                weight=0.15,
+                triggered=rsi_divergence_score != 0.0,
+            ),
+            SignalComponent(
+                name="vwap",
+                score=vwap_score,
+                weight=0.05,
+                triggered=abs(vwap_score) > 0.002,
+            ),
+        ]
+
+        ps.final_strength, ps.triggers = self._scorer.compute(ps.components)
+
+        if ps.final_strength != 0.0:
+            ps.direction = Direction.LONG if ps.final_strength > 0 else Direction.SHORT
+
+    # ── Step 5: Compute price levels ─────────────────────────────────────────
+
+    def compute_price_levels(self, ps: PipelineState) -> None:
+        """Compute ATR-based stop-loss and take-profit levels.
+
+        Args:
+            ps: Current pipeline state.
+        """
+        assert ps.tech is not None
+        assert ps.direction is not None
+        entry_price = ps.tick.price
+
+        atr = ps.tech.atr(period=14, timeframe="5m")
+        ps.atr_val = (
+            atr if atr is not None and atr > Decimal("0") else entry_price * _ATR_FALLBACK_PCT
+        )
+
+        if ps.direction == Direction.LONG:
+            ps.stop_loss = entry_price - _SL_ATR_MULT * ps.atr_val
+            ps.take_profit = [
+                entry_price + _TP1_ATR_MULT * ps.atr_val,
+                entry_price + _TP2_ATR_MULT * ps.atr_val,
+            ]
+        else:
+            ps.stop_loss = entry_price + _SL_ATR_MULT * ps.atr_val
+            ps.take_profit = [
+                entry_price - _TP1_ATR_MULT * ps.atr_val,
+                entry_price - _TP2_ATR_MULT * ps.atr_val,
+            ]
+
+        if ps.stop_loss <= Decimal("0"):
+            ps.stop_loss = entry_price * _FALLBACK_SL_PCT
+
+    # ── Step 6: Build MTF context + features ─────────────────────────────────
+
+    def build_mtf_context(self, ps: PipelineState) -> None:
+        """Assemble multi-timeframe context and technical features.
+
+        Args:
+            ps: Current pipeline state.
+        """
+        assert ps.direction is not None
+        assert ps.tech is not None
+        assert ps.micro is not None
+        tech = ps.tech
+
+        ps.strength = ps.final_strength
+        ps.confidence = min(
+            1.0, abs(ps.final_strength) + len(ps.triggers) / _MAX_TRIGGERS_FOR_CONFIDENCE * 0.3
+        )
+
+        self._mtf.update("5m", ps.direction.value, abs(ps.final_strength))
+        ps.mtf_ctx = self._mtf.build_context(ps.direction.value, ps.tick.timestamp_ms)
+
+        # TechnicalFeatures snapshot
+        vp = tech.volume_profile()
+        rsi_5m = tech.rsi(period=14, timeframe="5m")
+        rsi_15m = tech.rsi(period=14, timeframe="15m")
+        bb_u, bb_m, bb_l = tech.bollinger_bands(timeframe="5m")
+
+        ps.features = TechnicalFeatures(
+            rsi_1m=ps.rsi_1m,
+            rsi_5m=rsi_5m,
+            rsi_15m=rsi_15m,
+            bb_upper=bb_u,
+            bb_middle=bb_m,
+            bb_lower=bb_l,
+            bb_squeeze=tech.bb_squeeze(timeframe="5m"),
+            ema_8=ps.ema_8,
+            ema_21=ps.ema_21,
+            ema_55=tech.ema(period=55, timeframe="5m"),
+            vwap=tech.vwap(),
+            atr_14=tech.atr(period=14, timeframe="5m"),
+            poc=vp.get("poc"),
+            vah=vp.get("vah"),
+            val=vp.get("val"),
+            ofi=ps.ofi_val,
+            cvd=ps.micro.cvd(),
+            kyle_lambda=ps.micro.kyle_lambda(),
+        )
+
+    # ── Step 7: Construct signal ─────────────────────────────────────────────
+
+    def construct_signal(self, ps: PipelineState) -> None:
+        """Construct, validate, and set the final Signal on state.
+
+        Args:
+            ps: Current pipeline state.
+        """
+        assert ps.direction is not None
+        try:
+            ps.signal = Signal(
+                signal_id=str(uuid.uuid4()),
+                symbol=ps.symbol,
+                timestamp_ms=ps.tick.timestamp_ms,
+                direction=ps.direction,
+                strength=ps.strength,
+                signal_type=SignalType.COMPOSITE,
+                triggers=ps.triggers,
+                entry=ps.tick.price,
+                stop_loss=ps.stop_loss,
+                take_profit=ps.take_profit,
+                confidence=ps.confidence,
+                features=ps.features,
+                mtf_context=ps.mtf_ctx,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Signal construction failed",
+                symbol=ps.symbol,
+                direction=ps.direction.value,
+                error=str(exc),
+            )
+
+    # ── Full pipeline ────────────────────────────────────────────────────────
+
+    async def run(self, tick: NormalizedTick) -> Signal | None:
+        """Execute the full tick-to-signal pipeline.
+
+        Args:
+            tick: Validated normalized tick.
+
+        Returns:
+            A :class:`Signal` if confluence conditions are met, else ``None``.
+        """
+        ps = PipelineState(tick=tick)
+
+        # Step 1: lazy-init
+        self.ensure_initialized(ps)
+
+        # Step 2: VPIN
+        await self.refresh_vpin(ps)
+        if ps.vpin_blocked:
+            return None
+
+        # Step 3: indicators
+        self.compute_indicators(ps)
+
+        # Step 4: scorer components
+        self.build_components(ps)
+        if ps.final_strength == 0.0:
+            return None  # No confluent signal
+
+        # Step 5: price levels
+        self.compute_price_levels(ps)
+
+        # Step 6: MTF context + features
+        self.build_mtf_context(ps)
+
+        # Step 7: construct signal
+        self.construct_signal(ps)
+
+        return ps.signal

--- a/services/s02_signal_engine/service.py
+++ b/services/s02_signal_engine/service.py
@@ -12,7 +12,6 @@ Redis cache key:  ``signal:{SYMBOL}``
 from __future__ import annotations
 
 import asyncio
-from decimal import Decimal
 from typing import Any
 
 from core.base_service import BaseService
@@ -67,18 +66,12 @@ class SignalEngineService(BaseService):
         self._vpin: dict[str, VPINCalculator] = {}
         self._adv_counter: dict[str, int] = {}
 
-        # Previous EMA values per symbol - needed for cross detection.
-        self._prev_ema_8: dict[str, Decimal | None] = {}
-        self._prev_ema_21: dict[str, Decimal | None] = {}
-
         # Pipeline encapsulates the full tick-to-signal transformation.
         self._pipeline = SignalPipeline(
             micro_store=self._micro,
             tech_store=self._tech,
             vpin_store=self._vpin,
             adv_counter=self._adv_counter,
-            prev_ema_8=self._prev_ema_8,
-            prev_ema_21=self._prev_ema_21,
             mtf=self._mtf,
             scorer=self._scorer,
             state=self.state,

--- a/services/s02_signal_engine/service.py
+++ b/services/s02_signal_engine/service.py
@@ -12,23 +12,17 @@ Redis cache key:  ``signal:{SYMBOL}``
 from __future__ import annotations
 
 import asyncio
-import uuid
 from decimal import Decimal
 from typing import Any
 
 from core.base_service import BaseService
 from core.logger import get_logger
-from core.models.signal import (
-    Direction,
-    MTFContext,
-    Signal,
-    SignalType,
-    TechnicalFeatures,
-)
+from core.models.signal import Signal
 from core.models.tick import NormalizedTick
 from services.s02_signal_engine.microstructure import MicrostructureAnalyzer
 from services.s02_signal_engine.mtf_aligner import MTFAligner
-from services.s02_signal_engine.signal_scorer import SignalComponent, SignalScorer
+from services.s02_signal_engine.pipeline import SignalPipeline
+from services.s02_signal_engine.signal_scorer import SignalScorer
 from services.s02_signal_engine.technical import TechnicalAnalyzer
 from services.s02_signal_engine.vpin import VPINCalculator
 
@@ -37,40 +31,20 @@ logger = get_logger("s02_signal_engine.service")
 # ZMQ topic prefix for all normalized ticks.
 _TICK_TOPICS: list[str] = ["tick."]
 
-# OFI magnitude threshold for triggering an OFI signal.
-_OFI_THRESHOLD: float = 0.3
-
-# ATR multiples for stop-loss and take-profit levels.
-_SL_ATR_MULT: Decimal = Decimal("1.5")
-_TP1_ATR_MULT: Decimal = Decimal("2.0")
-_TP2_ATR_MULT: Decimal = Decimal("3.0")
-
-# Fallback stop-loss distance when ATR is unavailable (0.2% of entry price).
-_ATR_FALLBACK_PCT: Decimal = Decimal("0.002")
-
-# Minimum stop-loss floor when the computed stop-loss turns non-positive
-# (e.g. entry near zero): expressed as a fraction of entry price.
-_FALLBACK_SL_PCT: Decimal = Decimal("0.001")
-
-# Number of triggers needed for full confidence (confidence = triggers / N).
-_MAX_TRIGGERS_FOR_CONFIDENCE: float = 4.0
-
-# How many ticks between ADV refreshes from Redis (≈5 min at 1 tick/s).
-_ADV_REFRESH_EVERY: int = 300
-
 
 class SignalEngineService(BaseService):
     """Generates technical trading signals from the live tick stream.
 
-    For each incoming :class:`~core.models.tick.NormalizedTick` the service:
+    For each incoming :class:`~core.models.tick.NormalizedTick` the service
+    delegates to :class:`~.pipeline.SignalPipeline` which:
 
-    1. Updates per-symbol :class:`~.microstructure.MicrostructureAnalyzer`
-       and :class:`~.technical.TechnicalAnalyzer` instances.
-    2. Evaluates four trigger conditions (OFI, RSI, Bollinger Band bounce,
-       EMA cross) and categorises each as long or short.
+    1. Updates per-symbol analyzers (microstructure, technical, VPIN).
+    2. Evaluates trigger conditions and builds scorer components.
     3. If a net directional consensus exists, builds a fully-populated
        :class:`~core.models.signal.Signal` with ATR-based price levels.
-    4. Publishes the signal on ZMQ and caches it in Redis.
+    4. Returns the signal (or ``None`` if no confluence).
+
+    The service then publishes the signal on ZMQ and caches it in Redis.
     """
 
     service_id: str = "s02_signal_engine"
@@ -96,6 +70,19 @@ class SignalEngineService(BaseService):
         # Previous EMA values per symbol - needed for cross detection.
         self._prev_ema_8: dict[str, Decimal | None] = {}
         self._prev_ema_21: dict[str, Decimal | None] = {}
+
+        # Pipeline encapsulates the full tick-to-signal transformation.
+        self._pipeline = SignalPipeline(
+            micro_store=self._micro,
+            tech_store=self._tech,
+            vpin_store=self._vpin,
+            adv_counter=self._adv_counter,
+            prev_ema_8=self._prev_ema_8,
+            prev_ema_21=self._prev_ema_21,
+            mtf=self._mtf,
+            scorer=self._scorer,
+            state=self.state,
+        )
 
     # ── BaseService interface ─────────────────────────────────────────────────
 
@@ -141,271 +128,31 @@ class SignalEngineService(BaseService):
         Args:
             tick: Validated normalized tick.
         """
-        symbol = tick.symbol
+        signal = await self._pipeline.run(tick)
+        if signal is not None:
+            await self._publish_signal(signal)
 
-        # Lazy-initialize per-symbol analyzers.
-        if symbol not in self._micro:
-            self._micro[symbol] = MicrostructureAnalyzer(symbol)
-        if symbol not in self._tech:
-            self._tech[symbol] = TechnicalAnalyzer(symbol)
-        if symbol not in self._vpin:
-            self._vpin[symbol] = VPINCalculator(default_bucket_size=1000.0)
-            self._adv_counter[symbol] = 0
+    async def _publish_signal(self, signal: Signal) -> None:
+        """Publish a signal on ZMQ and cache in Redis.
 
-        micro = self._micro[symbol]
-        tech = self._tech[symbol]
-
-        micro.update(tick)
-        tech.update(tick)
-
-        # ── VPIN: refresh ADV from S07 every N ticks, then update + gate ─────
-        self._adv_counter[symbol] += 1
-        if self._adv_counter[symbol] >= _ADV_REFRESH_EVERY:
-            self._adv_counter[symbol] = 0
-            try:
-                adv_data = await self.state.get(f"analytics:adv:{symbol}")
-                if isinstance(adv_data, dict):
-                    adv_val = float(adv_data.get("adv_1d", 0) or 0)
-                    if adv_val > 0:
-                        self._vpin[symbol].update_adv(adv_val)
-            except Exception as exc:
-                self.logger.debug(
-                    "ADV refresh failed, keeping default bucket_size",
-                    symbol=symbol,
-                    error=str(exc),
-                )
-
-        self._vpin[symbol].update(tick)
-        vpin_metrics = self._vpin[symbol].compute()
-
-        await self.state.set(
-            f"vpin:{symbol}",
-            {
-                "vpin": vpin_metrics.vpin,
-                "toxicity_level": vpin_metrics.toxicity_level,
-                "size_multiplier": vpin_metrics.size_multiplier,
-                "effective_bucket_size": vpin_metrics.effective_bucket_size,
-                "adv_source": vpin_metrics.adv_source,
-                "buy_volume_pct": vpin_metrics.buy_volume_pct,
-            },
-            ttl=60,
-        )
-
-        if vpin_metrics.toxicity_level == "extreme":
-            self.logger.warning("vpin_extreme_block", symbol=symbol, vpin=vpin_metrics.vpin)
-            return  # Signal abandoned — flow too toxic
-
-        # ── Compute indicators ────────────────────────────────────────────────
-        ofi_val = micro.ofi()
-        rsi_1m = tech.rsi(period=14, timeframe="1m")
-        bb_upper, _bb_middle, bb_lower = tech.bollinger_bands(period=20, std=2.0, timeframe="5m")
-        entry_price: Decimal = tick.price
-
-        # EMA 5m (for cross detection state persistence)
-        ema_8 = tech.ema(period=8, timeframe="5m")
-        ema_21 = tech.ema(period=21, timeframe="5m")
-        self._prev_ema_8[symbol] = ema_8
-        self._prev_ema_21[symbol] = ema_21
-
-        # EMA 1m and 15m (for MTF alignment scorer)
-        ema_8_1m = tech.ema(period=8, timeframe="1m")
-        ema_21_1m = tech.ema(period=21, timeframe="1m")
-        ema_8_15m = tech.ema(period=8, timeframe="15m")
-        ema_21_15m = tech.ema(period=21, timeframe="15m")
-        vwap_val = tech.vwap()
-
-        # ── Build scorer components ───────────────────────────────────────────
-        # Microstructure: OFI normalised to [-1, +1]
-        ofi_score = max(-1.0, min(1.0, ofi_val / max(abs(ofi_val), 1e-6))) if ofi_val != 0 else 0.0
-
-        # Bollinger score
-        if bb_upper is not None and bb_lower is not None and _bb_middle is not None:
-            bb_score = tech.compute_bollinger_score(
-                price=float(entry_price),
-                upper=float(bb_upper),
-                lower=float(bb_lower),
-                middle=float(_bb_middle),
-                bandwidth_pct=50.0,  # conservative default (no historical pct yet)
-            )
-        else:
-            bb_score = 0.0
-
-        # EMA MTF alignment score
-        if (
-            ema_8_1m is not None
-            and ema_21_1m is not None
-            and ema_8_15m is not None
-            and ema_21_15m is not None
-        ):
-            price_above_vwap = vwap_val is not None and entry_price > vwap_val
-            ema_alignment_score = self._mtf.compute_alignment_score(
-                ema_fast_1m=float(ema_8_1m),
-                ema_slow_1m=float(ema_21_1m),
-                ema_fast_15m=float(ema_8_15m),
-                ema_slow_15m=float(ema_21_15m),
-                price_above_vwap=price_above_vwap,
-            )
-        else:
-            ema_alignment_score = 0.0
-
-        # RSI divergence score
-        rsi_div = tech.rsi_divergence(timeframe="5m")
-        rsi_divergence_score = (
-            1.0 if rsi_div == "bullish" else (-1.0 if rsi_div == "bearish" else 0.0)
-        )
-
-        # VWAP score: (price - vwap) / vwap, normalised to [-1, +1]
-        if vwap_val is not None and vwap_val > Decimal("0"):
-            raw_vwap = float((entry_price - vwap_val) / vwap_val)
-            # Invert: price above VWAP → short pressure; below → long pressure
-            vwap_score = max(-1.0, min(1.0, -raw_vwap * 20.0))
-        else:
-            vwap_score = 0.0
-
-        components = [
-            SignalComponent(
-                name="microstructure",
-                score=ofi_score,
-                weight=0.35,
-                triggered=abs(ofi_val) > _OFI_THRESHOLD,
-                metadata={"ofi": ofi_val, "cvd": micro.cvd()},
-            ),
-            SignalComponent(
-                name="bollinger",
-                score=bb_score,
-                weight=0.25,
-                triggered=abs(bb_score) > 0.15,
-                metadata={"squeeze": tech.bb_squeeze(timeframe="5m")},
-            ),
-            SignalComponent(
-                name="ema_mtf",
-                score=ema_alignment_score,
-                weight=0.20,
-                triggered=abs(ema_alignment_score) > 0.10,
-            ),
-            SignalComponent(
-                name="rsi_divergence",
-                score=rsi_divergence_score,
-                weight=0.15,
-                triggered=rsi_divergence_score != 0.0,
-            ),
-            SignalComponent(
-                name="vwap",
-                score=vwap_score,
-                weight=0.05,
-                triggered=abs(vwap_score) > 0.002,
-            ),
-        ]
-
-        final_strength, triggers = self._scorer.compute(components)
-
-        if final_strength == 0.0:
-            return  # No confluent signal
-
-        direction = Direction.LONG if final_strength > 0 else Direction.SHORT
-
-        # ── Price levels (ATR-based) ──────────────────────────────────────────
-        atr = tech.atr(period=14, timeframe="5m")
-        atr_val: Decimal = (
-            atr if atr is not None and atr > Decimal("0") else entry_price * _ATR_FALLBACK_PCT
-        )
-
-        if direction == Direction.LONG:
-            stop_loss = entry_price - _SL_ATR_MULT * atr_val
-            take_profit = [
-                entry_price + _TP1_ATR_MULT * atr_val,
-                entry_price + _TP2_ATR_MULT * atr_val,
-            ]
-        else:
-            stop_loss = entry_price + _SL_ATR_MULT * atr_val
-            take_profit = [
-                entry_price - _TP1_ATR_MULT * atr_val,
-                entry_price - _TP2_ATR_MULT * atr_val,
-            ]
-
-        # Guard: stop_loss must be strictly positive.
-        if stop_loss <= Decimal("0"):
-            stop_loss = entry_price * _FALLBACK_SL_PCT
-
-        # ── Signal strength and confidence ───────────────────────────────────
-        strength = final_strength  # already signed and in [-1.0, +1.0]
-        confidence = min(
-            1.0, abs(final_strength) + len(triggers) / _MAX_TRIGGERS_FOR_CONFIDENCE * 0.3
-        )
-
-        # ── MTF context ───────────────────────────────────────────────────────
-        self._mtf.update("5m", direction.value, abs(final_strength))
-        mtf_ctx: MTFContext = self._mtf.build_context(direction.value, tick.timestamp_ms)
-
-        # ── TechnicalFeatures snapshot ────────────────────────────────────────
-        vp = tech.volume_profile()
-        rsi_5m = tech.rsi(period=14, timeframe="5m")
-        rsi_15m = tech.rsi(period=14, timeframe="15m")
-        bb_u, bb_m, bb_l = tech.bollinger_bands(timeframe="5m")
-
-        features = TechnicalFeatures(
-            rsi_1m=rsi_1m,
-            rsi_5m=rsi_5m,
-            rsi_15m=rsi_15m,
-            bb_upper=bb_u,
-            bb_middle=bb_m,
-            bb_lower=bb_l,
-            bb_squeeze=tech.bb_squeeze(timeframe="5m"),
-            ema_8=ema_8,
-            ema_21=ema_21,
-            ema_55=tech.ema(period=55, timeframe="5m"),
-            vwap=tech.vwap(),
-            atr_14=atr,
-            poc=vp.get("poc"),
-            vah=vp.get("vah"),
-            val=vp.get("val"),
-            ofi=ofi_val,
-            cvd=micro.cvd(),
-            kyle_lambda=micro.kyle_lambda(),
-        )
-
-        # ── Construct and validate Signal ─────────────────────────────────────
-        try:
-            signal = Signal(
-                signal_id=str(uuid.uuid4()),
-                symbol=symbol,
-                timestamp_ms=tick.timestamp_ms,
-                direction=direction,
-                strength=strength,
-                signal_type=SignalType.COMPOSITE,
-                triggers=triggers,
-                entry=entry_price,
-                stop_loss=stop_loss,
-                take_profit=take_profit,
-                confidence=confidence,
-                features=features,
-                mtf_context=mtf_ctx,
-            )
-        except Exception as exc:
-            self.logger.warning(
-                "Signal construction failed",
-                symbol=symbol,
-                direction=direction.value,
-                error=str(exc),
-            )
-            return
-
-        # ── Publish and cache ─────────────────────────────────────────────────
+        Args:
+            signal: Validated Signal object.
+        """
         signal_dict = signal.model_dump()
-        pub_topic = f"signal.technical.{symbol}"
+        pub_topic = f"signal.technical.{signal.symbol}"
 
         await asyncio.gather(
             self.bus.publish(pub_topic, signal_dict),
-            self.state.set(f"signal:{symbol}", signal_dict),
+            self.state.set(f"signal:{signal.symbol}", signal_dict),
         )
 
         self.logger.info(
             "Signal published",
-            symbol=symbol,
-            direction=direction.value,
-            triggers=triggers,
-            confidence=confidence,
-            entry=str(entry_price),
+            symbol=signal.symbol,
+            direction=signal.direction.value,
+            triggers=signal.triggers,
+            confidence=signal.confidence,
+            entry=str(signal.entry),
         )
 
 

--- a/services/s06_execution/broker_alpaca.py
+++ b/services/s06_execution/broker_alpaca.py
@@ -16,11 +16,13 @@ from alpaca.trading.models import Order, Position, TradeAccount
 from alpaca.trading.requests import LimitOrderRequest, MarketOrderRequest
 
 from core.logger import get_logger
+from core.models.order import ApprovedOrder, ExecutedOrder
+from services.s06_execution.broker_base import Broker, BrokerConnectionError
 
 logger = get_logger("s06_execution.broker_alpaca")
 
 
-class AlpacaBroker:
+class AlpacaBroker(Broker):
     """Sync/async equity broker backed by the ``alpaca-py`` TradingClient.
 
     ``alpaca-py``'s :class:`~alpaca.trading.client.TradingClient` is
@@ -74,9 +76,65 @@ class AlpacaBroker:
         self._client = None
         logger.info("AlpacaBroker disconnected")
 
-    # ── Order operations ──────────────────────────────────────────────────────
+    # ── Broker ABC interface ────────────────────────────────────────────────
 
-    async def place_order(
+    @property
+    def is_connected(self) -> bool:
+        """Current connection state."""
+        return self._client is not None
+
+    async def place_order(self, order: ApprovedOrder) -> ExecutedOrder | None:
+        """Place an equity order via Alpaca from an approved order.
+
+        Extracts symbol, quantity, side, and price from the
+        :class:`~core.models.order.ApprovedOrder` and submits to Alpaca.
+        Returns ``None`` because live fills are confirmed asynchronously.
+
+        Args:
+            order: Risk-approved order.
+
+        Returns:
+            ``None`` — fill confirmed asynchronously via Alpaca webhooks.
+
+        Raises:
+            BrokerConnectionError: If not connected.
+        """
+        if not self.is_connected:
+            raise BrokerConnectionError("AlpacaBroker not connected. Call connect() first.")
+        candidate = order.candidate
+        side = "buy" if candidate.direction.value == "long" else "sell"
+        resp = await self._submit_raw_order(
+            symbol=candidate.symbol,
+            qty=float(order.adjusted_size),
+            side=side,
+            order_type="limit",
+            limit_price=float(candidate.entry),
+            stop_price=float(candidate.stop_loss),
+        )
+        logger.info(
+            "Alpaca order placed",
+            order_id=candidate.order_id,
+            alpaca_id=resp.get("id"),
+        )
+        return None
+
+    async def cancel_order(self, order_id: str) -> bool:
+        """Cancel an open order by its Alpaca order UUID.
+
+        Args:
+            order_id: Alpaca-assigned order UUID string.
+
+        Returns:
+            ``True`` if cancel succeeded.
+        """
+        client = self._ensure_client()
+        client.cancel_order_by_id(UUID(order_id))
+        logger.info("Order cancelled", order_id=order_id)
+        return True
+
+    # ── Venue-specific operations ────────────────────────────────────────────
+
+    async def _submit_raw_order(
         self,
         symbol: str,
         qty: float,
@@ -85,14 +143,13 @@ class AlpacaBroker:
         limit_price: float | None = None,
         stop_price: float | None = None,
     ) -> dict[str, Any]:
-        """Submit an order to Alpaca.
+        """Submit a raw order to Alpaca with venue-specific parameters.
 
         Args:
             symbol:      Ticker symbol (e.g. ``"AAPL"``).
             qty:         Number of shares (fractional supported by Alpaca).
             side:        ``"buy"`` or ``"sell"``.
-            order_type:  ``"market"`` or ``"limit"`` (stop orders use
-                         stop_limit via separate call if needed).
+            order_type:  ``"market"`` or ``"limit"``.
             limit_price: Required when *order_type* is ``"limit"``.
             stop_price:  Ignored for simple limit/market (use OCO for stops).
 
@@ -122,26 +179,16 @@ class AlpacaBroker:
             )
 
         raw = client.submit_order(order_data=req)
-        order: Order = raw if isinstance(raw, Order) else Order.model_validate(raw)
+        alpaca_order: Order = raw if isinstance(raw, Order) else Order.model_validate(raw)
         return {
-            "id": str(order.id),
-            "symbol": order.symbol,
-            "qty": str(order.qty),
-            "side": str(order.side),
-            "type": str(order.order_type),
-            "status": str(order.status),
-            "limit_price": str(order.limit_price) if order.limit_price else None,
+            "id": str(alpaca_order.id),
+            "symbol": alpaca_order.symbol,
+            "qty": str(alpaca_order.qty),
+            "side": str(alpaca_order.side),
+            "type": str(alpaca_order.order_type),
+            "status": str(alpaca_order.status),
+            "limit_price": (str(alpaca_order.limit_price) if alpaca_order.limit_price else None),
         }
-
-    async def cancel_order(self, order_id: str) -> None:
-        """Cancel an open order by its Alpaca order UUID.
-
-        Args:
-            order_id: Alpaca-assigned order UUID string.
-        """
-        client = self._ensure_client()
-        client.cancel_order_by_id(UUID(order_id))
-        logger.info("Order cancelled", order_id=order_id)
 
     # ── Account / position queries ────────────────────────────────────────────
 

--- a/services/s06_execution/broker_alpaca.py
+++ b/services/s06_execution/broker_alpaca.py
@@ -270,8 +270,8 @@ class AlpacaBroker(Broker):
             Active :class:`~alpaca.trading.client.TradingClient`.
 
         Raises:
-            RuntimeError: If :meth:`connect` has not been called.
+            BrokerConnectionError: If :meth:`connect` has not been called.
         """
         if self._client is None:
-            raise RuntimeError("AlpacaBroker not connected. Call connect() first.")
+            raise BrokerConnectionError("AlpacaBroker not connected. Call connect() first.")
         return self._client

--- a/services/s06_execution/broker_base.py
+++ b/services/s06_execution/broker_base.py
@@ -1,0 +1,74 @@
+"""Broker abstract base class — common interface for all execution backends.
+
+All execution backends (Alpaca, Binance, PaperTrader, future IBKR, …) must
+implement this interface so that :class:`ExecutionService` depends on the
+abstraction rather than on concrete broker classes (DIP).
+
+The :meth:`place_order` contract returns ``ExecutedOrder`` when the fill is
+synchronous (e.g. paper trading) and ``None`` when the fill will be confirmed
+asynchronously (e.g. live venue).
+
+References:
+    Robert C. Martin (2017) Clean Architecture Ch. 11 — DIP
+    Gang of Four (1994) — Strategy Pattern
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from core.models.order import ApprovedOrder, ExecutedOrder
+
+
+class Broker(ABC):
+    """Abstract broker interface for APEX execution backends."""
+
+    @abstractmethod
+    async def connect(self) -> None:
+        """Establish connection to broker (auth, websocket, etc.). Idempotent."""
+        ...
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        """Close connection cleanly. Idempotent."""
+        ...
+
+    @property
+    @abstractmethod
+    def is_connected(self) -> bool:
+        """Current connection state."""
+        ...
+
+    @abstractmethod
+    async def place_order(self, order: ApprovedOrder) -> ExecutedOrder | None:
+        """Place an order for execution.
+
+        Args:
+            order: Risk-approved order ready for execution.
+
+        Returns:
+            ``ExecutedOrder`` when the fill is synchronous (paper),
+            ``None`` when the fill will be confirmed asynchronously (live).
+
+        Raises:
+            BrokerConnectionError: If the broker is not connected.
+            BrokerRejectedError: If the broker rejects the order.
+        """
+        ...
+
+    @abstractmethod
+    async def cancel_order(self, order_id: str) -> bool:
+        """Cancel an outstanding order by ID.
+
+        Returns:
+            ``True`` if cancel succeeded, ``False`` if already filled/cancelled.
+        """
+        ...
+
+
+class BrokerConnectionError(RuntimeError):
+    """Raised when a broker operation fails due to connection issues."""
+
+
+class BrokerRejectedError(RuntimeError):
+    """Raised when the broker rejects an order (insufficient funds, etc.)."""

--- a/services/s06_execution/broker_binance.py
+++ b/services/s06_execution/broker_binance.py
@@ -14,8 +14,14 @@ from typing import Any
 
 import aiohttp
 
+from core.logger import get_logger
+from core.models.order import ApprovedOrder, ExecutedOrder
+from services.s06_execution.broker_base import Broker, BrokerConnectionError
 
-class BinanceBroker:
+logger = get_logger("s06_execution.broker_binance")
+
+
+class BinanceBroker(Broker):
     """Async HTTP client for the Binance spot trading API.
 
     Supports both mainnet and testnet environments.  The ``base_url``
@@ -45,6 +51,7 @@ class BinanceBroker:
         self._base_url = base_url.rstrip("/")
         self._testnet = testnet
         self._session: aiohttp.ClientSession | None = None
+        self._order_symbols: dict[str, str] = {}  # orderId → symbol for cancel
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -78,9 +85,72 @@ class BinanceBroker:
             hashlib.sha256,
         ).hexdigest()
 
-    # ── Order operations ──────────────────────────────────────────────────────
+    # ── Broker ABC interface ────────────────────────────────────────────────
 
-    async def place_order(
+    @property
+    def is_connected(self) -> bool:
+        """Current connection state."""
+        return self._session is not None
+
+    async def place_order(self, order: ApprovedOrder) -> ExecutedOrder | None:
+        """Place a crypto order via Binance from an approved order.
+
+        Extracts symbol, quantity, side, and price from the
+        :class:`~core.models.order.ApprovedOrder` and submits to Binance.
+        Returns ``None`` because live fills are confirmed asynchronously.
+
+        Args:
+            order: Risk-approved order.
+
+        Returns:
+            ``None`` — fill confirmed asynchronously.
+
+        Raises:
+            BrokerConnectionError: If not connected.
+        """
+        if not self.is_connected:
+            raise BrokerConnectionError("BinanceBroker not connected. Call connect() first.")
+        candidate = order.candidate
+        side = "BUY" if candidate.direction.value == "long" else "SELL"
+        resp = await self._submit_raw_order(
+            symbol=candidate.symbol,
+            side=side,
+            order_type="LIMIT",
+            quantity=float(order.adjusted_size),
+            price=float(candidate.entry),
+        )
+        # Track symbol for cancel_order lookups.
+        resp_order_id = str(resp.get("orderId", ""))
+        if resp_order_id:
+            self._order_symbols[resp_order_id] = candidate.symbol
+        logger.info(
+            "Binance order placed",
+            order_id=candidate.order_id,
+            binance_id=resp.get("orderId"),
+        )
+        return None
+
+    async def cancel_order(self, order_id: str) -> bool:
+        """Cancel an open Binance order by ID.
+
+        Uses the internally tracked symbol mapping from :meth:`place_order`.
+
+        Args:
+            order_id: Binance-assigned numeric order ID as a string.
+
+        Returns:
+            ``True`` if cancel succeeded.
+        """
+        symbol = self._order_symbols.get(order_id, "")
+        if not symbol:
+            logger.warning("cancel_order: unknown symbol for order_id", order_id=order_id)
+            return False
+        await self._cancel_raw_order(symbol, order_id)
+        return True
+
+    # ── Venue-specific operations ────────────────────────────────────────────
+
+    async def _submit_raw_order(
         self,
         symbol: str,
         side: str,
@@ -89,7 +159,7 @@ class BinanceBroker:
         price: float | None = None,
         stop_price: float | None = None,
     ) -> dict[str, Any]:
-        """Submit a signed order to Binance.
+        """Submit a signed order to Binance with venue-specific parameters.
 
         Args:
             symbol:     Trading pair symbol (e.g. ``"BTCUSDT"``).
@@ -124,8 +194,8 @@ class BinanceBroker:
             result: dict[str, Any] = dict(await resp.json())
             return result
 
-    async def cancel_order(self, symbol: str, order_id: str) -> None:
-        """Cancel an open Binance order.
+    async def _cancel_raw_order(self, symbol: str, order_id: str) -> None:
+        """Cancel an open Binance order using venue-specific parameters.
 
         Args:
             symbol:   Trading pair symbol.

--- a/services/s06_execution/broker_binance.py
+++ b/services/s06_execution/broker_binance.py
@@ -268,8 +268,8 @@ class BinanceBroker(Broker):
             Active :class:`aiohttp.ClientSession`.
 
         Raises:
-            RuntimeError: If :meth:`connect` has not been called.
+            BrokerConnectionError: If :meth:`connect` has not been called.
         """
         if self._session is None:
-            raise RuntimeError("BinanceBroker not connected. Call connect() first.")
+            raise BrokerConnectionError("BinanceBroker not connected. Call connect() first.")
         return self._session

--- a/services/s06_execution/broker_factory.py
+++ b/services/s06_execution/broker_factory.py
@@ -94,7 +94,7 @@ class BrokerFactory:
                 api_key=self._settings.binance_api_key.get_secret_value(),
                 secret_key=self._settings.binance_secret_key.get_secret_value(),
                 base_url=self._settings.binance_rest_url,
-                testnet=False,
+                testnet=self._settings.binance_testnet,
             )
         return self._binance
 

--- a/services/s06_execution/broker_factory.py
+++ b/services/s06_execution/broker_factory.py
@@ -1,0 +1,118 @@
+"""Broker factory — instantiates the right Broker based on config and symbol.
+
+Centralises broker construction so that adding a new venue (e.g. IBKR) is a
+single registration rather than a multi-file change.
+
+References:
+    Gang of Four (1994) — Factory Method Pattern
+"""
+
+from __future__ import annotations
+
+from core.config import Settings, TradingMode
+from core.state import StateStore
+from services.s06_execution.broker_alpaca import AlpacaBroker
+from services.s06_execution.broker_base import Broker
+from services.s06_execution.broker_binance import BinanceBroker
+from services.s06_execution.paper_trader import PaperTrader
+
+# Crypto symbols share a common suffix pattern.
+_CRYPTO_SUFFIXES = ("USDT", "BUSD", "BTC", "ETH", "USDC")
+
+
+def _is_crypto_symbol(symbol: str) -> bool:
+    """Return ``True`` if the symbol appears to be a crypto pair."""
+    return any(symbol.endswith(s) for s in _CRYPTO_SUFFIXES)
+
+
+class BrokerFactory:
+    """Creates :class:`~.broker_base.Broker` instances based on execution mode + asset class.
+
+    Usage::
+
+        factory = BrokerFactory(settings, state)
+        broker = factory.for_symbol("BTCUSDT")
+        await broker.connect()
+        executed = await broker.place_order(approved_order)
+    """
+
+    def __init__(self, settings: Settings, state: StateStore) -> None:
+        self._settings = settings
+        self._state = state
+
+        # Pre-built singletons for each venue (created lazily or eagerly).
+        self._paper: PaperTrader | None = None
+        self._alpaca: AlpacaBroker | None = None
+        self._binance: BinanceBroker | None = None
+
+    def for_symbol(self, symbol: str) -> Broker:
+        """Return the appropriate broker for a given symbol.
+
+        Routing logic:
+
+        - ``TradingMode.PAPER`` → :class:`PaperTrader`
+        - ``TradingMode.LIVE`` + crypto suffix → :class:`BinanceBroker`
+        - ``TradingMode.LIVE`` + equity → :class:`AlpacaBroker`
+
+        Args:
+            symbol: Uppercase trading symbol.
+
+        Returns:
+            A :class:`Broker` instance ready for use.
+
+        Raises:
+            RuntimeError: If a required live broker is not configured.
+        """
+        if self._settings.trading_mode == TradingMode.PAPER:
+            return self._get_paper()
+
+        if _is_crypto_symbol(symbol):
+            return self._get_binance()
+
+        return self._get_alpaca()
+
+    # ── Lazy singleton getters ───────────────────────────────────────────────
+
+    def _get_paper(self) -> PaperTrader:
+        if self._paper is None:
+            self._paper = PaperTrader(state=self._state)
+        return self._paper
+
+    def _get_alpaca(self) -> AlpacaBroker:
+        if self._alpaca is None:
+            self._alpaca = AlpacaBroker(
+                api_key=self._settings.alpaca_api_key.get_secret_value(),
+                secret_key=self._settings.alpaca_api_secret.get_secret_value(),
+                base_url=self._settings.alpaca_base_url,
+                paper=False,
+            )
+        return self._alpaca
+
+    def _get_binance(self) -> BinanceBroker:
+        if self._binance is None:
+            self._binance = BinanceBroker(
+                api_key=self._settings.binance_api_key.get_secret_value(),
+                secret_key=self._settings.binance_secret_key.get_secret_value(),
+                base_url=self._settings.binance_rest_url,
+                testnet=False,
+            )
+        return self._binance
+
+    async def connect_all(self) -> None:
+        """Connect all pre-built broker instances."""
+        if self._alpaca is not None:
+            await self._alpaca.connect()
+        if self._binance is not None:
+            await self._binance.connect()
+        # PaperTrader.connect() is a no-op but call for consistency.
+        if self._paper is not None:
+            await self._paper.connect()
+
+    async def disconnect_all(self) -> None:
+        """Disconnect all pre-built broker instances."""
+        if self._alpaca is not None:
+            await self._alpaca.disconnect()
+        if self._binance is not None:
+            await self._binance.disconnect()
+        if self._paper is not None:
+            await self._paper.disconnect()

--- a/services/s06_execution/paper_trader.py
+++ b/services/s06_execution/paper_trader.py
@@ -12,9 +12,14 @@ import time
 from decimal import Decimal
 from typing import Any
 
+from core.logger import get_logger
 from core.models.order import ApprovedOrder, ExecutedOrder
-from core.models.tick import NormalizedTick
+from core.models.tick import Market, NormalizedTick
+from core.state import StateStore
+from services.s06_execution.broker_base import Broker
 from services.s06_execution.optimal_execution import MarketImpactModel
+
+_logger = get_logger("s06_execution.paper_trader")
 
 _rng = secrets.SystemRandom()
 
@@ -28,17 +33,98 @@ _COMMISSION_RATE = Decimal("0.001")
 _LIQUIDITY_MULTIPLIER = 10
 
 
-class PaperTrader:
+_CRYPTO_SUFFIXES = ("USDT", "BUSD", "BTC", "ETH", "USDC")
+
+
+class PaperTrader(Broker):
     """Simulate order execution with realistic market microstructure effects.
 
     Slippage is modelled using the Bouchaud et al. (2018) square-root impact law
     for large orders, and the Kyle (1985) linear model for small orders.
     Latency is sampled uniformly from ``[5 ms, 50 ms]`` to mimic network delays.
+
+    Implements the :class:`~.broker_base.Broker` ABC so that
+    :class:`~.service.ExecutionService` can route orders uniformly.
     """
 
-    def __init__(self) -> None:
-        """Initialise with the market impact model."""
+    def __init__(self, state: StateStore | None = None) -> None:
+        """Initialise with the market impact model.
+
+        Args:
+            state: Optional :class:`~core.state.StateStore` for fetching
+                latest ticks in :meth:`place_order`. When ``None``,
+                :meth:`place_order` builds a synthetic tick from the order.
+        """
+        self._state = state
         self._impact_model = MarketImpactModel()
+
+    # ── Broker ABC interface ─────────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        """No-op — paper trading has no external connection."""
+
+    async def disconnect(self) -> None:
+        """No-op — paper trading has no external connection."""
+
+    @property
+    def is_connected(self) -> bool:
+        """Always ``True`` for paper trading."""
+        return True
+
+    async def place_order(self, order: ApprovedOrder) -> ExecutedOrder | None:
+        """Execute a paper order, returning the simulated fill immediately.
+
+        Fetches the latest tick from Redis when *state* was provided at
+        construction; otherwise synthesises a minimal tick from the order.
+
+        Args:
+            order: Risk-approved order.
+
+        Returns:
+            Simulated :class:`~core.models.order.ExecutedOrder`.
+        """
+        tick = await self._get_or_build_tick(order)
+        return await self.execute(order, tick)
+
+    async def cancel_order(self, order_id: str) -> bool:
+        """No-op — paper fills are instantaneous.
+
+        Returns:
+            ``True`` unconditionally.
+        """
+        return True
+
+    # ── Tick helper ──────────────────────────────────────────────────────────
+
+    async def _get_or_build_tick(self, order: ApprovedOrder) -> NormalizedTick:
+        """Return the latest cached tick or synthesise a minimal one.
+
+        Args:
+            order: Approved order (used to derive entry price / volume).
+
+        Returns:
+            A :class:`~core.models.tick.NormalizedTick` suitable for execution.
+        """
+        symbol = order.symbol
+        if self._state is not None:
+            raw = await self._state.get(f"tick:{symbol}")
+            if raw is not None:
+                try:
+                    return NormalizedTick.model_validate(raw)
+                except Exception as exc:
+                    _logger.debug("tick_parse_failed", error=str(exc))
+
+        is_crypto = any(symbol.endswith(s) for s in _CRYPTO_SUFFIXES)
+        entry = order.candidate.entry
+        size = order.adjusted_size
+        return NormalizedTick(
+            symbol=symbol,
+            market=Market.CRYPTO if is_crypto else Market.EQUITY,
+            timestamp_ms=int(time.time() * 1000),
+            price=entry,
+            volume=size * Decimal("100"),
+            spread_bps=Decimal("5"),
+        )
 
     def compute_slippage(
         self,

--- a/services/s06_execution/paper_trader.py
+++ b/services/s06_execution/paper_trader.py
@@ -123,7 +123,7 @@ class PaperTrader(Broker):
             timestamp_ms=int(time.time() * 1000),
             price=entry,
             volume=size * Decimal("100"),
-            spread_bps=Decimal("5"),
+            spread_bps=_DEFAULT_SPREAD_BPS,
         )
 
     def compute_slippage(

--- a/services/s06_execution/service.py
+++ b/services/s06_execution/service.py
@@ -1,50 +1,31 @@
 """S06 Execution service for APEX Trading System.
 
 Subscribes to ``order.approved`` messages and routes each order to the
-appropriate execution back-end (paper, Alpaca equity, or Binance crypto).
+appropriate execution back-end via :class:`~.broker_factory.BrokerFactory`.
 Maintains live position state in Redis and handles order timeouts.
 """
 
 from __future__ import annotations
 
 import asyncio
-import time
-from decimal import Decimal
 from typing import Any
 
 from core.base_service import BaseService
 from core.config import TradingMode, get_settings
 from core.models.order import ApprovedOrder, ExecutedOrder
-from core.models.tick import Market, NormalizedTick
-from services.s06_execution.broker_alpaca import AlpacaBroker
-from services.s06_execution.broker_binance import BinanceBroker
+from services.s06_execution.broker_base import Broker
+from services.s06_execution.broker_factory import BrokerFactory
 from services.s06_execution.order_manager import OrderManager
-from services.s06_execution.paper_trader import PaperTrader
 
 _APPROVED_TOPIC = "order.approved"
 _FILLED_TOPIC = "order.filled"
 _TIMEOUT_CHECK_INTERVAL_S: int = 15
 
-# Crypto symbols share a common suffix pattern.
-_CRYPTO_SUFFIXES = ("USDT", "BUSD", "BTC", "ETH", "USDC")
-
-
-def _is_crypto_symbol(symbol: str) -> bool:
-    """Return ``True`` if the symbol appears to be a crypto pair.
-
-    Args:
-        symbol: Uppercase trading symbol.
-
-    Returns:
-        ``True`` for crypto symbols.
-    """
-    return any(symbol.endswith(s) for s in _CRYPTO_SUFFIXES)
-
 
 class ExecutionService(BaseService):
     """Routes approved orders to the correct execution back-end.
 
-    Routing logic:
+    Routing is delegated to :class:`~.broker_factory.BrokerFactory`:
 
     - ``TradingMode.PAPER`` → :class:`~.paper_trader.PaperTrader`
     - ``TradingMode.LIVE`` + equity → :class:`~.broker_alpaca.AlpacaBroker`
@@ -67,27 +48,14 @@ class ExecutionService(BaseService):
         super().__init__(self.service_id)
         settings = get_settings()
 
-        self._paper = PaperTrader()
         self._order_manager = OrderManager(self.state)
+        self._broker_factory = BrokerFactory(settings, self.state)
 
-        self._alpaca: AlpacaBroker | None = None
-        self._binance: BinanceBroker | None = None
-
+        # Eagerly create live brokers so they're ready for connect_all().
         if settings.trading_mode == TradingMode.LIVE:
-            self._alpaca = AlpacaBroker(
-                api_key=settings.alpaca_api_key.get_secret_value(),
-                secret_key=settings.alpaca_api_secret.get_secret_value(),
-                base_url=settings.alpaca_base_url,
-                paper=False,
-            )
-            self._binance = BinanceBroker(
-                api_key=settings.binance_api_key.get_secret_value(),
-                secret_key=settings.binance_secret_key.get_secret_value(),
-                base_url=settings.binance_rest_url,
-                testnet=False,
-            )
-
-        # PUB socket is created in BaseService.start() with bind=False.
+            # Trigger lazy creation of live brokers.
+            self._broker_factory.for_symbol("AAPL")  # equity → AlpacaBroker
+            self._broker_factory.for_symbol("BTCUSDT")  # crypto → BinanceBroker
 
     # ── BaseService interface ─────────────────────────────────────────────────
 
@@ -115,10 +83,7 @@ class ExecutionService(BaseService):
         settings = get_settings()
 
         if settings.trading_mode == TradingMode.LIVE:
-            if self._alpaca is not None:
-                await self._alpaca.connect()
-            if self._binance is not None:
-                await self._binance.connect()
+            await self._broker_factory.connect_all()
 
         timeout_task = asyncio.create_task(self._timeout_loop())
         try:
@@ -127,10 +92,7 @@ class ExecutionService(BaseService):
             self.logger.info("ExecutionService subscribe loop cancelled")
             timeout_task.cancel()
             if settings.trading_mode == TradingMode.LIVE:
-                if self._alpaca is not None:
-                    await self._alpaca.disconnect()
-                if self._binance is not None:
-                    await self._binance.disconnect()
+                await self._broker_factory.disconnect_all()
             raise
 
     # ── Execution routing ─────────────────────────────────────────────────────
@@ -141,31 +103,13 @@ class ExecutionService(BaseService):
         Args:
             approved: The risk-approved order to execute.
         """
-        settings = get_settings()
         symbol = approved.symbol
-        is_crypto = _is_crypto_symbol(symbol)
 
-        broker_order_id = await self._order_manager.submit(approved)
+        await self._order_manager.submit(approved)
 
         try:
-            executed: ExecutedOrder | None = None
-
-            if settings.trading_mode == TradingMode.PAPER:
-                # Build a minimal synthetic tick for liquidity checks.
-                synthetic_tick = await self._get_or_build_tick(symbol, approved, is_crypto)
-                executed = await self._paper.execute(approved, synthetic_tick)
-
-            elif settings.trading_mode == TradingMode.LIVE:
-                if is_crypto and self._binance is not None:
-                    await self._live_execute_binance(approved, broker_order_id)
-                elif not is_crypto and self._alpaca is not None:
-                    await self._live_execute_alpaca(approved, broker_order_id)
-                else:
-                    raise RuntimeError(
-                        f"No live broker available for {'crypto' if is_crypto else 'equity'} "
-                        f"symbol {symbol}"
-                    )
-                return  # Live path handles its own confirmation separately.
+            broker: Broker = self._broker_factory.for_symbol(symbol)
+            executed: ExecutedOrder | None = await broker.place_order(approved)
 
             if executed is not None:
                 await self._on_filled(executed)
@@ -179,61 +123,6 @@ class ExecutionService(BaseService):
                 error=str(exc),
                 exc_info=exc,
             )
-
-    async def _live_execute_alpaca(
-        self,
-        approved: ApprovedOrder,
-        broker_order_id: str,
-    ) -> None:
-        """Place a live equity order via Alpaca.
-
-        Args:
-            approved:        The approved order.
-            broker_order_id: Internal broker order ID (for Redis tracking).
-        """
-        assert self._alpaca is not None  # guarded by caller
-        candidate = approved.candidate
-        side = "buy" if candidate.direction.value == "long" else "sell"
-        resp = await self._alpaca.place_order(
-            symbol=candidate.symbol,
-            qty=float(approved.adjusted_size),
-            side=side,
-            order_type="limit",
-            limit_price=float(candidate.entry),
-            stop_price=float(candidate.stop_loss),
-        )
-        self.logger.info(
-            "Alpaca order placed",
-            order_id=candidate.order_id,
-            alpaca_id=resp.get("id"),
-        )
-
-    async def _live_execute_binance(
-        self,
-        approved: ApprovedOrder,
-        broker_order_id: str,
-    ) -> None:
-        """Place a live crypto order via Binance.
-
-        Args:
-            approved:        The approved order.
-            broker_order_id: Internal broker order ID (for Redis tracking).
-        """
-        assert self._binance is not None  # guarded by caller
-        candidate = approved.candidate
-        side = "BUY" if candidate.direction.value == "long" else "SELL"
-        resp = await self._binance.place_order(
-            symbol=candidate.symbol,
-            side=side,
-            order_type="LIMIT",
-            quantity=float(approved.adjusted_size),
-            price=float(candidate.entry),
-        )
-        self.logger.info(
-            "Binance order placed",
-            order_id=candidate.order_id,
-            binance_id=resp.get("orderId"),
-        )
 
     # ── Post-fill actions ─────────────────────────────────────────────────────
 
@@ -296,43 +185,6 @@ class ExecutionService(BaseService):
                     error=str(exc),
                     exc_info=exc,
                 )
-
-    # ── Helpers ───────────────────────────────────────────────────────────────
-
-    async def _get_or_build_tick(
-        self,
-        symbol: str,
-        approved: ApprovedOrder,
-        is_crypto: bool,
-    ) -> NormalizedTick:
-        """Return the latest cached tick or synthesise a minimal one.
-
-        Args:
-            symbol:    Trading symbol.
-            approved:  Approved order (used to derive entry price / volume).
-            is_crypto: ``True`` for crypto symbols.
-
-        Returns:
-            A :class:`~core.models.tick.NormalizedTick` suitable for paper execution.
-        """
-        raw = await self.state.get(f"tick:{symbol}")
-        if raw is not None:
-            try:
-                return NormalizedTick.model_validate(raw)
-            except Exception as exc:
-                self.logger.debug("tick_parse_failed", error=str(exc))
-
-        # Synthesise a tick with generous volume so liquidity checks pass.
-        entry = approved.candidate.entry
-        size = approved.adjusted_size
-        return NormalizedTick(
-            symbol=symbol,
-            market=Market.CRYPTO if is_crypto else Market.EQUITY,
-            timestamp_ms=int(time.time() * 1000),
-            price=entry,
-            volume=size * Decimal("100"),
-            spread_bps=Decimal("5"),
-        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/s02/test_signal_pipeline.py
+++ b/tests/unit/s02/test_signal_pipeline.py
@@ -50,8 +50,6 @@ def _make_pipeline() -> SignalPipeline:
         tech_store={},
         vpin_store={},
         adv_counter={},
-        prev_ema_8={},
-        prev_ema_21={},
         mtf=MTFAligner(),
         scorer=SignalScorer(min_components=2, min_strength=0.20),
         state=state,

--- a/tests/unit/s02/test_signal_pipeline.py
+++ b/tests/unit/s02/test_signal_pipeline.py
@@ -1,0 +1,253 @@
+"""Unit tests for SignalPipeline — each step testable in isolation.
+
+Tests verify that the pipeline decomposes _process_tick correctly:
+each step reads/writes the expected PipelineState fields without
+requiring the full service to be stood up.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.models.tick import Market, NormalizedTick, TradeSide
+from services.s02_signal_engine.microstructure import MicrostructureAnalyzer
+from services.s02_signal_engine.mtf_aligner import MTFAligner
+from services.s02_signal_engine.pipeline import PipelineState, SignalPipeline
+from services.s02_signal_engine.signal_scorer import SignalScorer
+from services.s02_signal_engine.technical import TechnicalAnalyzer
+from services.s02_signal_engine.vpin import VPINCalculator
+
+
+def _make_tick(
+    symbol: str = "BTCUSDT",
+    price: str = "50000",
+    volume: str = "10",
+    timestamp_ms: int = 1_000_000,
+) -> NormalizedTick:
+    return NormalizedTick(
+        symbol=symbol,
+        market=Market.CRYPTO,
+        timestamp_ms=timestamp_ms,
+        price=Decimal(price),
+        volume=Decimal(volume),
+        side=TradeSide.BUY,
+        bid=Decimal(price) * Decimal("0.9999"),
+        ask=Decimal(price) * Decimal("1.0001"),
+        spread_bps=Decimal("5"),
+    )
+
+
+def _make_pipeline() -> SignalPipeline:
+    """Create a pipeline with empty stores and a mock state."""
+    state = MagicMock()
+    state.get = AsyncMock(return_value=None)
+    state.set = AsyncMock()
+    return SignalPipeline(
+        micro_store={},
+        tech_store={},
+        vpin_store={},
+        adv_counter={},
+        prev_ema_8={},
+        prev_ema_21={},
+        mtf=MTFAligner(),
+        scorer=SignalScorer(min_components=2, min_strength=0.20),
+        state=state,
+    )
+
+
+class TestPipelineState:
+    def test_symbol_set_from_tick(self) -> None:
+        tick = _make_tick(symbol="ETHUSDT")
+        ps = PipelineState(tick=tick)
+        assert ps.symbol == "ETHUSDT"
+
+    def test_default_values(self) -> None:
+        ps = PipelineState(tick=_make_tick())
+        assert ps.vpin_blocked is False
+        assert ps.signal is None
+        assert ps.direction is None
+        assert ps.components == []
+
+
+class TestEnsureInitialized:
+    def test_creates_analyzers_on_first_tick(self) -> None:
+        pipeline = _make_pipeline()
+        ps = PipelineState(tick=_make_tick())
+        pipeline.ensure_initialized(ps)
+        assert ps.micro is not None
+        assert ps.tech is not None
+        assert isinstance(ps.micro, MicrostructureAnalyzer)
+        assert isinstance(ps.tech, TechnicalAnalyzer)
+
+    def test_reuses_analyzers_on_second_tick(self) -> None:
+        pipeline = _make_pipeline()
+        ps1 = PipelineState(tick=_make_tick())
+        pipeline.ensure_initialized(ps1)
+        micro_ref = ps1.micro
+
+        ps2 = PipelineState(tick=_make_tick(timestamp_ms=2_000_000))
+        pipeline.ensure_initialized(ps2)
+        assert ps2.micro is micro_ref  # same instance
+
+    def test_creates_vpin_calculator(self) -> None:
+        pipeline = _make_pipeline()
+        ps = PipelineState(tick=_make_tick())
+        pipeline.ensure_initialized(ps)
+        assert "BTCUSDT" in pipeline._vpin_store
+        assert isinstance(pipeline._vpin_store["BTCUSDT"], VPINCalculator)
+
+
+class TestRefreshVpin:
+    @pytest.mark.asyncio
+    async def test_normal_toxicity_does_not_block(self) -> None:
+        pipeline = _make_pipeline()
+        ps = PipelineState(tick=_make_tick())
+        pipeline.ensure_initialized(ps)
+        await pipeline.refresh_vpin(ps)
+        assert ps.vpin_blocked is False
+
+    @pytest.mark.asyncio
+    async def test_state_set_called_with_vpin_data(self) -> None:
+        pipeline = _make_pipeline()
+        ps = PipelineState(tick=_make_tick())
+        pipeline.ensure_initialized(ps)
+        await pipeline.refresh_vpin(ps)
+        pipeline._state.set.assert_called_once()  # type: ignore[union-attr]
+        call_args = pipeline._state.set.call_args  # type: ignore[union-attr]
+        assert call_args[0][0] == "vpin:BTCUSDT"
+
+
+class TestComputeIndicators:
+    def test_sets_ofi_and_ema_values(self) -> None:
+        pipeline = _make_pipeline()
+        # Feed enough ticks for analyzers to produce values.
+        ticks = [_make_tick(timestamp_ms=1_000_000 + i * 1000) for i in range(5)]
+        for tick in ticks:
+            ps = PipelineState(tick=tick)
+            pipeline.ensure_initialized(ps)
+        # Compute indicators on the last state
+        pipeline.compute_indicators(ps)
+        # OFI should be a float (may be 0.0 for identical ticks)
+        assert isinstance(ps.ofi_val, float)
+
+
+class TestBuildComponents:
+    def test_builds_five_components(self) -> None:
+        pipeline = _make_pipeline()
+        ticks = [_make_tick(timestamp_ms=1_000_000 + i * 1000) for i in range(5)]
+        for tick in ticks:
+            ps = PipelineState(tick=tick)
+            pipeline.ensure_initialized(ps)
+        pipeline.compute_indicators(ps)
+        pipeline.build_components(ps)
+        assert len(ps.components) == 5
+        names = {c.name for c in ps.components}
+        assert names == {"microstructure", "bollinger", "ema_mtf", "rsi_divergence", "vwap"}
+
+
+class TestComputePriceLevels:
+    def test_long_stop_below_entry(self) -> None:
+        pipeline = _make_pipeline()
+        tick = _make_tick(price="50000")
+        ps = PipelineState(tick=tick)
+        pipeline.ensure_initialized(ps)
+        pipeline.compute_indicators(ps)
+        # Force direction for testing
+        from core.models.signal import Direction
+
+        ps.direction = Direction.LONG
+        pipeline.compute_price_levels(ps)
+        assert ps.stop_loss < tick.price
+        assert all(tp > tick.price for tp in ps.take_profit)
+
+    def test_short_stop_above_entry(self) -> None:
+        pipeline = _make_pipeline()
+        tick = _make_tick(price="50000")
+        ps = PipelineState(tick=tick)
+        pipeline.ensure_initialized(ps)
+        pipeline.compute_indicators(ps)
+        from core.models.signal import Direction
+
+        ps.direction = Direction.SHORT
+        pipeline.compute_price_levels(ps)
+        assert ps.stop_loss > tick.price
+        assert all(tp < tick.price for tp in ps.take_profit)
+
+    def test_stop_loss_never_non_positive(self) -> None:
+        pipeline = _make_pipeline()
+        tick = _make_tick(price="0.001")
+        ps = PipelineState(tick=tick)
+        pipeline.ensure_initialized(ps)
+        pipeline.compute_indicators(ps)
+        from core.models.signal import Direction
+
+        ps.direction = Direction.SHORT
+        pipeline.compute_price_levels(ps)
+        assert ps.stop_loss > Decimal("0")
+
+
+class TestBuildMtfContext:
+    def test_builds_features_and_context(self) -> None:
+        pipeline = _make_pipeline()
+        tick = _make_tick()
+        ps = PipelineState(tick=tick)
+        pipeline.ensure_initialized(ps)
+        pipeline.compute_indicators(ps)
+        from core.models.signal import Direction
+
+        ps.direction = Direction.LONG
+        ps.final_strength = 0.5
+        ps.triggers = ["microstructure", "bollinger"]
+        pipeline.build_mtf_context(ps)
+        assert ps.mtf_ctx is not None
+        assert ps.features is not None
+        assert ps.confidence > 0.0
+
+
+class TestConstructSignal:
+    def test_constructs_valid_signal(self) -> None:
+        pipeline = _make_pipeline()
+        tick = _make_tick()
+        ps = PipelineState(tick=tick)
+        pipeline.ensure_initialized(ps)
+        pipeline.compute_indicators(ps)
+        from core.models.signal import Direction
+
+        ps.direction = Direction.LONG
+        ps.final_strength = 0.5
+        ps.triggers = ["microstructure", "bollinger"]
+        pipeline.compute_price_levels(ps)
+        pipeline.build_mtf_context(ps)
+        pipeline.construct_signal(ps)
+        assert ps.signal is not None
+        assert ps.signal.symbol == "BTCUSDT"
+        assert ps.signal.direction == Direction.LONG
+
+    def test_invalid_signal_sets_none(self) -> None:
+        pipeline = _make_pipeline()
+        tick = _make_tick()
+        ps = PipelineState(tick=tick)
+        pipeline.ensure_initialized(ps)
+        pipeline.compute_indicators(ps)
+        from core.models.signal import Direction
+
+        ps.direction = Direction.LONG
+        ps.strength = 999.0  # invalid: out of [-1, 1]
+        ps.confidence = 999.0  # invalid
+        ps.stop_loss = Decimal("0")  # invalid
+        pipeline.construct_signal(ps)
+        # Signal construction failed, signal stays None
+        assert ps.signal is None
+
+
+class TestFullPipeline:
+    @pytest.mark.asyncio
+    async def test_run_returns_none_for_single_tick(self) -> None:
+        """A single tick cannot produce enough triggers for a signal."""
+        pipeline = _make_pipeline()
+        tick = _make_tick()
+        result = await pipeline.run(tick)
+        assert result is None  # Not enough data for confluence

--- a/tests/unit/s06/test_broker_base.py
+++ b/tests/unit/s06/test_broker_base.py
@@ -1,0 +1,152 @@
+"""Tests for Broker ABC, concrete broker conformance, and BrokerFactory routing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.s06_execution.broker_alpaca import AlpacaBroker
+from services.s06_execution.broker_base import Broker, BrokerConnectionError, BrokerRejectedError
+from services.s06_execution.broker_binance import BinanceBroker
+from services.s06_execution.paper_trader import PaperTrader
+
+# ── ABC contract tests ───────────────────────────────────────────────────────
+
+
+class TestBrokerABC:
+    def test_broker_abc_cannot_be_instantiated(self) -> None:
+        with pytest.raises(TypeError):
+            Broker()  # type: ignore[abstract]
+
+    def test_all_concrete_brokers_implement_abc(self) -> None:
+        for broker_cls in [AlpacaBroker, BinanceBroker, PaperTrader]:
+            assert issubclass(broker_cls, Broker)
+
+    def test_broker_connection_error_is_runtime_error(self) -> None:
+        assert issubclass(BrokerConnectionError, RuntimeError)
+
+    def test_broker_rejected_error_is_runtime_error(self) -> None:
+        assert issubclass(BrokerRejectedError, RuntimeError)
+
+
+# ── is_connected property tests ──────────────────────────────────────────────
+
+
+class TestIsConnected:
+    def test_alpaca_not_connected_initially(self) -> None:
+        broker = AlpacaBroker(api_key="k", secret_key="s")
+        assert broker.is_connected is False
+
+    def test_binance_not_connected_initially(self) -> None:
+        broker = BinanceBroker(api_key="k", secret_key="s", base_url="http://localhost")
+        assert broker.is_connected is False
+
+    def test_paper_always_connected(self) -> None:
+        trader = PaperTrader()
+        assert trader.is_connected is True
+
+
+# ── PaperTrader Broker ABC compliance ────────────────────────────────────────
+
+
+class TestPaperTraderBrokerInterface:
+    @pytest.mark.asyncio
+    async def test_connect_is_noop(self) -> None:
+        trader = PaperTrader()
+        await trader.connect()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_disconnect_is_noop(self) -> None:
+        trader = PaperTrader()
+        await trader.disconnect()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_cancel_order_returns_true(self) -> None:
+        trader = PaperTrader()
+        assert await trader.cancel_order("any-id") is True
+
+
+# ── BrokerFactory tests ──────────────────────────────────────────────────────
+
+
+class TestBrokerFactory:
+    @pytest.fixture
+    def mock_settings(self) -> MagicMock:
+        settings = MagicMock()
+        settings.trading_mode = MagicMock()
+        settings.alpaca_api_key.get_secret_value.return_value = "ak"
+        settings.alpaca_api_secret.get_secret_value.return_value = "as"
+        settings.alpaca_base_url = "http://localhost"
+        settings.binance_api_key.get_secret_value.return_value = "bk"
+        settings.binance_secret_key.get_secret_value.return_value = "bs"
+        settings.binance_rest_url = "http://localhost"
+        return settings
+
+    def test_paper_mode_returns_paper_trader(self, mock_settings: MagicMock) -> None:
+        from core.config import TradingMode
+        from core.state import StateStore
+
+        mock_settings.trading_mode = TradingMode.PAPER
+        state = MagicMock(spec=StateStore)
+
+        from services.s06_execution.broker_factory import BrokerFactory
+
+        factory = BrokerFactory(mock_settings, state)
+        broker = factory.for_symbol("BTCUSDT")
+        assert isinstance(broker, PaperTrader)
+
+    def test_paper_mode_for_equity_returns_paper_trader(self, mock_settings: MagicMock) -> None:
+        from core.config import TradingMode
+        from core.state import StateStore
+
+        mock_settings.trading_mode = TradingMode.PAPER
+        state = MagicMock(spec=StateStore)
+
+        from services.s06_execution.broker_factory import BrokerFactory
+
+        factory = BrokerFactory(mock_settings, state)
+        broker = factory.for_symbol("AAPL")
+        assert isinstance(broker, PaperTrader)
+
+    def test_live_crypto_returns_binance(self, mock_settings: MagicMock) -> None:
+        from core.config import TradingMode
+        from core.state import StateStore
+
+        mock_settings.trading_mode = TradingMode.LIVE
+        state = MagicMock(spec=StateStore)
+
+        from services.s06_execution.broker_factory import BrokerFactory
+
+        factory = BrokerFactory(mock_settings, state)
+        broker = factory.for_symbol("BTCUSDT")
+        assert isinstance(broker, BinanceBroker)
+
+    def test_live_equity_returns_alpaca(self, mock_settings: MagicMock) -> None:
+        from core.config import TradingMode
+        from core.state import StateStore
+
+        mock_settings.trading_mode = TradingMode.LIVE
+        state = MagicMock(spec=StateStore)
+
+        from services.s06_execution.broker_factory import BrokerFactory
+
+        factory = BrokerFactory(mock_settings, state)
+        broker = factory.for_symbol("AAPL")
+        assert isinstance(broker, AlpacaBroker)
+
+    def test_factory_returns_same_instance_on_repeated_calls(
+        self, mock_settings: MagicMock
+    ) -> None:
+        from core.config import TradingMode
+        from core.state import StateStore
+
+        mock_settings.trading_mode = TradingMode.LIVE
+        state = MagicMock(spec=StateStore)
+
+        from services.s06_execution.broker_factory import BrokerFactory
+
+        factory = BrokerFactory(mock_settings, state)
+        b1 = factory.for_symbol("AAPL")
+        b2 = factory.for_symbol("MSFT")
+        assert b1 is b2  # same AlpacaBroker singleton


### PR DESCRIPTION
Closes #72 #73

## Summary

Sprint 5 of post-audit cleanup. Two coordinated SOLID heavy refactors.
Separate commits for granular review and rollback.

## Changes

### #72 — S06 Broker ABC (commit 1)
- New `Broker` ABC with `connect/disconnect/place_order(ApprovedOrder)->ExecutedOrder|None/cancel_order/is_connected`
- `BrokerConnectionError` + `BrokerRejectedError` exceptions
- `AlpacaBroker`, `BinanceBroker`, `PaperTrader` all inherit from `Broker`
- Raw venue methods renamed to `_submit_raw_order()` (preserved for direct access)
- New `BrokerFactory` for symbol/mode-based routing (lazy singletons)
- `ExecutionService._execute()` reduced from 35 lines + 4 branches to 5 lines
- Adding a new broker = 1 new file + 1 registry entry

### #73 — S02 SignalPipeline (commit 2)
- `_process_tick` decomposed from ~270 lines into 7 discrete steps
- New `SignalPipeline` class + `PipelineState` dataclass
- Steps: `ensure_initialized`, `refresh_vpin`, `compute_indicators`, `build_components`, `compute_price_levels`, `build_mtf_context`, `construct_signal`
- Each step unit-testable in isolation (16 new tests)
- `SignalEngine._process_tick` now 3 lines delegating to `pipeline.run()`

## Zero behavior change
Both refactors preserve existing flow exactly. All existing tests pass unchanged.

## Quality gates
- [x] ruff check + format clean
- [x] mypy --strict (324 files, 0 errors)
- [x] 1259 unit tests passing (+31 new: 15 broker ABC/factory + 16 pipeline steps)
- [x] Coverage 79.68% (>= 75% gate)
- [x] Integration tests: 21 passed (7 TimescaleDB errors pre-existing, Docker-dependent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)