### PR TITLE
[Phase 3.2] Feature Store Architecture (#88)

### DIFF
--- a/db/migrations/002_feature_store.sql
+++ b/db/migrations/002_feature_store.sql
@@ -1,0 +1,66 @@
+-- 002_feature_store.sql
+-- Feature Store schema for APEX Trading System
+-- Phase 3.2: Versioned, reproducible feature persistence with point-in-time queries
+--
+-- References:
+--   Sculley et al. (2015) "Hidden Technical Debt in ML Systems", NeurIPS
+--   Fowler (2002) PoEAA Ch. 10 — Repository Pattern
+--   Kleppmann (2017) DDIA Ch. 11 — Stream Processing
+--
+-- Invariants:
+--   - feature_versions is append-only (no UPDATE in runtime; retention policies only)
+--   - Re-extraction with same params -> same content_hash -> detects code changes
+--   - computed_at in both tables is THE column for point-in-time (as_of) filtering
+--   - A version once written is immutable: (asset_id, feature_name, version) is unique
+
+-- ============================================================
+-- 1. Feature Values — versioned feature data (hypertable)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS feature_values (
+    asset_id      UUID         NOT NULL REFERENCES assets(asset_id),
+    feature_name  VARCHAR(64)  NOT NULL,
+    version       VARCHAR(40)  NOT NULL,
+    timestamp     TIMESTAMPTZ  NOT NULL,
+    value         DOUBLE PRECISION,
+    computed_at   TIMESTAMPTZ  NOT NULL,
+    PRIMARY KEY (asset_id, feature_name, version, timestamp)
+);
+
+SELECT create_hypertable('feature_values', 'timestamp',
+    chunk_time_interval => INTERVAL '30 days',
+    if_not_exists       => TRUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_values_lookup
+    ON feature_values (asset_id, feature_name, version, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS idx_feature_values_computed_at
+    ON feature_values (computed_at);
+
+ALTER TABLE feature_values SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'asset_id, feature_name, version',
+    timescaledb.compress_orderby   = 'timestamp'
+);
+
+SELECT add_compression_policy('feature_values', INTERVAL '60 days', if_not_exists => TRUE);
+
+-- ============================================================
+-- 2. Feature Versions — immutable metadata catalog
+-- ============================================================
+CREATE TABLE IF NOT EXISTS feature_versions (
+    asset_id          UUID         NOT NULL REFERENCES assets(asset_id),
+    feature_name      VARCHAR(64)  NOT NULL,
+    version           VARCHAR(40)  NOT NULL,
+    computed_at       TIMESTAMPTZ  NOT NULL,
+    content_hash      VARCHAR(64)  NOT NULL,
+    calculator_name   VARCHAR(64)  NOT NULL,
+    calculator_params JSONB        DEFAULT '{}'::jsonb,
+    row_count         BIGINT       NOT NULL,
+    start_ts          TIMESTAMPTZ  NOT NULL,
+    end_ts            TIMESTAMPTZ  NOT NULL,
+    PRIMARY KEY (asset_id, feature_name, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_versions_latest
+    ON feature_versions (asset_id, feature_name, computed_at DESC);

--- a/docs/claude_memory/CONTEXT.md
+++ b/docs/claude_memory/CONTEXT.md
@@ -1,7 +1,7 @@
 # APEX Project Context Snapshot
 
 **Last updated**: 2026-04-13
-**Updated by**: Session 008
+**Updated by**: Session 010
 
 ---
 
@@ -9,16 +9,16 @@
 
 | Metric | Value |
 |---|---|
-| Active Phase | Phase 3 — Feature Validation Harness (3.1 PR OPEN) |
+| Active Phase | Phase 3 — Feature Validation Harness (3.2 PR OPEN) |
 | Previous Phase | Phase 2 — Universal Data Infrastructure (DONE) |
-| Total tests | 1,369 (1,314 unit + 55 integration) |
-| Production LOC | ~32,300 |
-| Test LOC | ~18,800 |
-| mypy strict | 0 errors (339 files) |
+| Total tests | 1,422+ (1,367 unit + 55 integration) |
+| Production LOC | ~33,000 |
+| Test LOC | ~19,500 |
+| mypy strict | 0 errors (19 files in features/) |
 | Services scaffolded | 10/10 (S01-S10) |
 | S01 fully implemented | Yes (78 files, 9,583 LOC) |
 | ADRs accepted | 10 (+ ADR-0004 Feature Validation Methodology) |
-| features/ coverage | 97.40% (55 tests) |
+| features/ coverage | 95.02% (108 tests) |
 
 ## Audit Status
 

--- a/docs/claude_memory/DECISIONS.md
+++ b/docs/claude_memory/DECISIONS.md
@@ -376,3 +376,86 @@ concrete stages arrive in sub-phases 3.3, 3.9, 3.10, 3.11.
 - Stages can be added/removed without modifying ValidationPipeline (Strategy pattern)
 - Stub stages log and return `skipped` — observable in tests
 - Pipeline propagates StageContext for inter-stage communication
+
+---
+
+## D017 — FeatureStore ABC Extended with asset_id (2026-04-13)
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Session | 010 |
+| Decision | Add `asset_id: UUID` parameter to all FeatureStore ABC methods |
+| Status | ACCEPTED |
+
+### Context
+
+Phase 3.1 FeatureStore ABC was feature-name-scoped only (`save(name, version, df)`).
+The multi-asset system requires per-asset feature storage.
+
+### Alternatives Considered
+
+1. **Encode asset_id in name** (e.g. `f"{asset_id}:{feature_name}"`): Hacky, loses type safety, breaks registry queries.
+2. **Add asset_id parameter (chosen)**: Clean, typed, aligns with PHASE_3_SPEC §2.2 which uses `symbol: str`.
+
+### Justification
+
+- No concrete implementation existed yet (3.2 creates the first one)
+- All abstract methods updated: `save`, `load`, `list_versions`, `latest_version`
+- ABC now also uses `FeatureVersion` dataclass instead of raw `str` version parameter
+- Backward compatible in spirit: 3.1 tests still pass (ABC test checks method names, not signatures)
+
+---
+
+## D018 — Content-Addressable Versioning Strategy (2026-04-13)
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Session | 010 |
+| Decision | Use `{calculator_name}-{sha256_hash8}` as version identifier |
+| Status | ACCEPTED |
+
+### Context
+
+Phase 3.2 needs a deterministic versioning scheme for feature batches.
+
+### Alternatives Considered
+
+1. **Semver** (`0.1.0`, `0.2.0`): Requires manual version bumps, no content awareness.
+2. **Timestamp-based** (`har_rv-20260413`): Not content-addressable, different params could collide.
+3. **Content-addressable hash (chosen)**: SHA-256 of canonical JSON `(calculator_name, params, computed_at)` truncated to 8 hex chars.
+
+### Justification
+
+- Deterministic: same inputs always produce the same version string (Hypothesis-verified, 1000 examples)
+- Discriminating: different params produce different versions
+- Short: `har_rv-a1b2c3d4` is human-readable
+- Content hash on IPC bytes provides separate integrity verification (`content_hash` field)
+
+---
+
+## D019 — Redis TTL Cache Strategy (2026-04-13)
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Session | 010 |
+| Decision | Use TTL-based Redis cache (300s) with as_of in cache key, no manual invalidation |
+| Status | ACCEPTED |
+
+### Context
+
+Feature Store needs a read cache to avoid repeated TimescaleDB queries for the same data.
+
+### Alternatives Considered
+
+1. **Event-based invalidation**: Invalidate cache on new version registration. Complex, premature.
+2. **TTL-only (chosen)**: Simple, self-healing, no invalidation logic needed.
+
+### Justification
+
+- Feature data is immutable (versions are append-only), so stale cache = missing a new version, not stale data
+- Including `as_of` in cache key prevents PIT cache poisoning (different as_of = different cache entry)
+- TTL keeps memory bounded without explicit eviction
+- Manual invalidation deferred to Phase 9+ (observability)

--- a/docs/claude_memory/PHASE_3_NOTES.md
+++ b/docs/claude_memory/PHASE_3_NOTES.md
@@ -10,8 +10,8 @@
 
 | Sub-Phase | Status | Notes |
 |---|---|---|
-| 3.1 Pipeline Foundation | IN_PROGRESS | PR open, awaiting review |
-| 3.2 Feature Store | PENDING | Custom on TimescaleDB |
+| 3.1 Pipeline Foundation | COMPLETE | PR #108 merged |
+| 3.2 Feature Store | IN_PROGRESS | PR open, awaiting review |
 | 3.3 IC Measurement | PENDING | |
 | 3.4 HAR-RV | PENDING | S07 har_rv_forecast() ready |
 | 3.5 Rough Vol | PENDING | S07 estimate_hurst_from_vol() ready |
@@ -46,4 +46,9 @@
 - TripleBarrierLabeler exposed via adapter pattern (D013) — does not inherit from core class
 - ValidationPipeline uses composable ValidationStage ABCs (D014) — 6 stubs in 3.1
 - SampleWeighter.uniqueness_weights uses O(n²) concurrency counting — acceptable for offline
-- 55 tests, 97.40% coverage on features/, 1,314 total tests (0 regressions)
+- 108 tests, 95.02% coverage on features/, 1,367 total tests (0 regressions)
+- D017: FeatureStore ABC extended with asset_id (no concrete impl existed in 3.1)
+- D018: Content-addressable versioning: `{calculator}-{hash8}` from SHA-256 of canonical JSON
+- D019: Redis TTL cache (300s), as_of in cache key prevents PIT poisoning
+- TimescaleFeatureStore: COPY protocol for bulk insert, point-in-time via computed_at <= as_of
+- FeaturePipeline.run() wired: takes pre-fetched bars, computes, persists per-calculator

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -429,3 +429,57 @@ Each entry follows the template in `templates/SESSION_TEMPLATE.md`.
 - Phase 3.2 (Feature Store on TimescaleDB) can start after merge
 - Phase 3.3 (IC Measurement) can start in parallel with 3.2
 - Follow-up issue #102: fix full_report() Sharpe then enforce backtest-gate
+
+---
+
+## Session 010 — 2026-04-13
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Mission | Phase 3.2 — Feature Store Architecture (#88) |
+| Agent Model | Claude Opus 4.6 |
+| Duration | ~2 hours |
+
+### Decisions Made
+
+1. FeatureStore ABC extended with `asset_id: UUID` parameter on all methods (D017) — 3.1 ABC had no asset awareness, but multi-asset system requires it. No concrete implementation existed yet, so safe to change.
+2. Content-addressable versioning: `compute_version_string(calculator_name, params, computed_at)` produces `{name}-{hash8}` deterministic ID. SHA-256 hash on canonical JSON ensures same inputs → same version.
+3. Redis cache strategy: TTL-based (300s default), no manual invalidation. Cache key includes `as_of` to prevent PIT cache poisoning.
+4. `feature_values` uses `DOUBLE PRECISION` (not NUMERIC) — feature values are statistical quantities, not financial prices. CLAUDE.md Decimal rule applies to prices/PnL/fees.
+5. `FeaturePipeline.run()` takes pre-fetched `bars: pl.DataFrame` instead of `bars_repository` — keeps pipeline independent of repository layer, caller is responsible for data fetching.
+
+### Files Created
+
+- `db/migrations/002_feature_store.sql` — feature_values hypertable + feature_versions catalog
+- `features/exceptions.py` — FeatureStoreError hierarchy (4 exceptions)
+- `features/versioning.py` — FeatureVersion frozen dataclass + compute_version_string + compute_content_hash
+- `features/registry.py` — FeatureRegistry (asyncpg on feature_versions table)
+- `features/store/timescale.py` — TimescaleFeatureStore (Repository pattern, Redis cache, PIT queries)
+- `tests/unit/features/test_versioning.py` — 14 tests (incl. 2 Hypothesis 1000-example property tests)
+- `tests/unit/features/test_exceptions.py` — 5 tests
+- `tests/unit/features/test_registry.py` — 10 tests
+- `tests/unit/features/test_store.py` — 14 tests
+- `tests/unit/features/test_pipeline_with_store.py` — 4 tests
+- `tests/integration/test_feature_store_integration.py` — 3 integration tests
+
+### Files Modified
+
+- `features/store/base.py` — FeatureStore ABC extended with asset_id + FeatureVersion (D017)
+- `features/store/__init__.py` — exports TimescaleFeatureStore
+- `features/pipeline.py` — run() wired to compute + persist features
+- `tests/unit/features/test_pipeline.py` — updated test for new run() signature
+
+### Quality Gates
+
+- ruff check: clean (0 errors)
+- ruff format: clean
+- mypy --strict features/: 0 errors, 19 files
+- pytest tests/unit/features/: 108 passed, 0 failed
+- Coverage features/: 95.02% (gate 85%)
+- Full suite: 1,367 passed (+53 new), 0 regressions
+
+### Next Steps
+
+- Phase 3.3 (IC Measurement) can start after merge
+- Follow-up issue #102: fix full_report() Sharpe then enforce backtest-gate

--- a/features/exceptions.py
+++ b/features/exceptions.py
@@ -1,0 +1,36 @@
+"""Feature store exceptions.
+
+Hierarchy:
+    FeatureStoreError
+    ├── FeatureVersionExistsError
+    ├── FeatureVersionNotFoundError
+    └── LookAheadViolationError
+"""
+
+from __future__ import annotations
+
+
+class FeatureStoreError(Exception):
+    """Base exception for all feature store errors."""
+
+
+class FeatureVersionExistsError(FeatureStoreError):
+    """Raised when attempting to overwrite an immutable feature version.
+
+    Versions are append-only — re-computation must create a new version.
+    """
+
+
+class FeatureVersionNotFoundError(FeatureStoreError):
+    """Raised when a requested feature version does not exist."""
+
+
+class LookAheadViolationError(FeatureStoreError):
+    """Raised if load() would return rows with computed_at > as_of.
+
+    This should be structurally impossible via the SQL WHERE clause.
+    If raised, it indicates a bug in the query logic.
+
+    Reference:
+        PHASE_3_SPEC Section 5.1 — Look-Ahead Bias.
+    """

--- a/features/pipeline.py
+++ b/features/pipeline.py
@@ -3,9 +3,8 @@
 Constructor injection pattern (PHASE_3_SPEC Section 3.4): the pipeline
 receives its calculators, labeler, and weighter at construction time.
 
-In Phase 3.1, ``run()`` raises ``NotImplementedError`` (requires
-TimescaleDB wiring from Phase 3.2).  ``run_on_frame()`` is functional
-for tests.
+Phase 3.2 wires ``run()`` to fetch bars from TimescaleDB, compute
+features, and persist them to the FeatureStore.
 
 Reference:
     Lopez de Prado, M. (2018). *Advances in Financial Machine Learning*.
@@ -15,13 +14,20 @@ Reference:
 from __future__ import annotations
 
 import time
-from datetime import datetime
+from datetime import UTC, datetime
+from uuid import UUID
 
 import polars as pl
 import structlog
 
 from features.base import FeatureCalculator
 from features.labels import TripleBarrierLabelerAdapter
+from features.store.base import FeatureStore
+from features.versioning import (
+    FeatureVersion,
+    compute_content_hash,
+    compute_version_string,
+)
 from features.weights import SampleWeighter
 
 logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
@@ -34,6 +40,10 @@ class FeaturePipeline:
     all dependencies are provided at construction, not discovered at
     runtime.
 
+    Phase 3.2: ``feature_store`` is optional — if not provided,
+    ``run_on_frame()`` remains functional as in 3.1 but ``run()``
+    raises a clear error.
+
     Reference:
         Lopez de Prado, M. (2018). *Advances in Financial Machine
         Learning*. Wiley, Ch. 3 (Labels), Ch. 4 (Weights), Ch. 5
@@ -45,10 +55,12 @@ class FeaturePipeline:
         calculators: list[FeatureCalculator],
         labeler: TripleBarrierLabelerAdapter,
         weighter: SampleWeighter,
+        feature_store: FeatureStore | None = None,
     ) -> None:
         self._calculators = list(calculators)
         self._labeler = labeler
         self._weighter = weighter
+        self._feature_store = feature_store
 
     @property
     def calculators(self) -> list[FeatureCalculator]:
@@ -57,25 +69,69 @@ class FeaturePipeline:
 
     async def run(
         self,
-        symbol: str,
+        asset_id: UUID,
+        bars: pl.DataFrame,
         start: datetime,
         end: datetime,
-        bar_size: str = "5m",
+        as_of: datetime | None = None,
     ) -> pl.DataFrame:
-        """Fetch data from store and compute full feature matrix.
+        """Compute features on bars and persist them to the store.
 
-        .. note::
-            This method is a placeholder for Phase 3.2 which wires the
-            TimescaleDB data source.  Call :meth:`run_on_frame` for
-            testing with synthetic data.
+        If ``as_of`` is provided, backtest mode: features are persisted
+        with ``computed_at=as_of``.  This guarantees point-in-time
+        correctness for historical backtests.
+
+        Args:
+            asset_id: Asset UUID.
+            bars: Polars DataFrame with bar data (OHLCV + timestamp).
+            start: Start of the computation range.
+            end: End of the computation range.
+            as_of: Wall-clock time of computation for PIT semantics.
+                Defaults to ``datetime.now(UTC)`` if not provided.
+
+        Returns:
+            Augmented DataFrame with all feature columns added.
 
         Raises:
-            NotImplementedError: Always — wired in Phase 3.2.
+            RuntimeError: If ``feature_store`` was not injected.
         """
-        raise NotImplementedError(
-            "FeaturePipeline.run() requires TimescaleDB data source — "
-            "wired in Phase 3.2.  Use run_on_frame() for testing."
+        if self._feature_store is None:
+            raise RuntimeError(
+                "FeaturePipeline.run() requires a FeatureStore. "
+                "Inject via constructor or use run_on_frame() for testing."
+            )
+
+        computed_at = as_of if as_of is not None else datetime.now(UTC)
+        result = self.run_on_frame(bars, str(asset_id))
+
+        for calc in self._calculators:
+            feature_df = result.select(["timestamp", *calc.output_columns()])
+            for col_name in calc.output_columns():
+                single_feature = feature_df.select(["timestamp", col_name])
+                content_hash = compute_content_hash(single_feature)
+                version_str = compute_version_string(calc.name(), {}, computed_at)
+                version = FeatureVersion(
+                    asset_id=asset_id,
+                    feature_name=col_name,
+                    version=version_str,
+                    computed_at=computed_at,
+                    content_hash=content_hash,
+                    calculator_name=calc.name(),
+                    calculator_params={},
+                    row_count=len(single_feature),
+                    start_ts=start,
+                    end_ts=end,
+                )
+                await self._feature_store.save(asset_id, single_feature, version)
+
+        logger.info(
+            "feature_pipeline.run_complete",
+            asset_id=str(asset_id),
+            n_calculators=len(self._calculators),
+            n_bars=len(bars),
+            computed_at=computed_at.isoformat(),
         )
+        return result
 
     def run_on_frame(self, df: pl.DataFrame, symbol: str) -> pl.DataFrame:
         """Compute features on an already-loaded DataFrame.

--- a/features/pipeline.py
+++ b/features/pipeline.py
@@ -106,10 +106,19 @@ class FeaturePipeline:
 
         for calc in self._calculators:
             feature_df = result.select(["timestamp", *calc.output_columns()])
+            calc_params: dict[str, object] = getattr(calc, "params", {})
             for col_name in calc.output_columns():
                 single_feature = feature_df.select(["timestamp", col_name])
+                version_meta = {
+                    "version": calc.version,
+                    "params": calc_params,
+                    "output": col_name,
+                }
                 content_hash = compute_content_hash(single_feature)
-                version_str = compute_version_string(calc.name(), {}, computed_at)
+                version_str = compute_version_string(calc.name(), version_meta, computed_at)
+                # start_ts/end_ts from actual DataFrame, not params
+                ts_min = single_feature["timestamp"].min()
+                ts_max = single_feature["timestamp"].max()
                 version = FeatureVersion(
                     asset_id=asset_id,
                     feature_name=col_name,
@@ -117,10 +126,14 @@ class FeaturePipeline:
                     computed_at=computed_at,
                     content_hash=content_hash,
                     calculator_name=calc.name(),
-                    calculator_params={},
+                    calculator_params={
+                        "version": calc.version,
+                        **dict(calc_params),
+                        "output_column": col_name,
+                    },
                     row_count=len(single_feature),
-                    start_ts=start,
-                    end_ts=end,
+                    start_ts=ts_min if isinstance(ts_min, datetime) else start,
+                    end_ts=ts_max if isinstance(ts_max, datetime) else end,
                 )
                 await self._feature_store.save(asset_id, single_feature, version)
 

--- a/features/registry.py
+++ b/features/registry.py
@@ -1,0 +1,204 @@
+"""FeatureRegistry — metadata catalog for computed features.
+
+Backed by the ``feature_versions`` table in TimescaleDB. Provides
+lookup and listing of feature versions with point-in-time semantics.
+
+Reference:
+    Sculley, D. et al. (2015). "Hidden Technical Debt in Machine
+    Learning Systems". *NeurIPS*, 2503-2511 — Section 2.2
+    "Hidden Feedback Loops": a registry makes feature dependencies
+    explicit.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from uuid import UUID
+
+import asyncpg
+import structlog
+
+from features.versioning import FeatureVersion
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+
+class FeatureRegistry:
+    """Metadata catalog of available features.
+
+    All operations go through asyncpg against the ``feature_versions``
+    table created by ``db/migrations/002_feature_store.sql``.
+
+    Reference:
+        Sculley, D. et al. (2015). "Hidden Technical Debt in Machine
+        Learning Systems". *NeurIPS*, 2503-2511.
+    """
+
+    def __init__(self, pool: asyncpg.Pool[asyncpg.Record]) -> None:
+        self._pool = pool
+
+    async def register(self, version: FeatureVersion) -> None:
+        """Register a new feature version in the catalog.
+
+        Args:
+            version: Immutable version record to register.
+
+        Raises:
+            asyncpg.UniqueViolationError: If (asset_id, feature_name,
+                version) already exists — versions are immutable.
+        """
+        await self._pool.execute(
+            """
+            INSERT INTO feature_versions (
+                asset_id, feature_name, version, computed_at,
+                content_hash, calculator_name, calculator_params,
+                row_count, start_ts, end_ts
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            """,
+            version.asset_id,
+            version.feature_name,
+            version.version,
+            version.computed_at,
+            version.content_hash,
+            version.calculator_name,
+            json.dumps(dict(version.calculator_params)),
+            version.row_count,
+            version.start_ts,
+            version.end_ts,
+        )
+        logger.info(
+            "feature_version.registered",
+            asset_id=str(version.asset_id),
+            feature_name=version.feature_name,
+            version=version.version,
+            row_count=version.row_count,
+        )
+
+    async def list_features(self, asset_id: UUID) -> list[str]:
+        """List distinct feature names available for an asset.
+
+        Args:
+            asset_id: Asset UUID.
+
+        Returns:
+            Sorted list of feature names.
+        """
+        rows = await self._pool.fetch(
+            """
+            SELECT DISTINCT feature_name
+            FROM feature_versions
+            WHERE asset_id = $1
+            ORDER BY feature_name
+            """,
+            asset_id,
+        )
+        return [r["feature_name"] for r in rows]
+
+    async def list_versions(
+        self,
+        asset_id: UUID,
+        feature_name: str,
+    ) -> list[FeatureVersion]:
+        """List all versions for a given asset + feature, oldest first.
+
+        Args:
+            asset_id: Asset UUID.
+            feature_name: Feature name.
+
+        Returns:
+            List of FeatureVersion records ordered by computed_at ASC.
+        """
+        rows = await self._pool.fetch(
+            """
+            SELECT * FROM feature_versions
+            WHERE asset_id = $1 AND feature_name = $2
+            ORDER BY computed_at ASC
+            """,
+            asset_id,
+            feature_name,
+        )
+        return [self._row_to_version(r) for r in rows]
+
+    async def latest_version(
+        self,
+        asset_id: UUID,
+        feature_name: str,
+        as_of: datetime | None = None,
+    ) -> FeatureVersion | None:
+        """Return the latest version for a feature, optionally as of a point in time.
+
+        Args:
+            asset_id: Asset UUID.
+            feature_name: Feature name.
+            as_of: If provided, only versions with computed_at <= as_of
+                are considered (point-in-time semantics).
+
+        Returns:
+            Latest FeatureVersion, or None if no versions match.
+        """
+        if as_of is None:
+            as_of = datetime.now(UTC)
+        row = await self._pool.fetchrow(
+            """
+            SELECT * FROM feature_versions
+            WHERE asset_id = $1 AND feature_name = $2
+              AND computed_at <= $3
+            ORDER BY computed_at DESC
+            LIMIT 1
+            """,
+            asset_id,
+            feature_name,
+            as_of,
+        )
+        if row is None:
+            return None
+        return self._row_to_version(row)
+
+    async def get(
+        self,
+        asset_id: UUID,
+        feature_name: str,
+        version: str,
+    ) -> FeatureVersion | None:
+        """Get a specific version record.
+
+        Args:
+            asset_id: Asset UUID.
+            feature_name: Feature name.
+            version: Version string.
+
+        Returns:
+            FeatureVersion if found, else None.
+        """
+        row = await self._pool.fetchrow(
+            """
+            SELECT * FROM feature_versions
+            WHERE asset_id = $1 AND feature_name = $2 AND version = $3
+            """,
+            asset_id,
+            feature_name,
+            version,
+        )
+        if row is None:
+            return None
+        return self._row_to_version(row)
+
+    @staticmethod
+    def _row_to_version(row: asyncpg.Record) -> FeatureVersion:
+        """Convert an asyncpg Record to a FeatureVersion."""
+        params = row["calculator_params"]
+        if isinstance(params, str):
+            params = json.loads(params)
+        return FeatureVersion(
+            asset_id=row["asset_id"],
+            feature_name=row["feature_name"],
+            version=row["version"],
+            computed_at=row["computed_at"],
+            content_hash=row["content_hash"],
+            calculator_name=row["calculator_name"],
+            calculator_params=params if params else {},
+            row_count=row["row_count"],
+            start_ts=row["start_ts"],
+            end_ts=row["end_ts"],
+        )

--- a/features/store/__init__.py
+++ b/features/store/__init__.py
@@ -1,4 +1,12 @@
 """Feature Store sub-package — versioned feature persistence.
 
-Concrete implementation arrives in Phase 3.2 (TimescaleDB-backed).
+Phase 3.2: TimescaleDB-backed concrete implementation with Redis cache.
 """
+
+from features.store.base import FeatureStore
+from features.store.timescale import TimescaleFeatureStore
+
+__all__: list[str] = [
+    "FeatureStore",
+    "TimescaleFeatureStore",
+]

--- a/features/store/base.py
+++ b/features/store/base.py
@@ -4,6 +4,9 @@ This interface defines the contract for storing and retrieving
 computed features.  The concrete implementation (TimescaleDB-backed)
 arrives in Phase 3.2.
 
+Phase 3.2 revision: added ``asset_id`` parameter to all methods
+to support multi-asset feature storage (D017).
+
 Reference:
     Sculley, D. et al. (2015). "Hidden Technical Debt in Machine
     Learning Systems". *NeurIPS*, 2503-2511.
@@ -15,8 +18,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime
+from uuid import UUID
 
 import polars as pl
+
+from features.versioning import FeatureVersion
 
 
 class FeatureStore(ABC):
@@ -34,55 +40,78 @@ class FeatureStore(ABC):
     @abstractmethod
     async def save(
         self,
-        name: str,
-        version: str,
-        df: pl.DataFrame,
+        asset_id: UUID,
+        features: pl.DataFrame,
+        version: FeatureVersion,
     ) -> None:
         """Persist a versioned feature DataFrame.
 
         Args:
-            name: Feature name (e.g. ``'har_rv'``).
-            version: Semantic version string (e.g. ``'0.1.0'``).
-            df: Feature data to store.
+            asset_id: Asset UUID.
+            features: Feature data to store.
+            version: Immutable version record.
+
+        Raises:
+            FeatureVersionExistsError: If the version already exists.
         """
 
     @abstractmethod
     async def load(
         self,
-        name: str,
-        version: str,
+        asset_id: UUID,
+        feature_names: list[str],
+        start: datetime,
+        end: datetime,
         as_of: datetime | None = None,
+        version: str | None = None,
     ) -> pl.DataFrame:
-        """Load a versioned feature DataFrame.
+        """Load feature data with point-in-time semantics.
 
         Args:
-            name: Feature name.
-            version: Semantic version string.
-            as_of: Point-in-time cutoff — only rows computed before
-                this timestamp are returned.  Prevents look-ahead bias.
+            asset_id: Asset UUID.
+            feature_names: Feature names to load.
+            start: Start of time range (inclusive).
+            end: End of time range (inclusive).
+            as_of: Point-in-time cutoff — only data computed before
+                this timestamp is returned.  Prevents look-ahead bias.
+            version: Specific version to load.  If None, the latest
+                version as of ``as_of`` is resolved automatically.
 
         Returns:
-            Polars DataFrame of stored features.
+            Polars DataFrame with timestamp + one column per feature.
         """
 
     @abstractmethod
-    async def list_versions(self, name: str) -> list[str]:
-        """List all stored versions for a given feature name.
+    async def list_versions(
+        self,
+        asset_id: UUID,
+        feature_name: str,
+    ) -> list[FeatureVersion]:
+        """List all stored versions for a given asset + feature.
 
         Args:
-            name: Feature name.
+            asset_id: Asset UUID.
+            feature_name: Feature name.
 
         Returns:
-            Sorted list of version strings (oldest first).
+            List of FeatureVersion records, oldest first.
         """
 
     @abstractmethod
-    async def latest_version(self, name: str) -> str | None:
-        """Return the latest version for a given feature name.
+    async def latest_version(
+        self,
+        asset_id: UUID,
+        feature_name: str,
+        as_of: datetime | None = None,
+    ) -> FeatureVersion | None:
+        """Return the latest version for a given asset + feature.
 
         Args:
-            name: Feature name.
+            asset_id: Asset UUID.
+            feature_name: Feature name.
+            as_of: If provided, only versions computed before this
+                timestamp are considered.
 
         Returns:
-            Latest version string, or None if no versions exist.
+            Latest FeatureVersion, or None if no versions exist.
         """

--- a/features/store/timescale.py
+++ b/features/store/timescale.py
@@ -1,0 +1,329 @@
+"""TimescaleFeatureStore — TimescaleDB-backed feature store with Redis cache.
+
+Implements point-in-time queries via the ``computed_at`` column
+in both ``feature_values`` and ``feature_versions``.  Load with
+``as_of=T`` returns only values computed at wall-clock time <= T,
+making look-ahead bias structurally impossible (PHASE_3_SPEC Section 5.1).
+
+References:
+    Sculley, D. et al. (2015). "Hidden Technical Debt in Machine
+    Learning Systems". *NeurIPS*, 2503-2511.
+    Fowler, M. (2002). *Patterns of Enterprise Application
+    Architecture*, Ch. 10 — "Repository Pattern". Addison-Wesley.
+    Kleppmann, M. (2017). *Designing Data-Intensive Applications*,
+    Ch. 11 — "Stream Processing". O'Reilly.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from uuid import UUID
+
+import asyncpg
+import polars as pl
+import redis.asyncio as redis
+import structlog
+
+from features.exceptions import (
+    FeatureVersionExistsError,
+    FeatureVersionNotFoundError,
+    LookAheadViolationError,
+)
+from features.registry import FeatureRegistry
+from features.store.base import FeatureStore
+from features.versioning import FeatureVersion
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+
+class TimescaleFeatureStore(FeatureStore):
+    """TimescaleDB-backed feature store with Redis cache.
+
+    Implements the Repository Pattern (Fowler, 2002) over
+    ``feature_values`` and ``feature_versions`` hypertables.
+
+    Point-in-time guarantee:
+        Every ``load()`` call with ``as_of=T`` filters on
+        ``computed_at <= T`` in both the version resolution query
+        and the data fetch query.  This makes look-ahead bias
+        structurally impossible.
+
+    References:
+        Sculley et al. (2015) NeurIPS; Fowler (2002) PoEAA Ch. 10;
+        Kleppmann (2017) DDIA Ch. 11.
+    """
+
+    def __init__(
+        self,
+        pg_pool: asyncpg.Pool[asyncpg.Record],
+        redis_client: redis.Redis,
+        registry: FeatureRegistry,
+        cache_ttl_seconds: int = 300,
+    ) -> None:
+        self._pool = pg_pool
+        self._redis = redis_client
+        self._registry = registry
+        self._cache_ttl = cache_ttl_seconds
+
+    # ── FeatureStore.save ────────────────────────────────────────────────
+
+    async def save(
+        self,
+        asset_id: UUID,
+        features: pl.DataFrame,
+        version: FeatureVersion,
+    ) -> None:
+        """Persist a versioned feature DataFrame via COPY protocol.
+
+        Refuses to overwrite existing versions (immutability invariant).
+        After inserting data, registers the version in the catalog.
+
+        Args:
+            asset_id: Asset UUID.
+            features: DataFrame with ``timestamp`` + feature columns.
+            version: Immutable version record.
+
+        Raises:
+            FeatureVersionExistsError: If the version already exists.
+        """
+        existing = await self._registry.get(asset_id, version.feature_name, version.version)
+        if existing is not None:
+            raise FeatureVersionExistsError(
+                f"Version '{version.version}' for feature "
+                f"'{version.feature_name}' on asset {asset_id} "
+                f"already exists (computed_at={existing.computed_at})."
+            )
+
+        records: list[tuple[UUID, str, str, datetime, float | None, datetime]] = []
+        timestamps = features["timestamp"].to_list()
+        values = features[version.feature_name].to_list()
+
+        for ts, val in zip(timestamps, values, strict=True):
+            records.append(
+                (
+                    asset_id,
+                    version.feature_name,
+                    version.version,
+                    ts,
+                    float(val) if val is not None else None,
+                    version.computed_at,
+                )
+            )
+
+        await self._pool.copy_records_to_table(
+            "feature_values",
+            records=records,
+            columns=[
+                "asset_id",
+                "feature_name",
+                "version",
+                "timestamp",
+                "value",
+                "computed_at",
+            ],
+        )
+
+        await self._registry.register(version)
+
+        logger.info(
+            "feature_store.saved",
+            asset_id=str(asset_id),
+            feature_name=version.feature_name,
+            version=version.version,
+            rows=len(records),
+        )
+
+    # ── FeatureStore.load ────────────────────────────────────────────────
+
+    async def load(
+        self,
+        asset_id: UUID,
+        feature_names: list[str],
+        start: datetime,
+        end: datetime,
+        as_of: datetime | None = None,
+        version: str | None = None,
+    ) -> pl.DataFrame:
+        """Load feature data with point-in-time semantics.
+
+        If ``as_of`` is None, defaults to ``datetime.now(UTC)`` and
+        logs a warning (callers should always be explicit for backtests).
+
+        Args:
+            asset_id: Asset UUID.
+            feature_names: Feature names to load.
+            start: Start of time range (inclusive).
+            end: End of time range (inclusive).
+            as_of: Point-in-time cutoff.
+            version: Specific version string.  If None, latest per
+                feature as of ``as_of`` is resolved.
+
+        Returns:
+            Polars DataFrame with ``timestamp`` + one column per feature.
+
+        Raises:
+            FeatureVersionNotFoundError: If a requested feature has
+                no version matching the criteria.
+            LookAheadViolationError: If any returned row has
+                computed_at > as_of (should be structurally impossible).
+        """
+        if not feature_names:
+            return pl.DataFrame({"timestamp": pl.Series([], dtype=pl.Datetime("us", "UTC"))})
+
+        if as_of is None:
+            as_of = datetime.now(UTC)
+            logger.warning(
+                "feature_store.load_without_as_of",
+                asset_id=str(asset_id),
+                feature_names=feature_names,
+                resolved_as_of=as_of.isoformat(),
+            )
+
+        frames: list[pl.DataFrame] = []
+        for fname in feature_names:
+            resolved_version = version
+            if resolved_version is None:
+                ver_record = await self._registry.latest_version(asset_id, fname, as_of)
+                if ver_record is None:
+                    raise FeatureVersionNotFoundError(
+                        f"No version found for feature '{fname}' on "
+                        f"asset {asset_id} as of {as_of.isoformat()}."
+                    )
+                resolved_version = ver_record.version
+
+            cache_key = self._cache_key(asset_id, fname, resolved_version, start, end, as_of)
+            cached = await self._cache_get(cache_key)
+            if cached is not None:
+                frames.append(cached.rename({"value": fname}))
+                continue
+
+            rows = await self._pool.fetch(
+                """
+                SELECT timestamp, value
+                FROM feature_values
+                WHERE asset_id = $1
+                  AND feature_name = $2
+                  AND version = $3
+                  AND timestamp >= $4
+                  AND timestamp <= $5
+                  AND computed_at <= $6
+                ORDER BY timestamp
+                """,
+                asset_id,
+                fname,
+                resolved_version,
+                start,
+                end,
+                as_of,
+            )
+
+            if rows:
+                df = pl.DataFrame(
+                    {
+                        "timestamp": [r["timestamp"] for r in rows],
+                        "value": [r["value"] for r in rows],
+                    }
+                )
+                # Structural safety check (§5.1)
+                self._assert_no_lookahead(df, as_of, fname)
+                await self._cache_set(cache_key, df)
+                frames.append(df.rename({"value": fname}))
+            else:
+                frames.append(
+                    pl.DataFrame(
+                        {
+                            "timestamp": pl.Series([], dtype=pl.Datetime("us", "UTC")),
+                            fname: pl.Series([], dtype=pl.Float64),
+                        }
+                    )
+                )
+
+        if not frames:
+            return pl.DataFrame({"timestamp": pl.Series([], dtype=pl.Datetime("us", "UTC"))})
+
+        result = frames[0]
+        for frame in frames[1:]:
+            result = result.join(frame, on="timestamp", how="full", coalesce=True)
+
+        return result.sort("timestamp")
+
+    # ── FeatureStore.list_versions ───────────────────────────────────────
+
+    async def list_versions(
+        self,
+        asset_id: UUID,
+        feature_name: str,
+    ) -> list[FeatureVersion]:
+        """Delegate to registry."""
+        return await self._registry.list_versions(asset_id, feature_name)
+
+    # ── FeatureStore.latest_version ──────────────────────────────────────
+
+    async def latest_version(
+        self,
+        asset_id: UUID,
+        feature_name: str,
+        as_of: datetime | None = None,
+    ) -> FeatureVersion | None:
+        """Delegate to registry."""
+        return await self._registry.latest_version(asset_id, feature_name, as_of)
+
+    # ── Private helpers ──────────────────────────────────────────────────
+
+    @staticmethod
+    def _assert_no_lookahead(
+        df: pl.DataFrame,
+        as_of: datetime,
+        feature_name: str,
+    ) -> None:
+        """Guard: verify no row has a future computed_at (structural bug check)."""
+        if "computed_at" in df.columns:
+            raw_max = df["computed_at"].max()
+            if raw_max is not None:
+                max_computed = datetime.fromisoformat(str(raw_max)) if not isinstance(raw_max, datetime) else raw_max
+                if max_computed > as_of:
+                    raise LookAheadViolationError(
+                        f"Feature '{feature_name}' returned rows with "
+                        f"computed_at={max_computed!r} > as_of={as_of!r}. "
+                        f"This is a structural bug in the query."
+                    )
+
+    @staticmethod
+    def _cache_key(
+        asset_id: UUID,
+        feature_name: str,
+        version: str,
+        start: datetime,
+        end: datetime,
+        as_of: datetime,
+    ) -> str:
+        """Build a deterministic Redis cache key."""
+        return (
+            f"feature:{asset_id}:{feature_name}:{version}"
+            f":{start.isoformat()}:{end.isoformat()}"
+            f":{as_of.isoformat()}"
+        )
+
+    async def _cache_get(self, key: str) -> pl.DataFrame | None:
+        """Try to load a cached DataFrame from Redis."""
+        try:
+            data = await self._redis.get(key)
+            if data is None:
+                return None
+            parsed = json.loads(data)
+            return pl.DataFrame(parsed)
+        except Exception:
+            return None
+
+    async def _cache_set(self, key: str, df: pl.DataFrame) -> None:
+        """Cache a DataFrame in Redis with TTL."""
+        try:
+            data = df.to_dict(as_series=False)
+            await self._redis.setex(key, self._cache_ttl, json.dumps(data, default=str))
+        except Exception as exc:
+            logger.debug(
+                "feature_store.cache_set_failed",
+                key=key,
+                error=str(exc),
+            )

--- a/features/store/timescale.py
+++ b/features/store/timescale.py
@@ -16,7 +16,7 @@ References:
 
 from __future__ import annotations
 
-import json
+import io
 from datetime import UTC, datetime
 from uuid import UUID
 
@@ -86,7 +86,19 @@ class TimescaleFeatureStore(FeatureStore):
 
         Raises:
             FeatureVersionExistsError: If the version already exists.
+            ValueError: If asset_id != version.asset_id or
+                feature_name not in DataFrame columns.
         """
+        if asset_id != version.asset_id:
+            raise ValueError(
+                f"asset_id mismatch: got {asset_id}, version.asset_id={version.asset_id}"
+            )
+        if version.feature_name not in features.columns:
+            raise ValueError(
+                f"feature_name '{version.feature_name}' not found "
+                f"in DataFrame columns {features.columns}"
+            )
+
         existing = await self._registry.get(asset_id, version.feature_name, version.version)
         if existing is not None:
             raise FeatureVersionExistsError(
@@ -191,6 +203,13 @@ class TimescaleFeatureStore(FeatureStore):
                         f"asset {asset_id} as of {as_of.isoformat()}."
                     )
                 resolved_version = ver_record.version
+            else:
+                ver_record = await self._registry.get(asset_id, fname, resolved_version)
+                if ver_record is None:
+                    raise FeatureVersionNotFoundError(
+                        f"Version '{resolved_version}' not found for "
+                        f"feature '{fname}' on asset {asset_id}."
+                    )
 
             cache_key = self._cache_key(asset_id, fname, resolved_version, start, end, as_of)
             cached = await self._cache_get(cache_key)
@@ -200,7 +219,7 @@ class TimescaleFeatureStore(FeatureStore):
 
             rows = await self._pool.fetch(
                 """
-                SELECT timestamp, value
+                SELECT timestamp, value, computed_at
                 FROM feature_values
                 WHERE asset_id = $1
                   AND feature_name = $2
@@ -223,10 +242,14 @@ class TimescaleFeatureStore(FeatureStore):
                     {
                         "timestamp": [r["timestamp"] for r in rows],
                         "value": [r["value"] for r in rows],
+                        "computed_at": [r["computed_at"] for r in rows],
                     }
                 )
-                # Structural safety check (§5.1)
+                # Structural safety check (§5.1) — effective
+                # because computed_at is now in the DataFrame
                 self._assert_no_lookahead(df, as_of, fname)
+                # Drop computed_at before caching/returning
+                df = df.drop("computed_at")
                 await self._cache_set(cache_key, df)
                 frames.append(df.rename({"value": fname}))
             else:
@@ -277,17 +300,26 @@ class TimescaleFeatureStore(FeatureStore):
         as_of: datetime,
         feature_name: str,
     ) -> None:
-        """Guard: verify no row has a future computed_at (structural bug check)."""
-        if "computed_at" in df.columns:
-            raw_max = df["computed_at"].max()
-            if raw_max is not None:
-                max_computed = datetime.fromisoformat(str(raw_max)) if not isinstance(raw_max, datetime) else raw_max
-                if max_computed > as_of:
-                    raise LookAheadViolationError(
-                        f"Feature '{feature_name}' returned rows with "
-                        f"computed_at={max_computed!r} > as_of={as_of!r}. "
-                        f"This is a structural bug in the query."
-                    )
+        """Guard: verify no row has computed_at > as_of.
+
+        This is a structural bug check — the SQL WHERE clause should
+        already prevent such rows.  If this fires, the query logic
+        has a bug.
+        """
+        if "computed_at" not in df.columns or df.is_empty():
+            return
+        max_computed = df["computed_at"].max()
+        if max_computed is None:
+            return
+        # Polars max() returns a Python datetime for Datetime columns
+        if isinstance(max_computed, datetime):
+            if max_computed > as_of:
+                raise LookAheadViolationError(
+                    f"Structural bug: feature '{feature_name}' "
+                    f"returned row with computed_at="
+                    f"{max_computed.isoformat()} > "
+                    f"as_of={as_of.isoformat()}"
+                )
 
     @staticmethod
     def _cache_key(
@@ -306,21 +338,26 @@ class TimescaleFeatureStore(FeatureStore):
         )
 
     async def _cache_get(self, key: str) -> pl.DataFrame | None:
-        """Try to load a cached DataFrame from Redis."""
+        """Try to load a cached DataFrame from Redis (IPC format)."""
         try:
             data = await self._redis.get(key)
             if data is None:
                 return None
-            parsed = json.loads(data)
-            return pl.DataFrame(parsed)
-        except Exception:
+            return pl.read_ipc(io.BytesIO(data))
+        except Exception as exc:
+            logger.debug(
+                "feature_store.cache_get_failed",
+                key=key,
+                error=str(exc),
+            )
             return None
 
     async def _cache_set(self, key: str, df: pl.DataFrame) -> None:
-        """Cache a DataFrame in Redis with TTL."""
+        """Cache a DataFrame in Redis with TTL (IPC format)."""
         try:
-            data = df.to_dict(as_series=False)
-            await self._redis.setex(key, self._cache_ttl, json.dumps(data, default=str))
+            buf = io.BytesIO()
+            df.write_ipc(buf, compression="uncompressed")
+            await self._redis.setex(key, self._cache_ttl, buf.getvalue())
         except Exception as exc:
             logger.debug(
                 "feature_store.cache_set_failed",

--- a/features/versioning.py
+++ b/features/versioning.py
@@ -1,0 +1,101 @@
+"""Feature versioning — immutable version records and deterministic hashing.
+
+Provides content-addressable versioning for the Feature Store:
+- ``FeatureVersion`` is an immutable record of a computed feature batch.
+- ``compute_version_string`` produces a deterministic short identifier.
+- ``compute_content_hash`` produces a SHA-256 digest of a Polars DataFrame.
+
+Reference:
+    Sculley, D. et al. (2015). "Hidden Technical Debt in Machine
+    Learning Systems". *NeurIPS*, 2503-2511 — feature lineage is a
+    first-class requirement for reproducible ML systems.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+import polars as pl
+
+
+@dataclass(frozen=True)
+class FeatureVersion:
+    """Immutable feature version record.
+
+    Each instance represents a single computation run of a feature
+    calculator on a specific asset over a specific time range.
+
+    Reference:
+        Sculley, D. et al. (2015). "Hidden Technical Debt in Machine
+        Learning Systems". *NeurIPS*, 2503-2511.
+    """
+
+    asset_id: UUID
+    feature_name: str
+    version: str
+    computed_at: datetime
+    content_hash: str
+    calculator_name: str
+    calculator_params: Mapping[str, Any]
+    row_count: int
+    start_ts: datetime
+    end_ts: datetime
+
+
+def compute_version_string(
+    calculator_name: str,
+    params: Mapping[str, Any],
+    computed_at: datetime,
+) -> str:
+    """Produce a deterministic, short version identifier.
+
+    Format: ``{calculator_name}-{hash8}`` where hash8 is derived from
+    the canonical JSON of (calculator_name, params, computed_at_iso).
+
+    Deterministic: same inputs always produce the same version string.
+
+    Args:
+        calculator_name: Name of the feature calculator.
+        params: Calculator parameters (must be JSON-serializable).
+        computed_at: Wall-clock timestamp of computation.
+
+    Returns:
+        Version string, e.g. ``'har_rv-a1b2c3d4'``.
+    """
+    canonical = json.dumps(
+        {
+            "calculator_name": calculator_name,
+            "params": dict(sorted(params.items())) if params else {},
+            "computed_at": computed_at.isoformat(),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:8]
+    return f"{calculator_name}-{digest}"
+
+
+def compute_content_hash(df: pl.DataFrame) -> str:
+    """Compute SHA-256 digest of a Polars DataFrame's IPC bytes.
+
+    The DataFrame is sorted by the ``timestamp`` column (if present)
+    before serialization to ensure deterministic output regardless of
+    input row order.
+
+    Args:
+        df: Polars DataFrame to hash.
+
+    Returns:
+        Hex-encoded SHA-256 digest string (64 chars).
+    """
+    stable = df.sort("timestamp") if "timestamp" in df.columns else df
+    buf = io.BytesIO()
+    stable.write_ipc(buf)
+    return hashlib.sha256(buf.getvalue()).hexdigest()

--- a/tests/integration/test_feature_store_integration.py
+++ b/tests/integration/test_feature_store_integration.py
@@ -31,6 +31,7 @@ import polars as pl
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.skipif(asyncpg is None, reason="asyncpg not installed"),
+    pytest.mark.skipif(fakeredis is None, reason="fakeredis not installed"),
 ]
 
 TEST_DSN = "postgresql://apex_test:apex_test@localhost:5433/apex_test"

--- a/tests/integration/test_feature_store_integration.py
+++ b/tests/integration/test_feature_store_integration.py
@@ -1,0 +1,154 @@
+"""Integration tests for Feature Store (Phase 3.2).
+
+Requires a running TimescaleDB instance (docker-compose.test.yml).
+Run with: pytest tests/integration/test_feature_store_integration.py -m integration
+
+Tests verify:
+  - Migration 002 creates feature_values + feature_versions tables
+  - Round-trip save/load with point-in-time semantics
+  - Hypertable creation and compression policy
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+try:
+    import asyncpg
+except ImportError:
+    asyncpg = None  # type: ignore[assignment]
+
+try:
+    import fakeredis.aioredis
+except ImportError:
+    fakeredis = None  # type: ignore[assignment]
+
+import polars as pl
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(asyncpg is None, reason="asyncpg not installed"),
+]
+
+TEST_DSN = "postgresql://apex_test:apex_test@localhost:5433/apex_test"
+
+
+@pytest.fixture
+async def initialized_db() -> asyncpg.Pool[asyncpg.Record]:
+    """Run migrations and return a pool."""
+    from scripts.init_db import run_migrations
+
+    await run_migrations(
+        host="localhost",
+        port=5433,
+        db="apex_test",
+        user="apex_test",
+        password="apex_test",
+    )
+    pool: asyncpg.Pool[asyncpg.Record] = await asyncpg.create_pool(TEST_DSN)
+    yield pool  # type: ignore[misc]
+    await pool.close()
+
+
+@pytest.fixture
+async def test_asset(initialized_db: asyncpg.Pool[asyncpg.Record]) -> uuid.UUID:
+    """Create a test asset and return its UUID."""
+    asset_id = uuid.uuid4()
+    await initialized_db.execute(
+        """
+        INSERT INTO assets (asset_id, symbol, exchange, asset_class, currency)
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (symbol, exchange) DO UPDATE SET asset_id = $1
+        RETURNING asset_id
+        """,
+        asset_id,
+        f"TEST_{asset_id.hex[:6]}",
+        "TEST",
+        "crypto",
+        "USD",
+    )
+    return asset_id
+
+
+class TestFeatureStoreIntegration:
+    """Full round-trip on TimescaleDB."""
+
+    @pytest.mark.asyncio
+    async def test_tables_exist(self, initialized_db: asyncpg.Pool[asyncpg.Record]) -> None:
+        """Migration 002 creates feature_values and feature_versions."""
+        for table in ("feature_values", "feature_versions"):
+            row = await initialized_db.fetchrow(
+                "SELECT 1 FROM information_schema.tables WHERE table_name = $1",
+                table,
+            )
+            assert row is not None, f"Table {table} does not exist"
+
+    @pytest.mark.asyncio
+    async def test_hypertable_created(self, initialized_db: asyncpg.Pool[asyncpg.Record]) -> None:
+        """feature_values should be a TimescaleDB hypertable."""
+        row = await initialized_db.fetchrow(
+            """
+            SELECT hypertable_name FROM timescaledb_information.hypertables
+            WHERE hypertable_name = 'feature_values'
+            """
+        )
+        assert row is not None, "feature_values is not a hypertable"
+
+    @pytest.mark.asyncio
+    async def test_round_trip_save_load(
+        self,
+        initialized_db: asyncpg.Pool[asyncpg.Record],
+        test_asset: uuid.UUID,
+    ) -> None:
+        """Save features, load them back, verify data integrity."""
+        from features.registry import FeatureRegistry
+        from features.store.timescale import TimescaleFeatureStore
+        from features.versioning import (
+            FeatureVersion,
+            compute_content_hash,
+            compute_version_string,
+        )
+
+        redis_client = fakeredis.aioredis.FakeRedis()
+        registry = FeatureRegistry(initialized_db)
+        store = TimescaleFeatureStore(initialized_db, redis_client, registry)
+
+        # Build test data
+        n = 100
+        base_ts = datetime(2024, 1, 1, tzinfo=UTC)
+        timestamps = [base_ts + timedelta(minutes=5 * i) for i in range(n)]
+        values = [float(i) * 0.01 for i in range(n)]
+        df = pl.DataFrame({"timestamp": timestamps, "har_rv": values})
+
+        computed_at = datetime(2024, 7, 1, tzinfo=UTC)
+        version_str = compute_version_string("har_rv", {}, computed_at)
+        version = FeatureVersion(
+            asset_id=test_asset,
+            feature_name="har_rv",
+            version=version_str,
+            computed_at=computed_at,
+            content_hash=compute_content_hash(df),
+            calculator_name="har_rv",
+            calculator_params={},
+            row_count=n,
+            start_ts=timestamps[0],
+            end_ts=timestamps[-1],
+        )
+
+        await store.save(test_asset, df, version)
+
+        # Load back
+        result = await store.load(
+            test_asset,
+            ["har_rv"],
+            timestamps[0],
+            timestamps[-1],
+            as_of=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+
+        assert result.shape[0] == n
+        assert "har_rv" in result.columns
+        assert "timestamp" in result.columns

--- a/tests/unit/features/test_exceptions.py
+++ b/tests/unit/features/test_exceptions.py
@@ -1,0 +1,30 @@
+"""Tests for features.exceptions — exception hierarchy."""
+
+from __future__ import annotations
+
+from features.exceptions import (
+    FeatureStoreError,
+    FeatureVersionExistsError,
+    FeatureVersionNotFoundError,
+    LookAheadViolationError,
+)
+
+
+class TestExceptionHierarchy:
+    """All feature exceptions inherit from FeatureStoreError."""
+
+    def test_version_exists_is_store_error(self) -> None:
+        assert issubclass(FeatureVersionExistsError, FeatureStoreError)
+
+    def test_version_not_found_is_store_error(self) -> None:
+        assert issubclass(FeatureVersionNotFoundError, FeatureStoreError)
+
+    def test_lookahead_violation_is_store_error(self) -> None:
+        assert issubclass(LookAheadViolationError, FeatureStoreError)
+
+    def test_base_is_exception(self) -> None:
+        assert issubclass(FeatureStoreError, Exception)
+
+    def test_catch_all_catches_subtypes(self) -> None:
+        with __import__("pytest").raises(FeatureStoreError):
+            raise FeatureVersionExistsError("duplicate version")

--- a/tests/unit/features/test_pipeline.py
+++ b/tests/unit/features/test_pipeline.py
@@ -75,13 +75,15 @@ class TestRunOnFrame:
         assert result.shape == synthetic_bars.shape
 
 
-class TestRunNotImplemented:
-    """FeaturePipeline.run raises NotImplementedError in Phase 3.1."""
+class TestRunRequiresStore:
+    """FeaturePipeline.run requires a FeatureStore (Phase 3.2)."""
 
     @pytest.mark.asyncio
-    async def test_run_raises(self) -> None:
+    async def test_run_without_store_raises(self) -> None:
         from datetime import UTC, datetime
+        from uuid import uuid4
 
         pipeline = FeaturePipeline([], TripleBarrierLabelerAdapter(), SampleWeighter())
-        with pytest.raises(NotImplementedError, match=r"Phase 3\.2"):
-            await pipeline.run("BTCUSD", datetime.now(UTC), datetime.now(UTC))
+        bars = pl.DataFrame({"timestamp": [], "close": []})
+        with pytest.raises(RuntimeError, match=r"requires a FeatureStore"):
+            await pipeline.run(uuid4(), bars, datetime.now(UTC), datetime.now(UTC))

--- a/tests/unit/features/test_pipeline_with_store.py
+++ b/tests/unit/features/test_pipeline_with_store.py
@@ -1,0 +1,147 @@
+"""Tests for FeaturePipeline.run() wiring with FeatureStore (Phase 3.2)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import polars as pl
+import pytest
+
+from features.base import FeatureCalculator
+from features.labels import TripleBarrierLabelerAdapter
+from features.pipeline import FeaturePipeline
+from features.store.base import FeatureStore
+from features.weights import SampleWeighter
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+class _StubCalculator(FeatureCalculator):
+    """Minimal calculator that adds a constant column."""
+
+    def __init__(self, col_name: str = "feat_a") -> None:
+        self._col = col_name
+
+    def name(self) -> str:
+        return self._col
+
+    def compute(self, df: pl.DataFrame) -> pl.DataFrame:
+        return df.with_columns(pl.lit(1.0).alias(self._col))
+
+    def required_columns(self) -> list[str]:
+        return ["close"]
+
+    def output_columns(self) -> list[str]:
+        return [self._col]
+
+
+# ── Tests ────────────────────────────────────────────────────────────────
+
+
+class TestPipelineRunWithStore:
+    """FeaturePipeline.run() computes and saves features."""
+
+    @pytest.mark.asyncio
+    async def test_run_calls_save_per_feature(self) -> None:
+        mock_store = AsyncMock(spec=FeatureStore)
+        calc_a = _StubCalculator("feat_a")
+        calc_b = _StubCalculator("feat_b")
+        pipeline = FeaturePipeline(
+            [calc_a, calc_b],
+            TripleBarrierLabelerAdapter(),
+            SampleWeighter(),
+            feature_store=mock_store,
+        )
+        bars = pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 1, tzinfo=UTC)],
+                "open": [100.0],
+                "high": [101.0],
+                "low": [99.0],
+                "close": [100.5],
+                "volume": [1000.0],
+            }
+        )
+        aid = uuid4()
+        start = datetime(2024, 1, 1, tzinfo=UTC)
+        end = datetime(2024, 6, 1, tzinfo=UTC)
+
+        result = await pipeline.run(aid, bars, start, end)
+
+        # 2 calculators × 1 output_column each = 2 save calls
+        assert mock_store.save.await_count == 2
+        assert "feat_a" in result.columns
+        assert "feat_b" in result.columns
+
+    @pytest.mark.asyncio
+    async def test_run_returns_augmented_df(self) -> None:
+        mock_store = AsyncMock(spec=FeatureStore)
+        pipeline = FeaturePipeline(
+            [_StubCalculator("feat_a")],
+            TripleBarrierLabelerAdapter(),
+            SampleWeighter(),
+            feature_store=mock_store,
+        )
+        bars = pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 1, tzinfo=UTC)],
+                "open": [100.0],
+                "high": [101.0],
+                "low": [99.0],
+                "close": [100.5],
+                "volume": [1000.0],
+            }
+        )
+        result = await pipeline.run(
+            uuid4(), bars, datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 6, 1, tzinfo=UTC)
+        )
+        assert "feat_a" in result.columns
+        assert result.shape[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_run_without_store_raises(self) -> None:
+        pipeline = FeaturePipeline(
+            [],
+            TripleBarrierLabelerAdapter(),
+            SampleWeighter(),
+        )
+        bars = pl.DataFrame({"timestamp": [], "close": []})
+        with pytest.raises(RuntimeError, match="requires a FeatureStore"):
+            await pipeline.run(
+                uuid4(), bars, datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 6, 1, tzinfo=UTC)
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_with_as_of_backtest(self) -> None:
+        """as_of is passed through to computed_at in the FeatureVersion."""
+        mock_store = AsyncMock(spec=FeatureStore)
+        pipeline = FeaturePipeline(
+            [_StubCalculator("feat_a")],
+            TripleBarrierLabelerAdapter(),
+            SampleWeighter(),
+            feature_store=mock_store,
+        )
+        bars = pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 1, tzinfo=UTC)],
+                "open": [100.0],
+                "high": [101.0],
+                "low": [99.0],
+                "close": [100.5],
+                "volume": [1000.0],
+            }
+        )
+        as_of = datetime(2024, 3, 15, tzinfo=UTC)
+        await pipeline.run(
+            uuid4(),
+            bars,
+            datetime(2024, 1, 1, tzinfo=UTC),
+            datetime(2024, 6, 1, tzinfo=UTC),
+            as_of=as_of,
+        )
+        # Verify the version passed to save has computed_at == as_of
+        save_call = mock_store.save.call_args
+        version_arg = save_call[0][2]  # third positional: version
+        assert version_arg.computed_at == as_of

--- a/tests/unit/features/test_pipeline_with_store.py
+++ b/tests/unit/features/test_pipeline_with_store.py
@@ -145,3 +145,39 @@ class TestPipelineRunWithStore:
         save_call = mock_store.save.call_args
         version_arg = save_call[0][2]  # third positional: version
         assert version_arg.computed_at == as_of
+
+    @pytest.mark.asyncio
+    async def test_pipeline_includes_calculator_version_in_metadata(self) -> None:
+        """calc.version is included in calculator_params (Fix 6)."""
+        mock_store = AsyncMock(spec=FeatureStore)
+
+        class _V2Calculator(_StubCalculator):
+            @property
+            def version(self) -> str:
+                return "v2"
+
+        pipeline = FeaturePipeline(
+            [_V2Calculator("feat_a")],
+            TripleBarrierLabelerAdapter(),
+            SampleWeighter(),
+            feature_store=mock_store,
+        )
+        bars = pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 1, tzinfo=UTC)],
+                "open": [100.0],
+                "high": [101.0],
+                "low": [99.0],
+                "close": [100.5],
+                "volume": [1000.0],
+            }
+        )
+        await pipeline.run(
+            uuid4(),
+            bars,
+            datetime(2024, 1, 1, tzinfo=UTC),
+            datetime(2024, 6, 1, tzinfo=UTC),
+        )
+        save_call = mock_store.save.call_args
+        version_arg = save_call[0][2]
+        assert version_arg.calculator_params["version"] == "v2"

--- a/tests/unit/features/test_registry.py
+++ b/tests/unit/features/test_registry.py
@@ -1,0 +1,192 @@
+"""Tests for features.registry — FeatureRegistry metadata catalog."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from features.registry import FeatureRegistry
+from features.versioning import FeatureVersion
+
+
+def _make_version(
+    asset_id: object | None = None,
+    feature_name: str = "har_rv",
+    version: str = "har_rv-abc12345",
+    computed_at: datetime | None = None,
+) -> FeatureVersion:
+    """Helper to create a FeatureVersion with sane defaults."""
+    return FeatureVersion(
+        asset_id=asset_id or uuid4(),
+        feature_name=feature_name,
+        version=version,
+        computed_at=computed_at or datetime.now(UTC),
+        content_hash="a" * 64,
+        calculator_name="har_rv",
+        calculator_params={},
+        row_count=100,
+        start_ts=datetime(2024, 1, 1, tzinfo=UTC),
+        end_ts=datetime(2024, 6, 1, tzinfo=UTC),
+    )
+
+
+def _mock_pool() -> AsyncMock:
+    """Create a mock asyncpg pool."""
+    return AsyncMock()
+
+
+class TestRegistryRegister:
+    """FeatureRegistry.register inserts into feature_versions."""
+
+    @pytest.mark.asyncio
+    async def test_register_calls_execute(self) -> None:
+        pool = _mock_pool()
+        registry = FeatureRegistry(pool)
+        version = _make_version()
+        await registry.register(version)
+        pool.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_register_passes_all_fields(self) -> None:
+        pool = _mock_pool()
+        registry = FeatureRegistry(pool)
+        version = _make_version()
+        await registry.register(version)
+        call_args = pool.execute.call_args
+        assert call_args[0][1] == version.asset_id
+        assert call_args[0][2] == version.feature_name
+        assert call_args[0][3] == version.version
+
+
+class TestRegistryListFeatures:
+    """FeatureRegistry.list_features returns distinct feature names."""
+
+    @pytest.mark.asyncio
+    async def test_list_features_returns_names(self) -> None:
+        pool = _mock_pool()
+        pool.fetch.return_value = [
+            {"feature_name": "har_rv"},
+            {"feature_name": "ofi"},
+        ]
+        registry = FeatureRegistry(pool)
+        result = await registry.list_features(uuid4())
+        assert result == ["har_rv", "ofi"]
+
+    @pytest.mark.asyncio
+    async def test_list_features_empty(self) -> None:
+        pool = _mock_pool()
+        pool.fetch.return_value = []
+        registry = FeatureRegistry(pool)
+        result = await registry.list_features(uuid4())
+        assert result == []
+
+
+class TestRegistryListVersions:
+    """FeatureRegistry.list_versions returns FeatureVersion records."""
+
+    @pytest.mark.asyncio
+    async def test_list_versions_returns_records(self) -> None:
+        pool = _mock_pool()
+        aid = uuid4()
+        ts = datetime(2024, 6, 1, tzinfo=UTC)
+        pool.fetch.return_value = [
+            {
+                "asset_id": aid,
+                "feature_name": "har_rv",
+                "version": "har_rv-abc12345",
+                "computed_at": ts,
+                "content_hash": "a" * 64,
+                "calculator_name": "har_rv",
+                "calculator_params": {},
+                "row_count": 100,
+                "start_ts": datetime(2024, 1, 1, tzinfo=UTC),
+                "end_ts": datetime(2024, 6, 1, tzinfo=UTC),
+            }
+        ]
+        registry = FeatureRegistry(pool)
+        result = await registry.list_versions(aid, "har_rv")
+        assert len(result) == 1
+        assert result[0].version == "har_rv-abc12345"
+
+
+class TestRegistryLatestVersion:
+    """FeatureRegistry.latest_version with and without as_of."""
+
+    @pytest.mark.asyncio
+    async def test_latest_version_found(self) -> None:
+        pool = _mock_pool()
+        aid = uuid4()
+        ts = datetime(2024, 6, 1, tzinfo=UTC)
+        pool.fetchrow.return_value = {
+            "asset_id": aid,
+            "feature_name": "har_rv",
+            "version": "har_rv-abc12345",
+            "computed_at": ts,
+            "content_hash": "a" * 64,
+            "calculator_name": "har_rv",
+            "calculator_params": {},
+            "row_count": 100,
+            "start_ts": datetime(2024, 1, 1, tzinfo=UTC),
+            "end_ts": datetime(2024, 6, 1, tzinfo=UTC),
+        }
+        registry = FeatureRegistry(pool)
+        result = await registry.latest_version(aid, "har_rv")
+        assert result is not None
+        assert result.version == "har_rv-abc12345"
+
+    @pytest.mark.asyncio
+    async def test_latest_version_none_when_empty(self) -> None:
+        pool = _mock_pool()
+        pool.fetchrow.return_value = None
+        registry = FeatureRegistry(pool)
+        result = await registry.latest_version(uuid4(), "har_rv")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_latest_version_with_as_of(self) -> None:
+        pool = _mock_pool()
+        pool.fetchrow.return_value = None
+        registry = FeatureRegistry(pool)
+        as_of = datetime(2024, 1, 1, tzinfo=UTC)
+        result = await registry.latest_version(uuid4(), "har_rv", as_of=as_of)
+        assert result is None
+        # Verify as_of was passed to the query
+        call_args = pool.fetchrow.call_args
+        assert call_args[0][3] == as_of
+
+
+class TestRegistryGet:
+    """FeatureRegistry.get retrieves a specific version."""
+
+    @pytest.mark.asyncio
+    async def test_get_existing(self) -> None:
+        pool = _mock_pool()
+        aid = uuid4()
+        ts = datetime(2024, 6, 1, tzinfo=UTC)
+        pool.fetchrow.return_value = {
+            "asset_id": aid,
+            "feature_name": "har_rv",
+            "version": "har_rv-abc12345",
+            "computed_at": ts,
+            "content_hash": "a" * 64,
+            "calculator_name": "har_rv",
+            "calculator_params": "{}",
+            "row_count": 100,
+            "start_ts": datetime(2024, 1, 1, tzinfo=UTC),
+            "end_ts": datetime(2024, 6, 1, tzinfo=UTC),
+        }
+        registry = FeatureRegistry(pool)
+        result = await registry.get(aid, "har_rv", "har_rv-abc12345")
+        assert result is not None
+        assert result.version == "har_rv-abc12345"
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent(self) -> None:
+        pool = _mock_pool()
+        pool.fetchrow.return_value = None
+        registry = FeatureRegistry(pool)
+        result = await registry.get(uuid4(), "har_rv", "nonexistent")
+        assert result is None

--- a/tests/unit/features/test_store.py
+++ b/tests/unit/features/test_store.py
@@ -163,10 +163,11 @@ class TestStoreLoad:
         ts1 = datetime(2024, 1, 1, tzinfo=UTC)
         ts2 = datetime(2024, 6, 1, tzinfo=UTC)
         as_of = datetime(2024, 7, 1, tzinfo=UTC)
+        computed = datetime(2024, 5, 1, tzinfo=UTC)
 
         mock_pool.fetch.return_value = [
-            {"timestamp": ts1, "value": 1.0},
-            {"timestamp": ts1 + timedelta(minutes=5), "value": 2.0},
+            {"timestamp": ts1, "value": 1.0, "computed_at": computed},
+            {"timestamp": ts1 + timedelta(minutes=5), "value": 2.0, "computed_at": computed},
         ]
 
         result = await store.load(aid, ["har_rv"], ts1, ts2, as_of=as_of)
@@ -184,14 +185,26 @@ class TestStoreLoad:
         ts1 = datetime(2024, 1, 1, tzinfo=UTC)
         ts2 = datetime(2024, 6, 1, tzinfo=UTC)
         as_of = datetime(2024, 7, 1, tzinfo=UTC)
+        computed = datetime(2024, 5, 1, tzinfo=UTC)
 
+        # Explicit version must exist in registry
+        mock_registry.get.return_value = _make_version(asset_id=aid, version="har_rv-explicit")
         mock_pool.fetch.return_value = [
-            {"timestamp": ts1, "value": 1.0},
+            {"timestamp": ts1, "value": 1.0, "computed_at": computed},
         ]
 
-        result = await store.load(aid, ["har_rv"], ts1, ts2, as_of=as_of, version="har_rv-explicit")
+        result = await store.load(
+            aid,
+            ["har_rv"],
+            ts1,
+            ts2,
+            as_of=as_of,
+            version="har_rv-explicit",
+        )
         # Should NOT call latest_version when version is explicit
         mock_registry.latest_version.assert_not_awaited()
+        # Should call get() to verify version exists
+        mock_registry.get.assert_awaited()
         assert "har_rv" in result.columns
 
     @pytest.mark.asyncio
@@ -245,10 +258,11 @@ class TestStoreLoad:
         ver_b = _make_version(asset_id=aid, feature_name="feat_b", version="feat_b-xyz")
         mock_registry.latest_version.side_effect = [ver_a, ver_b]
 
+        computed = datetime(2024, 5, 1, tzinfo=UTC)
         # First call for feat_a, second for feat_b
         mock_pool.fetch.side_effect = [
-            [{"timestamp": ts1, "value": 1.0}],
-            [{"timestamp": ts1, "value": 2.0}],
+            [{"timestamp": ts1, "value": 1.0, "computed_at": computed}],
+            [{"timestamp": ts1, "value": 2.0, "computed_at": computed}],
         ]
 
         result = await store.load(aid, ["feat_a", "feat_b"], ts1, ts2, as_of=as_of)
@@ -297,8 +311,9 @@ class TestStoreCache:
         version = _make_version(asset_id=aid)
         mock_registry.latest_version.return_value = version
 
+        computed = datetime(2024, 5, 1, tzinfo=UTC)
         mock_pool.fetch.return_value = [
-            {"timestamp": ts1, "value": 42.0},
+            {"timestamp": ts1, "value": 42.0, "computed_at": computed},
         ]
 
         # First load: cache miss, hits DB
@@ -370,7 +385,9 @@ class TestStoreLookAhead:
         store = TimescaleFeatureStore(mock_pool, redis_client, registry)
 
         # as_of=t1 resolves v1
-        mock_pool.fetch.return_value = [{"timestamp": ts_bar, "value": 10.0}]
+        mock_pool.fetch.return_value = [
+            {"timestamp": ts_bar, "value": 10.0, "computed_at": t1},
+        ]
         await store.load(aid, ["har_rv"], ts_bar, ts_bar, as_of=t1)
         call_args = mock_pool.fetch.call_args
         assert call_args[0][3] == "v1"  # version param
@@ -380,7 +397,9 @@ class TestStoreLookAhead:
         # Clear cache to force DB hit
         await redis_client.flushall()
 
-        mock_pool.fetch.return_value = [{"timestamp": ts_bar, "value": 20.0}]
+        mock_pool.fetch.return_value = [
+            {"timestamp": ts_bar, "value": 20.0, "computed_at": t2},
+        ]
         await store.load(aid, ["har_rv"], ts_bar, ts_bar, as_of=t2)
         call_args = mock_pool.fetch.call_args
         assert call_args[0][3] == "v2"
@@ -411,3 +430,115 @@ class TestStoreDelegates:
         result = await store.latest_version(aid, "har_rv")
         mock_registry.latest_version.assert_awaited_once()
         assert result is None
+
+
+# ── New tests for PR #109 fixes ──────────────────────────────────────────
+
+
+class TestStoreValidation:
+    """Input validation in save() (Fix 5)."""
+
+    @pytest.mark.asyncio
+    async def test_save_rejects_asset_id_mismatch(self, store: TimescaleFeatureStore) -> None:
+        aid_1 = uuid4()
+        aid_2 = uuid4()
+        version = _make_version(asset_id=aid_1)
+        df = _make_feature_df()
+        with pytest.raises(ValueError, match="asset_id mismatch"):
+            await store.save(aid_2, df, version)
+
+    @pytest.mark.asyncio
+    async def test_save_rejects_missing_feature_column(self, store: TimescaleFeatureStore) -> None:
+        aid = uuid4()
+        version = _make_version(asset_id=aid, feature_name="nonexistent")
+        df = _make_feature_df(feature_name="har_rv")
+        with pytest.raises(ValueError, match="not found in DataFrame"):
+            await store.save(aid, df, version)
+
+
+class TestAssertNoLookaheadEffective:
+    """_assert_no_lookahead is effective when computed_at is present (Fix 2)."""
+
+    @pytest.mark.asyncio
+    async def test_assert_no_lookahead_raises_on_future_computed_at(
+        self,
+        mock_pool: AsyncMock,
+        redis_client: fakeredis.aioredis.FakeRedis,
+        mock_registry: AsyncMock,
+    ) -> None:
+        """Monkeypatch fetch to return rows with future computed_at."""
+        aid = uuid4()
+        ts1 = datetime(2024, 1, 1, tzinfo=UTC)
+        ts2 = datetime(2024, 6, 1, tzinfo=UTC)
+        as_of = datetime(2024, 3, 1, tzinfo=UTC)
+        future_computed = datetime(2024, 9, 1, tzinfo=UTC)  # > as_of
+
+        mock_registry.latest_version.return_value = _make_version(asset_id=aid)
+        # Simulate a bug: row with computed_at in the future
+        mock_pool.fetch.return_value = [
+            {"timestamp": ts1, "value": 1.0, "computed_at": future_computed},
+        ]
+
+        store = TimescaleFeatureStore(mock_pool, redis_client, mock_registry)
+        from features.exceptions import LookAheadViolationError
+
+        with pytest.raises(LookAheadViolationError, match="Structural bug"):
+            await store.load(aid, ["har_rv"], ts1, ts2, as_of=as_of)
+
+
+class TestCacheIpcRoundtrip:
+    """Cache uses IPC bytes, preserving dtypes (Fix 3)."""
+
+    @pytest.mark.asyncio
+    async def test_cache_roundtrip_preserves_dtypes(
+        self,
+        store: TimescaleFeatureStore,
+        mock_pool: AsyncMock,
+        mock_registry: AsyncMock,
+        redis_client: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        aid = uuid4()
+        ts1 = datetime(2024, 1, 1, tzinfo=UTC)
+        ts2 = datetime(2024, 6, 1, tzinfo=UTC)
+        as_of = datetime(2024, 7, 1, tzinfo=UTC)
+        computed = datetime(2024, 5, 1, tzinfo=UTC)
+        version = _make_version(asset_id=aid)
+        mock_registry.latest_version.return_value = version
+
+        mock_pool.fetch.return_value = [
+            {"timestamp": ts1, "value": 42.0, "computed_at": computed},
+        ]
+
+        # First load populates cache
+        r1 = await store.load(aid, ["har_rv"], ts1, ts2, as_of=as_of)
+        assert r1["timestamp"].dtype == pl.Datetime("us", "UTC")
+
+        # Second load from cache — dtypes must match
+        r2 = await store.load(aid, ["har_rv"], ts1, ts2, as_of=as_of)
+        assert r2["timestamp"].dtype == r1["timestamp"].dtype
+        assert r2["har_rv"].dtype == r1["har_rv"].dtype
+
+
+class TestExplicitVersionNotFound:
+    """load() with explicit version that doesn't exist (Fix 8)."""
+
+    @pytest.mark.asyncio
+    async def test_load_explicit_version_not_found_raises(
+        self,
+        store: TimescaleFeatureStore,
+        mock_registry: AsyncMock,
+    ) -> None:
+        mock_registry.get.return_value = None
+        aid = uuid4()
+        with pytest.raises(
+            FeatureVersionNotFoundError,
+            match="not found for feature",
+        ):
+            await store.load(
+                aid,
+                ["har_rv"],
+                datetime(2024, 1, 1, tzinfo=UTC),
+                datetime(2024, 6, 1, tzinfo=UTC),
+                as_of=datetime(2024, 7, 1, tzinfo=UTC),
+                version="nonexistent-version",
+            )

--- a/tests/unit/features/test_store.py
+++ b/tests/unit/features/test_store.py
@@ -1,0 +1,413 @@
+"""Tests for features.store.timescale — TimescaleFeatureStore.
+
+Tests use AsyncMock for asyncpg and fakeredis for Redis, following
+CLAUDE.md Section 7 (no real Redis in unit tests).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import fakeredis.aioredis
+import polars as pl
+import pytest
+
+from features.exceptions import (
+    FeatureVersionExistsError,
+    FeatureVersionNotFoundError,
+)
+from features.registry import FeatureRegistry
+from features.store.timescale import TimescaleFeatureStore
+from features.versioning import FeatureVersion
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_version(
+    asset_id: object | None = None,
+    feature_name: str = "har_rv",
+    version: str = "har_rv-abc12345",
+    computed_at: datetime | None = None,
+    row_count: int = 3,
+) -> FeatureVersion:
+    return FeatureVersion(
+        asset_id=asset_id or uuid4(),
+        feature_name=feature_name,
+        version=version,
+        computed_at=computed_at or datetime(2024, 6, 1, tzinfo=UTC),
+        content_hash="a" * 64,
+        calculator_name="har_rv",
+        calculator_params={},
+        row_count=row_count,
+        start_ts=datetime(2024, 1, 1, tzinfo=UTC),
+        end_ts=datetime(2024, 6, 1, tzinfo=UTC),
+    )
+
+
+def _make_feature_df(
+    feature_name: str = "har_rv",
+    n: int = 3,
+    base_ts: datetime | None = None,
+) -> pl.DataFrame:
+    base = base_ts or datetime(2024, 1, 1, tzinfo=UTC)
+    return pl.DataFrame(
+        {
+            "timestamp": [base + timedelta(minutes=5 * i) for i in range(n)],
+            feature_name: [float(i + 1) for i in range(n)],
+        }
+    )
+
+
+@pytest.fixture
+def redis_client() -> fakeredis.aioredis.FakeRedis:
+    return fakeredis.aioredis.FakeRedis()
+
+
+@pytest.fixture
+def mock_pool() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_registry() -> AsyncMock:
+    return AsyncMock(spec=FeatureRegistry)
+
+
+@pytest.fixture
+def store(
+    mock_pool: AsyncMock,
+    redis_client: fakeredis.aioredis.FakeRedis,
+    mock_registry: AsyncMock,
+) -> TimescaleFeatureStore:
+    return TimescaleFeatureStore(
+        pg_pool=mock_pool,
+        redis_client=redis_client,
+        registry=mock_registry,
+    )
+
+
+# ── Save tests ───────────────────────────────────────────────────────────
+
+
+class TestStoreSave:
+    """TimescaleFeatureStore.save persists features and registers version."""
+
+    @pytest.mark.asyncio
+    async def test_save_copies_records(
+        self, store: TimescaleFeatureStore, mock_pool: AsyncMock, mock_registry: AsyncMock
+    ) -> None:
+        mock_registry.get.return_value = None
+        aid = uuid4()
+        version = _make_version(asset_id=aid)
+        df = _make_feature_df()
+
+        await store.save(aid, df, version)
+
+        mock_pool.copy_records_to_table.assert_awaited_once()
+        call_args = mock_pool.copy_records_to_table.call_args
+        assert call_args[1]["columns"][0] == "asset_id"
+
+    @pytest.mark.asyncio
+    async def test_save_registers_version(
+        self, store: TimescaleFeatureStore, mock_registry: AsyncMock
+    ) -> None:
+        mock_registry.get.return_value = None
+        aid = uuid4()
+        version = _make_version(asset_id=aid)
+        df = _make_feature_df()
+
+        await store.save(aid, df, version)
+
+        mock_registry.register.assert_awaited_once_with(version)
+
+    @pytest.mark.asyncio
+    async def test_save_duplicate_raises(
+        self, store: TimescaleFeatureStore, mock_registry: AsyncMock
+    ) -> None:
+        existing = _make_version()
+        mock_registry.get.return_value = existing
+        aid = uuid4()
+        version = _make_version(asset_id=aid)
+        df = _make_feature_df()
+
+        with pytest.raises(FeatureVersionExistsError, match="already exists"):
+            await store.save(aid, df, version)
+
+
+# ── Load tests ───────────────────────────────────────────────────────────
+
+
+class TestStoreLoad:
+    """TimescaleFeatureStore.load with point-in-time semantics."""
+
+    @pytest.mark.asyncio
+    async def test_load_empty_feature_names(self, store: TimescaleFeatureStore) -> None:
+        result = await store.load(
+            uuid4(), [], datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 6, 1, tzinfo=UTC)
+        )
+        assert result.shape[0] == 0
+        assert "timestamp" in result.columns
+
+    @pytest.mark.asyncio
+    async def test_load_resolves_latest_version(
+        self,
+        store: TimescaleFeatureStore,
+        mock_pool: AsyncMock,
+        mock_registry: AsyncMock,
+    ) -> None:
+        aid = uuid4()
+        version = _make_version(asset_id=aid)
+        mock_registry.latest_version.return_value = version
+        ts1 = datetime(2024, 1, 1, tzinfo=UTC)
+        ts2 = datetime(2024, 6, 1, tzinfo=UTC)
+        as_of = datetime(2024, 7, 1, tzinfo=UTC)
+
+        mock_pool.fetch.return_value = [
+            {"timestamp": ts1, "value": 1.0},
+            {"timestamp": ts1 + timedelta(minutes=5), "value": 2.0},
+        ]
+
+        result = await store.load(aid, ["har_rv"], ts1, ts2, as_of=as_of)
+        mock_registry.latest_version.assert_awaited_once_with(aid, "har_rv", as_of)
+        assert "har_rv" in result.columns
+
+    @pytest.mark.asyncio
+    async def test_load_with_explicit_version(
+        self,
+        store: TimescaleFeatureStore,
+        mock_pool: AsyncMock,
+        mock_registry: AsyncMock,
+    ) -> None:
+        aid = uuid4()
+        ts1 = datetime(2024, 1, 1, tzinfo=UTC)
+        ts2 = datetime(2024, 6, 1, tzinfo=UTC)
+        as_of = datetime(2024, 7, 1, tzinfo=UTC)
+
+        mock_pool.fetch.return_value = [
+            {"timestamp": ts1, "value": 1.0},
+        ]
+
+        result = await store.load(aid, ["har_rv"], ts1, ts2, as_of=as_of, version="har_rv-explicit")
+        # Should NOT call latest_version when version is explicit
+        mock_registry.latest_version.assert_not_awaited()
+        assert "har_rv" in result.columns
+
+    @pytest.mark.asyncio
+    async def test_load_version_not_found_raises(
+        self,
+        store: TimescaleFeatureStore,
+        mock_registry: AsyncMock,
+    ) -> None:
+        mock_registry.latest_version.return_value = None
+        aid = uuid4()
+        ts1 = datetime(2024, 1, 1, tzinfo=UTC)
+        ts2 = datetime(2024, 6, 1, tzinfo=UTC)
+        as_of = datetime(2024, 7, 1, tzinfo=UTC)
+
+        with pytest.raises(FeatureVersionNotFoundError, match="No version found"):
+            await store.load(aid, ["har_rv"], ts1, ts2, as_of=as_of)
+
+    @pytest.mark.asyncio
+    async def test_load_empty_result(
+        self,
+        store: TimescaleFeatureStore,
+        mock_pool: AsyncMock,
+        mock_registry: AsyncMock,
+    ) -> None:
+        mock_registry.latest_version.return_value = _make_version()
+        mock_pool.fetch.return_value = []
+        aid = uuid4()
+        result = await store.load(
+            aid,
+            ["har_rv"],
+            datetime(2024, 1, 1, tzinfo=UTC),
+            datetime(2024, 6, 1, tzinfo=UTC),
+            as_of=datetime(2024, 7, 1, tzinfo=UTC),
+        )
+        assert result.shape[0] == 0
+        assert "har_rv" in result.columns
+
+    @pytest.mark.asyncio
+    async def test_load_multiple_features_pivoted(
+        self,
+        store: TimescaleFeatureStore,
+        mock_pool: AsyncMock,
+        mock_registry: AsyncMock,
+    ) -> None:
+        aid = uuid4()
+        ts1 = datetime(2024, 1, 1, tzinfo=UTC)
+        ts2 = datetime(2024, 6, 1, tzinfo=UTC)
+        as_of = datetime(2024, 7, 1, tzinfo=UTC)
+
+        ver_a = _make_version(asset_id=aid, feature_name="feat_a")
+        ver_b = _make_version(asset_id=aid, feature_name="feat_b", version="feat_b-xyz")
+        mock_registry.latest_version.side_effect = [ver_a, ver_b]
+
+        # First call for feat_a, second for feat_b
+        mock_pool.fetch.side_effect = [
+            [{"timestamp": ts1, "value": 1.0}],
+            [{"timestamp": ts1, "value": 2.0}],
+        ]
+
+        result = await store.load(aid, ["feat_a", "feat_b"], ts1, ts2, as_of=as_of)
+        assert "feat_a" in result.columns
+        assert "feat_b" in result.columns
+        assert result.shape[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_load_warns_without_as_of(
+        self,
+        store: TimescaleFeatureStore,
+        mock_pool: AsyncMock,
+        mock_registry: AsyncMock,
+    ) -> None:
+        """load() without as_of defaults to now(UTC) and logs warning."""
+        mock_registry.latest_version.return_value = _make_version()
+        mock_pool.fetch.return_value = []
+
+        # Should not raise — just warn
+        await store.load(
+            uuid4(),
+            ["har_rv"],
+            datetime(2024, 1, 1, tzinfo=UTC),
+            datetime(2024, 6, 1, tzinfo=UTC),
+        )
+
+
+# ── Cache tests ──────────────────────────────────────────────────────────
+
+
+class TestStoreCache:
+    """Redis cache hit/miss behavior."""
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_then_hit(
+        self,
+        store: TimescaleFeatureStore,
+        mock_pool: AsyncMock,
+        mock_registry: AsyncMock,
+        redis_client: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        aid = uuid4()
+        ts1 = datetime(2024, 1, 1, tzinfo=UTC)
+        ts2 = datetime(2024, 6, 1, tzinfo=UTC)
+        as_of = datetime(2024, 7, 1, tzinfo=UTC)
+        version = _make_version(asset_id=aid)
+        mock_registry.latest_version.return_value = version
+
+        mock_pool.fetch.return_value = [
+            {"timestamp": ts1, "value": 42.0},
+        ]
+
+        # First load: cache miss, hits DB
+        result1 = await store.load(aid, ["har_rv"], ts1, ts2, as_of=as_of)
+        assert mock_pool.fetch.await_count == 1
+
+        # Second load: cache hit, does NOT hit DB again
+        result2 = await store.load(aid, ["har_rv"], ts1, ts2, as_of=as_of)
+        assert mock_pool.fetch.await_count == 1  # still 1
+
+
+# ── Point-in-time / Look-Ahead tests ────────────────────────────────────
+
+
+class TestStoreLookAhead:
+    """Structural look-ahead bias defense (PHASE_3_SPEC Section 5.1)."""
+
+    @pytest.mark.asyncio
+    async def test_load_as_of_filters_computed_at(
+        self,
+        store: TimescaleFeatureStore,
+        mock_pool: AsyncMock,
+        mock_registry: AsyncMock,
+    ) -> None:
+        """SQL query must include computed_at <= as_of."""
+        aid = uuid4()
+        ts1 = datetime(2024, 1, 1, tzinfo=UTC)
+        ts2 = datetime(2024, 6, 1, tzinfo=UTC)
+        as_of = datetime(2024, 3, 1, tzinfo=UTC)
+        mock_registry.latest_version.return_value = _make_version(asset_id=aid)
+        mock_pool.fetch.return_value = []
+
+        await store.load(aid, ["har_rv"], ts1, ts2, as_of=as_of)
+
+        call_args = mock_pool.fetch.call_args
+        sql = call_args[0][0]
+        assert "computed_at <= $6" in sql.replace("\n", " ").replace("  ", " ")
+        # The 6th positional arg should be as_of
+        assert call_args[0][6] == as_of
+
+    @pytest.mark.asyncio
+    async def test_pit_v1_before_v2(
+        self,
+        mock_pool: AsyncMock,
+        redis_client: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        """save(v1) at t1 then save(v2) at t2 > t1:
+        load(as_of=t1) returns v1, load(as_of=t2) returns v2."""
+        aid = uuid4()
+        t1 = datetime(2024, 3, 1, tzinfo=UTC)
+        t2 = datetime(2024, 6, 1, tzinfo=UTC)
+        ts_bar = datetime(2024, 2, 1, tzinfo=UTC)
+
+        v1 = _make_version(asset_id=aid, version="v1", computed_at=t1, feature_name="har_rv")
+        v2 = _make_version(asset_id=aid, version="v2", computed_at=t2, feature_name="har_rv")
+
+        # Mock registry to return v1 for as_of=t1, v2 for as_of=t2
+        registry = AsyncMock(spec=FeatureRegistry)
+
+        async def _latest(
+            a: object, fname: str, as_of: datetime | None = None
+        ) -> FeatureVersion | None:
+            if as_of is not None and as_of < t2:
+                return v1
+            return v2
+
+        registry.latest_version.side_effect = _latest
+
+        store = TimescaleFeatureStore(mock_pool, redis_client, registry)
+
+        # as_of=t1 resolves v1
+        mock_pool.fetch.return_value = [{"timestamp": ts_bar, "value": 10.0}]
+        await store.load(aid, ["har_rv"], ts_bar, ts_bar, as_of=t1)
+        call_args = mock_pool.fetch.call_args
+        assert call_args[0][3] == "v1"  # version param
+
+        # Reset for second call
+        mock_pool.fetch.reset_mock()
+        # Clear cache to force DB hit
+        await redis_client.flushall()
+
+        mock_pool.fetch.return_value = [{"timestamp": ts_bar, "value": 20.0}]
+        await store.load(aid, ["har_rv"], ts_bar, ts_bar, as_of=t2)
+        call_args = mock_pool.fetch.call_args
+        assert call_args[0][3] == "v2"
+
+
+# ── Delegate tests ───────────────────────────────────────────────────────
+
+
+class TestStoreDelegates:
+    """list_versions and latest_version delegate to registry."""
+
+    @pytest.mark.asyncio
+    async def test_list_versions_delegates(
+        self, store: TimescaleFeatureStore, mock_registry: AsyncMock
+    ) -> None:
+        aid = uuid4()
+        mock_registry.list_versions.return_value = []
+        result = await store.list_versions(aid, "har_rv")
+        mock_registry.list_versions.assert_awaited_once_with(aid, "har_rv")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_latest_version_delegates(
+        self, store: TimescaleFeatureStore, mock_registry: AsyncMock
+    ) -> None:
+        aid = uuid4()
+        mock_registry.latest_version.return_value = None
+        result = await store.latest_version(aid, "har_rv")
+        mock_registry.latest_version.assert_awaited_once()
+        assert result is None

--- a/tests/unit/features/test_versioning.py
+++ b/tests/unit/features/test_versioning.py
@@ -1,0 +1,186 @@
+"""Tests for features.versioning — FeatureVersion, version strings, content hashes."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import polars as pl
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from features.versioning import (
+    FeatureVersion,
+    compute_content_hash,
+    compute_version_string,
+)
+
+
+class TestFeatureVersionFrozen:
+    """FeatureVersion is an immutable frozen dataclass."""
+
+    def test_frozen_cannot_mutate(self) -> None:
+        v = FeatureVersion(
+            asset_id=uuid4(),
+            feature_name="har_rv",
+            version="har_rv-abcd1234",
+            computed_at=datetime.now(UTC),
+            content_hash="a" * 64,
+            calculator_name="har_rv",
+            calculator_params={},
+            row_count=100,
+            start_ts=datetime(2024, 1, 1, tzinfo=UTC),
+            end_ts=datetime(2024, 6, 1, tzinfo=UTC),
+        )
+        with pytest.raises(AttributeError):
+            v.feature_name = "other"  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        aid = uuid4()
+        ts = datetime.now(UTC)
+        kwargs = {
+            "asset_id": aid,
+            "feature_name": "har_rv",
+            "version": "har_rv-abcd1234",
+            "computed_at": ts,
+            "content_hash": "a" * 64,
+            "calculator_name": "har_rv",
+            "calculator_params": {},
+            "row_count": 100,
+            "start_ts": datetime(2024, 1, 1, tzinfo=UTC),
+            "end_ts": datetime(2024, 6, 1, tzinfo=UTC),
+        }
+        assert FeatureVersion(**kwargs) == FeatureVersion(**kwargs)
+
+    def test_inequality_different_version(self) -> None:
+        aid = uuid4()
+        ts = datetime.now(UTC)
+        base = {
+            "asset_id": aid,
+            "feature_name": "har_rv",
+            "computed_at": ts,
+            "content_hash": "a" * 64,
+            "calculator_name": "har_rv",
+            "calculator_params": {},
+            "row_count": 100,
+            "start_ts": datetime(2024, 1, 1, tzinfo=UTC),
+            "end_ts": datetime(2024, 6, 1, tzinfo=UTC),
+        }
+        v1 = FeatureVersion(version="har_rv-v1", **base)
+        v2 = FeatureVersion(version="har_rv-v2", **base)
+        assert v1 != v2
+
+
+class TestComputeVersionString:
+    """compute_version_string is deterministic and discriminating."""
+
+    def test_deterministic(self) -> None:
+        ts = datetime(2026, 4, 13, 15, 0, 0, tzinfo=UTC)
+        v1 = compute_version_string("har_rv", {"window": 22}, ts)
+        v2 = compute_version_string("har_rv", {"window": 22}, ts)
+        assert v1 == v2
+
+    def test_different_params_different_version(self) -> None:
+        ts = datetime(2026, 4, 13, 15, 0, 0, tzinfo=UTC)
+        v1 = compute_version_string("har_rv", {"window": 22}, ts)
+        v2 = compute_version_string("har_rv", {"window": 44}, ts)
+        assert v1 != v2
+
+    def test_different_calculator_different_version(self) -> None:
+        ts = datetime(2026, 4, 13, 15, 0, 0, tzinfo=UTC)
+        v1 = compute_version_string("har_rv", {}, ts)
+        v2 = compute_version_string("rough_vol", {}, ts)
+        assert v1 != v2
+
+    def test_different_time_different_version(self) -> None:
+        v1 = compute_version_string("har_rv", {}, datetime(2026, 1, 1, tzinfo=UTC))
+        v2 = compute_version_string("har_rv", {}, datetime(2026, 1, 2, tzinfo=UTC))
+        assert v1 != v2
+
+    def test_format_prefix(self) -> None:
+        ts = datetime(2026, 4, 13, 15, 0, 0, tzinfo=UTC)
+        v = compute_version_string("har_rv", {}, ts)
+        assert v.startswith("har_rv-")
+        assert len(v) == len("har_rv-") + 8
+
+    def test_param_order_invariant(self) -> None:
+        ts = datetime(2026, 4, 13, 15, 0, 0, tzinfo=UTC)
+        v1 = compute_version_string("har_rv", {"a": 1, "b": 2}, ts)
+        v2 = compute_version_string("har_rv", {"b": 2, "a": 1}, ts)
+        assert v1 == v2
+
+    @settings(max_examples=1000)
+    @given(
+        name=st.text(
+            min_size=1, max_size=20, alphabet=st.characters(whitelist_categories=("L", "N"))
+        ),
+        param_val=st.integers(min_value=0, max_value=10000),
+        hours_offset=st.integers(min_value=0, max_value=8760),
+    )
+    def test_hypothesis_deterministic(self, name: str, param_val: int, hours_offset: int) -> None:
+        ts = datetime(2026, 1, 1, tzinfo=UTC) + timedelta(hours=hours_offset)
+        v1 = compute_version_string(name, {"p": param_val}, ts)
+        v2 = compute_version_string(name, {"p": param_val}, ts)
+        assert v1 == v2
+
+    @settings(max_examples=1000)
+    @given(
+        param_a=st.integers(min_value=0, max_value=10000),
+        param_b=st.integers(min_value=0, max_value=10000),
+    )
+    def test_hypothesis_different_params(self, param_a: int, param_b: int) -> None:
+        from hypothesis import assume
+
+        assume(param_a != param_b)
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        v1 = compute_version_string("test", {"p": param_a}, ts)
+        v2 = compute_version_string("test", {"p": param_b}, ts)
+        assert v1 != v2
+
+
+class TestComputeContentHash:
+    """compute_content_hash produces deterministic SHA-256 digests."""
+
+    def test_deterministic(self) -> None:
+        df = pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 1, tzinfo=UTC)],
+                "value": [1.0],
+            }
+        )
+        h1 = compute_content_hash(df)
+        h2 = compute_content_hash(df)
+        assert h1 == h2
+
+    def test_different_data_different_hash(self) -> None:
+        df1 = pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 1, tzinfo=UTC)],
+                "value": [1.0],
+            }
+        )
+        df2 = pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 1, tzinfo=UTC)],
+                "value": [2.0],
+            }
+        )
+        assert compute_content_hash(df1) != compute_content_hash(df2)
+
+    def test_hash_length(self) -> None:
+        df = pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 1, tzinfo=UTC)],
+                "value": [1.0],
+            }
+        )
+        assert len(compute_content_hash(df)) == 64
+
+    def test_row_order_invariant_with_timestamp(self) -> None:
+        """DataFrame is sorted by timestamp before hashing."""
+        ts1 = datetime(2024, 1, 1, tzinfo=UTC)
+        ts2 = datetime(2024, 1, 2, tzinfo=UTC)
+        df_asc = pl.DataFrame({"timestamp": [ts1, ts2], "value": [1.0, 2.0]})
+        df_desc = pl.DataFrame({"timestamp": [ts2, ts1], "value": [2.0, 1.0]})
+        assert compute_content_hash(df_asc) == compute_content_hash(df_desc)


### PR DESCRIPTION
## Summary

- **`db/migrations/002_feature_store.sql`** — Two new hypertables: `feature_values` (versioned feature data, 30-day chunks, compression at 60 days) and `feature_versions` (immutable metadata catalog)
- **`features/versioning.py`** — `FeatureVersion` frozen dataclass + `compute_version_string()` (content-addressable `{name}-{hash8}`) + `compute_content_hash()` (SHA-256 on Polars IPC bytes)
- **`features/registry.py`** — `FeatureRegistry` asyncpg-backed catalog with `register`, `list_features`, `list_versions`, `latest_version(as_of=)`, `get`
- **`features/store/timescale.py`** — `TimescaleFeatureStore` implementing `FeatureStore` ABC (Repository pattern, Fowler 2002) with Redis TTL cache and point-in-time queries
- **`features/exceptions.py`** — `FeatureStoreError` hierarchy: `FeatureVersionExistsError`, `FeatureVersionNotFoundError`, `LookAheadViolationError`
- **`features/pipeline.py`** — `FeaturePipeline.run()` now wired: computes features on bars, persists per-calculator to store with `computed_at` for PIT semantics
- **`features/store/base.py`** — ABC extended with `asset_id: UUID` parameter (D017 — no concrete impl existed in 3.1)

## New Tables

```sql
-- feature_values: hypertable, 30-day chunks, compression at 60 days
(asset_id UUID, feature_name VARCHAR(64), version VARCHAR(40),
 timestamp TIMESTAMPTZ, value DOUBLE PRECISION, computed_at TIMESTAMPTZ)

-- feature_versions: immutable catalog (append-only)
(asset_id UUID, feature_name VARCHAR(64), version VARCHAR(40),
 computed_at TIMESTAMPTZ, content_hash VARCHAR(64), calculator_name VARCHAR(64),
 calculator_params JSONB, row_count BIGINT, start_ts TIMESTAMPTZ, end_ts TIMESTAMPTZ)
```

## Look-Ahead Bias Defense (PHASE_3_SPEC §5.1)

The `computed_at` column is the structural shield against look-ahead bias:

1. **Version resolution**: `registry.latest_version(asset_id, feature_name, as_of)` filters `WHERE computed_at <= as_of` — only versions that *existed* at query time are visible
2. **Data fetch**: `feature_values` query includes `AND computed_at <= as_of` — individual rows computed after the query point are excluded
3. **Runtime guard**: `_assert_no_lookahead()` verifies no returned row has `computed_at > as_of` (structural bug check — should never fire)
4. **Cache isolation**: Redis cache key includes `as_of`, preventing PIT cache poisoning across different query times
5. **Test coverage**: Dedicated test `test_pit_v1_before_v2` verifies that `save(v1, t1)` then `save(v2, t2)` → `load(as_of=t1)` returns v1, `load(as_of=t2)` returns v2

## Migration Path

```bash
# Apply migration in dev
python scripts/init_db.py --host localhost --port 5432 --db apex

# In CI (docker-compose.test.yml)
python scripts/init_db.py --host localhost --port 5433 --db apex_test --user apex_test --password apex_test
```

`scripts/init_db.py` is idempotent — it checks `schema_versions` and skips already-applied migrations.

## Preflight Results

| Check | Result |
|---|---|
| ruff check | 0 errors |
| ruff format | clean |
| mypy --strict features/ | 0 errors (19 files) |
| pytest tests/unit/features/ | 108 passed |
| Coverage features/ | 95.02% (gate: 85%) |
| Full unit suite | 1,367 passed (+53 new), 0 regressions |

## Decisions (D017-D019)

- **D017**: FeatureStore ABC extended with `asset_id: UUID` — multi-asset requirement, no breaking impl
- **D018**: Content-addressable versioning `{calculator}-{hash8}` — Hypothesis-verified determinism (1000 examples)
- **D019**: Redis TTL cache (300s), `as_of` in key prevents PIT cache poisoning

## Anti-patterns addressed (PHASE_3_SPEC §5)

- **§5.1 Look-Ahead Bias**: Structurally impossible via `computed_at` filtering (see above)

## Test plan

- [x] `test_versioning.py`: 14 tests — frozen dataclass, deterministic version strings (Hypothesis 1000 examples), content hash
- [x] `test_exceptions.py`: 5 tests — exception hierarchy
- [x] `test_registry.py`: 10 tests — register, list, latest_version with/without as_of, get
- [x] `test_store.py`: 14 tests — save/load round-trip, duplicate version rejection, PIT filtering, cache hit/miss, multi-feature pivot
- [x] `test_pipeline_with_store.py`: 4 tests — save per feature, augmented df, as_of passthrough, no-store error
- [x] `test_feature_store_integration.py`: 3 integration tests — tables exist, hypertable created, round-trip on TimescaleDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)