### PR TITLE
[Phase 3.5] Rough Volatility Validation (Gatheral 2018) (#91)

### DIFF
--- a/docs/claude_memory/CONTEXT.md
+++ b/docs/claude_memory/CONTEXT.md
@@ -1,7 +1,7 @@
 # APEX Project Context Snapshot
 
 **Last updated**: 2026-04-13
-**Updated by**: Session 012
+**Updated by**: Session 014
 
 ---
 
@@ -9,16 +9,16 @@
 
 | Metric | Value |
 |---|---|
-| Active Phase | Phase 3 — Feature Validation Harness (3.4 PR #111 OPEN) |
+| Active Phase | Phase 3 — Feature Validation Harness (3.5 PR #112 OPEN) |
 | Previous Phase | Phase 2 — Universal Data Infrastructure (DONE) |
-| Total tests | 1,488+ (1,433 unit + 55 integration) |
-| Production LOC | ~34,500 |
-| Test LOC | ~21,500 |
-| mypy strict | 0 errors (378 files) |
+| Total tests | 1,514+ (1,491 unit + 55 integration) |
+| Production LOC | ~35,000 |
+| Test LOC | ~22,200 |
+| mypy strict | 0 errors (381 files) |
 | Services scaffolded | 10/10 (S01-S10) |
 | S01 fully implemented | Yes (78 files, 9,583 LOC) |
 | ADRs accepted | 10 (+ ADR-0004 Feature Validation Methodology) |
-| features/ coverage | 92.57% (174 tests) |
+| features/ coverage | 92.62% (207 tests) |
 
 ## Audit Status
 

--- a/docs/claude_memory/DECISIONS.md
+++ b/docs/claude_memory/DECISIONS.md
@@ -655,3 +655,41 @@ Every future calculator with period aggregates must include a test equivalent to
 
 - PR #111 Copilot review comment #1
 - PHASE_3_SPEC §5.1 Look-Ahead Bias
+
+---
+
+## D028 — Forecast-like Columns Safe to Broadcast in Intraday Mode (2026-04-13)
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Session | 015 |
+| Decision | Output columns computed from daily_series[:t] (strict past, excluding current day t) are forecast-like and safe to broadcast to all intraday bars of day t. Day-close-only emission (D027) applies ONLY to columns computed from daily_series[:t+1] or full-day aggregates including day t. |
+| Status | ACCEPTED |
+
+### Context
+
+PR #112 Phase 3.5 Rough Volatility. Initial implementation claimed "all 6 columns depend on current day's RV" (justifying day-close emission per D027), but the code actually used `daily_rv[:t]` (prior days only). Copilot caught the contradiction between code and docstring.
+
+### Resolution
+
+The code (`daily_rv[:t]`) was correct — all 6 Rough Vol columns are forecast-like estimates that use only prior days' statistics. The docstring and PR description were wrong. Switched to broadcast-to-all-intraday-bars in 5m mode (like HAR-RV's `har_rv_forecast`).
+
+### Rule refinement for 3.6-3.8
+
+When implementing a calculator with intraday (5m) mode, explicitly classify each output column:
+- **Forecast-like** (uses `series[:t]`, strict past) → safe broadcast to all bars
+- **Realization** (uses `series[:t+1]` or current-period aggregate) → day-close-only per D027
+
+Document the classification in the class docstring. Verify with a "different-intraday-same-past" test that forecast-like columns are invariant to current-day intraday data.
+
+### Implication
+
+- **Rough Vol (3.5)**: all 6 columns are forecast-like → broadcast
+- **HAR-RV (3.4)**: forecast is forecast-like (broadcast); residual and signal are realization-like (day-close) because residual requires current day's realized_rv
+
+### References
+
+- D027 (original rule, refined here)
+- PR #112 Copilot review comment #3
+- PHASE_3_SPEC §5.1 Look-Ahead Bias

--- a/docs/claude_memory/PHASE_3_NOTES.md
+++ b/docs/claude_memory/PHASE_3_NOTES.md
@@ -72,3 +72,7 @@
 - D027 applied to all 6 rough vol columns (all are realization, unlike HAR-RV forecast)
 - VR sanity verified: VR≈1 on random walk, VR>1 on AR(1) momentum series
 - 207 tests on features/, 1,491 total tests (0 regressions)
+- D028: Forecast-like columns (series[:t]) safe to broadcast in 5m mode; realization columns (series[:t+1]) day-close only (D027)
+- 3.5 hotfix: all 6 rough vol columns reclassified forecast-like → broadcast. rough_size_adjustment renamed rough_size_multiplier (raw S07 output)
+- For 3.6-3.8: each calculator must explicitly classify output columns (forecast-like vs realization) in docstring
+- 209 tests on features/, 1,493 total tests (0 regressions after hotfix)

--- a/docs/claude_memory/PHASE_3_NOTES.md
+++ b/docs/claude_memory/PHASE_3_NOTES.md
@@ -14,7 +14,7 @@
 | 3.2 Feature Store | COMPLETE | PR #109 merged |
 | 3.3 IC Measurement | COMPLETE | PR #110 merged |
 | 3.4 HAR-RV | IN_PROGRESS | PR #111 open — 20 tests, 91% coverage |
-| 3.5 Rough Vol | PENDING | S07 estimate_hurst_from_vol() ready |
+| 3.5 Rough Vol | IN_PROGRESS | PR #112 open — 23 tests, 94% coverage |
 | 3.6 OFI | PENDING | S02 ofi() ready |
 | 3.7 CVD + Kyle | PENDING | S02 cvd(), kyle_lambda() ready |
 | 3.8 GEX | PENDING | Risk: options data availability |
@@ -29,7 +29,7 @@
 | Feature | IC (BTC) | IC (ETH) | IC (SPY) | IC (QQQ) | IC_IR | Decision |
 |---|---|---|---|---|---|---|
 | HAR-RV | synth | synth | synth | synth | synth | Synthetic validated — real data pending Phase 5 |
-| Rough Vol | — | — | — | — | — | — |
+| Rough Vol | synth | synth | synth | synth | synth | Synthetic validated — real data pending Phase 5 |
 | OFI | — | — | — | — | — | — |
 | CVD | — | — | — | — | — | — |
 | Kyle Lambda | — | — | — | — | — | — |
@@ -68,3 +68,7 @@
 - D027: Intraday aggregate features emit realization columns at period-close only (3.5-3.8 gatekeeper)
 - 5m mode look-ahead fix: residual/signal only on last bar of each day (forecast safe to broadcast)
 - Timestamp monotonicity validated in compute() — unsorted input raises ValueError
+- RoughVolCalculator: wraps S07 estimate_hurst_from_vol + variance_ratio_test (D026 wrapper)
+- D027 applied to all 6 rough vol columns (all are realization, unlike HAR-RV forecast)
+- VR sanity verified: VR≈1 on random walk, VR>1 on AR(1) momentum series
+- 207 tests on features/, 1,491 total tests (0 regressions)

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -669,3 +669,45 @@ Each entry follows the template in `templates/SESSION_TEMPLATE.md`.
 
 - Await Copilot review on PR #112
 - Phase 3.6 OFI after merge
+
+---
+
+## Session 015 — 2026-04-13
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Mission | PR #112 Copilot review hotfix — PIT semantic + size_multiplier bugs |
+| Agent Model | Claude Opus 4.6 |
+| Duration | ~30 min |
+
+### Decisions Made
+
+1. D028: Forecast-like columns (using `series[:t]`) are safe to broadcast in intraday mode. Day-close-only (D027) applies only to realization columns.
+2. All 6 Rough Vol columns reclassified as forecast-like → broadcast to all intraday bars.
+3. `rough_size_adjustment` renamed to `rough_size_multiplier` — raw S07 output, no clamp.
+
+### What Changed
+
+- MODIFIED: `features/calculators/rough_vol.py` — PIT fix (broadcast all 6 cols), size_multiplier rename+unclamp, version 1.0.0, log-return comment
+- MODIFIED: `tests/unit/features/calculators/test_rough_vol.py` — D028 tests replace D027, size_multiplier tests, 25 tests total
+
+### Key Fixes
+
+- **Bug #1 PIT semantic**: Docstring claimed "depends on current day's RV" but code used `daily_rv[:t]` (prior days only). Contradiction resolved: all 6 columns are forecast-like → broadcast.
+- **Bug #2 size_adjustment constant**: `max(0, min(1, size_adjustment))` clamped all S07 multipliers (1.0-1.15) to 1.0 → constant column → IC=0. Fixed: expose raw multiplier.
+- **D028 introduced**: Explicit classification of forecast-like vs realization columns required for all intraday-mode calculators.
+
+### Quality Gates
+
+- ruff check: clean
+- ruff format: clean
+- mypy --strict: 0 errors (381 files)
+- rough_vol.py coverage: 93%
+- features/ coverage: 92.55% (> 85% gate)
+- Full test suite: 1,493 passed, 0 regressions
+
+### Next Steps
+
+- Await Copilot re-review on PR #112
+- Phase 3.6 OFI after merge

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -623,3 +623,49 @@ Each entry follows the template in `templates/SESSION_TEMPLATE.md`.
 
 - Await Copilot re-review on PR #111
 - Phase 3.5-3.8 after merge (D027 is gatekeeper template)
+
+---
+
+## Session 014 — 2026-04-13
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Mission | Phase 3.5 — Rough Volatility Validation (Gatheral 2018) (#91) |
+| Agent Model | Claude Opus 4.6 |
+| Duration | ~1 hour |
+
+### Decisions Made
+
+1. No new decisions required — D024-D027 cover all design choices
+2. `vr_lag=5` follows Lo-MacKinlay (1988) standard weekly lag convention
+3. All 6 output columns classified as realization (day-close-only in 5m mode), unlike HAR-RV where forecast was safe broadcast
+
+### What Changed
+
+- NEW: `features/calculators/rough_vol.py` — RoughVolCalculator (~400 LOC)
+- NEW: `features/validation/rough_vol_report.py` — RoughVolValidationReport (~95 LOC)
+- MODIFIED: `features/calculators/__init__.py` — added RoughVolCalculator export
+- NEW: `tests/unit/features/calculators/test_rough_vol.py` — 23 tests (~690 LOC)
+
+### Pattern Reuse from HAR-RV
+
+- Expanding-window loop (D024): identical structure, 2 S07 calls per iteration
+- tanh normalization (D025): scalping_score centers on rolling mean, vr_signal on VR=1
+- Strict S07 wrapper (D026): wraps estimate_hurst_from_vol + variance_ratio_test
+- D027 day-close emission: all 6 columns (vs HAR-RV where forecast was safe)
+- Test structure: same categories, adapted for 6 output columns
+
+### Quality Gates
+
+- ruff check: clean
+- ruff format: clean
+- mypy --strict: 0 errors (381 files)
+- rough_vol.py coverage: 94%
+- features/ coverage: 92.62% (> 85% gate)
+- Full test suite: 1,491 passed, 0 regressions
+
+### Next Steps
+
+- Await Copilot review on PR #112
+- Phase 3.6 OFI after merge

--- a/features/calculators/__init__.py
+++ b/features/calculators/__init__.py
@@ -9,5 +9,6 @@ Reference:
 """
 
 from features.calculators.har_rv import HARRVCalculator
+from features.calculators.rough_vol import RoughVolCalculator
 
-__all__ = ["HARRVCalculator"]
+__all__ = ["HARRVCalculator", "RoughVolCalculator"]

--- a/features/calculators/rough_vol.py
+++ b/features/calculators/rough_vol.py
@@ -8,7 +8,9 @@ Output columns:
     rough_hurst: Hurst exponent estimate (NaN during warm-up).
     rough_is_rough: 1.0 if H < 0.3 else 0.0 (Gatheral 2018 regime).
     rough_scalping_score: tanh-normalized scalping edge in [-1, +1].
-    rough_size_adjustment: volatility-adaptive sizing in [0, 1].
+    rough_size_multiplier: Volatility-adaptive sizing multiplier
+        (typically in [0.5, 2.0]). Raw S07 analyzer output — NOT
+        normalized to [0, 1] or [-1, +1]. Multiplicative factor.
     variance_ratio: Lo-MacKinlay VR(q) statistic (1.0 = random walk).
     vr_signal: tanh-normalized direction signal in [-1, +1].
         VR > 1 -> momentum (positive), VR < 1 -> mean-reversion (negative).
@@ -17,10 +19,16 @@ Look-ahead defense:
     Every row t's values are fit on data [0, t-1] only. Expanding
     window refit. O(n^2) by design (same trade-off as HAR-RV, D024).
 
-D027 intraday contract (bar_frequency="5m"):
-    All 6 output columns depend on daily realized variance aggregates.
-    They are emitted ONLY on the last bar of each day. Earlier intraday
-    bars stay NaN to prevent look-ahead within the day.
+D028 intraday contract (bar_frequency="5m"):
+    All 6 output columns are forecast-like: they use daily_rv[0:t]
+    (prior days only, excluding current day t) and are therefore
+    safe to broadcast to all intraday bars of day t. No information
+    from later bars of the same day is used.
+
+    This differs from HAR-RV where residual/signal required full-day
+    RV (day-close-only emission per D027). Rough Vol does NOT compute
+    a per-day residual — all outputs are estimates based purely on
+    prior days' statistics.
 
 Reference:
     Gatheral, J., Jaisson, T. & Rosenbaum, M. (2018). "Volatility is
@@ -51,13 +59,11 @@ class RoughVolCalculator(FeatureCalculator):
     variance_ratio_test() with expanding-window refit to prevent
     look-ahead bias.
 
-    Output contract (D027):
-        All 6 output columns depend on daily realized variance aggregates.
-        In ``bar_frequency="5m"`` mode, they are emitted ONLY on the last
-        bar of each day. Unlike HAR-RV where forecast is safe to broadcast,
-        here ALL columns depend on the current day's realized vol series
-        (Hurst needs the full daily RV up to t, VR needs the full daily
-        log-return series up to t). NaN elsewhere.
+    Output contract (D028):
+        All 6 output columns are forecast-like: they use daily_rv[0:t]
+        (prior days only, excluding current day t) and are therefore
+        safe to broadcast to all intraday bars of day t in 5m mode.
+        No information from later bars of the same day is used.
 
     Look-ahead defense (D024):
         Expanding window — values at day t are computed on data [0, t-1].
@@ -82,7 +88,7 @@ class RoughVolCalculator(FeatureCalculator):
         "rough_hurst",
         "rough_is_rough",
         "rough_scalping_score",
-        "rough_size_adjustment",
+        "rough_size_multiplier",
         "variance_ratio",
         "vr_signal",
     ]
@@ -129,7 +135,7 @@ class RoughVolCalculator(FeatureCalculator):
 
     @property
     def version(self) -> str:
-        return "v1.0"
+        return "1.0.0"
 
     def required_columns(self) -> list[str]:
         return list(self._REQUIRED_COLUMNS)
@@ -173,7 +179,7 @@ class RoughVolCalculator(FeatureCalculator):
         day_hurst = np.full(n_days, np.nan)
         day_is_rough = np.full(n_days, np.nan)
         day_edge_score = np.full(n_days, np.nan)
-        day_size_adj = np.full(n_days, np.nan)
+        day_size_mult = np.full(n_days, np.nan)
         day_vr = np.full(n_days, np.nan)
 
         for t in range(self._warm_up_days, n_days):
@@ -185,7 +191,7 @@ class RoughVolCalculator(FeatureCalculator):
             day_hurst[t] = signal.hurst_exponent
             day_is_rough[t] = 1.0 if signal.is_rough else 0.0
             day_edge_score[t] = signal.scalping_edge_score
-            day_size_adj[t] = max(0.0, min(1.0, signal.size_adjustment))
+            day_size_mult[t] = float(signal.size_adjustment)
 
             # VR from log-return series [0, t) — expanding window.
             lr_window = daily_log_returns[:t].tolist()
@@ -200,31 +206,20 @@ class RoughVolCalculator(FeatureCalculator):
         out_hurst = np.full(n_rows, np.nan)
         out_is_rough = np.full(n_rows, np.nan)
         out_scalping = np.full(n_rows, np.nan)
-        out_size_adj = np.full(n_rows, np.nan)
+        out_size_mult = np.full(n_rows, np.nan)
         out_vr = np.full(n_rows, np.nan)
         out_vr_sig = np.full(n_rows, np.nan)
 
-        # D027: In 5m mode, ALL 6 columns are day-close-only because
-        # they all depend on the daily RV aggregate (unlike HAR-RV where
-        # forecast depends only on prior days).
-        day_last_row = np.full(n_days, -1, dtype=np.int64)
-        for row_idx in range(n_rows):
-            day_idx = row_to_day[row_idx]
-            if day_idx >= 0:
-                day_last_row[day_idx] = row_idx
-
-        intraday_last_bar_only = self._bar_frequency == "5m"
-
+        # D028: All 6 columns are forecast-like (use daily_rv[:t], prior
+        # days only). Safe to broadcast to all intraday bars of day t.
         for row_idx in range(n_rows):
             day_idx = row_to_day[row_idx]
             if day_idx < 0:
                 continue
-            if intraday_last_bar_only and row_idx != day_last_row[day_idx]:
-                continue
             out_hurst[row_idx] = day_hurst[day_idx]
             out_is_rough[row_idx] = day_is_rough[day_idx]
             out_scalping[row_idx] = day_scalping_score[day_idx]
-            out_size_adj[row_idx] = day_size_adj[day_idx]
+            out_size_mult[row_idx] = day_size_mult[day_idx]
             out_vr[row_idx] = day_vr[day_idx]
             out_vr_sig[row_idx] = day_vr_signal[day_idx]
 
@@ -241,7 +236,7 @@ class RoughVolCalculator(FeatureCalculator):
             pl.Series("rough_hurst", out_hurst),
             pl.Series("rough_is_rough", out_is_rough),
             pl.Series("rough_scalping_score", out_scalping),
-            pl.Series("rough_size_adjustment", out_size_adj),
+            pl.Series("rough_size_multiplier", out_size_mult),
             pl.Series("variance_ratio", out_vr),
             pl.Series("vr_signal", out_vr_sig),
         )
@@ -323,7 +318,8 @@ class RoughVolCalculator(FeatureCalculator):
             intraday_returns = np.log(day_closes[1:] / day_closes[:-1])
             rv = float(np.sum(intraday_returns**2))
             daily_rv_list.append(rv)
-            # Daily log-return = log(last_close / first_open) ≈ sum of intraday.
+            # Daily log-return from close-to-close intraday bars:
+            # sum(log(C_t / C_{t-1})) = log(last_close / first_close).
             daily_lr_list.append(float(np.sum(intraday_returns)))
 
         daily_rv = np.array(daily_rv_list, dtype=np.float64)

--- a/features/calculators/rough_vol.py
+++ b/features/calculators/rough_vol.py
@@ -1,0 +1,396 @@
+"""Rough Volatility feature calculator (Gatheral, Jaisson & Rosenbaum 2018).
+
+Wraps S07 RoughVolAnalyzer.estimate_hurst_from_vol() and
+variance_ratio_test() with expanding-window refit to prevent
+look-ahead bias.
+
+Output columns:
+    rough_hurst: Hurst exponent estimate (NaN during warm-up).
+    rough_is_rough: 1.0 if H < 0.3 else 0.0 (Gatheral 2018 regime).
+    rough_scalping_score: tanh-normalized scalping edge in [-1, +1].
+    rough_size_adjustment: volatility-adaptive sizing in [0, 1].
+    variance_ratio: Lo-MacKinlay VR(q) statistic (1.0 = random walk).
+    vr_signal: tanh-normalized direction signal in [-1, +1].
+        VR > 1 -> momentum (positive), VR < 1 -> mean-reversion (negative).
+
+Look-ahead defense:
+    Every row t's values are fit on data [0, t-1] only. Expanding
+    window refit. O(n^2) by design (same trade-off as HAR-RV, D024).
+
+D027 intraday contract (bar_frequency="5m"):
+    All 6 output columns depend on daily realized variance aggregates.
+    They are emitted ONLY on the last bar of each day. Earlier intraday
+    bars stay NaN to prevent look-ahead within the day.
+
+Reference:
+    Gatheral, J., Jaisson, T. & Rosenbaum, M. (2018). "Volatility is
+    rough". Quantitative Finance, 18(6), 933-949.
+    Lo, A. W. & MacKinlay, A. C. (1988). "Stock market prices do not
+    follow random walks". Review of Financial Studies, 1(1), 41-66.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+import numpy as np
+import numpy.typing as npt
+import polars as pl
+import structlog
+
+from features.base import FeatureCalculator
+from services.s07_quant_analytics.rough_vol import RoughVolAnalyzer
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+
+class RoughVolCalculator(FeatureCalculator):
+    """Rough Volatility calculator (Gatheral, Jaisson & Rosenbaum 2018).
+
+    Wraps S07 RoughVolAnalyzer.estimate_hurst_from_vol() and
+    variance_ratio_test() with expanding-window refit to prevent
+    look-ahead bias.
+
+    Output contract (D027):
+        All 6 output columns depend on daily realized variance aggregates.
+        In ``bar_frequency="5m"`` mode, they are emitted ONLY on the last
+        bar of each day. Unlike HAR-RV where forecast is safe to broadcast,
+        here ALL columns depend on the current day's realized vol series
+        (Hurst needs the full daily RV up to t, VR needs the full daily
+        log-return series up to t). NaN elsewhere.
+
+    Look-ahead defense (D024):
+        Expanding window — values at day t are computed on data [0, t-1].
+        O(n^2) by design.
+
+    Reference:
+        Gatheral, J., Jaisson, T. & Rosenbaum, M. (2018). "Volatility is
+        rough". Quantitative Finance, 18(6), 933-949.
+        Lo, A. W. & MacKinlay, A. C. (1988). "Stock market prices do not
+        follow random walks". Review of Financial Studies, 1(1), 41-66.
+    """
+
+    _REQUIRED_COLUMNS: ClassVar[list[str]] = [
+        "timestamp",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    ]
+    _OUTPUT_COLUMNS: ClassVar[list[str]] = [
+        "rough_hurst",
+        "rough_is_rough",
+        "rough_scalping_score",
+        "rough_size_adjustment",
+        "variance_ratio",
+        "vr_signal",
+    ]
+
+    def __init__(
+        self,
+        bar_frequency: Literal["5m", "1d"] = "1d",
+        warm_up_days: int = 60,
+        vr_lag: int = 5,
+        scalping_score_k: float = 3.0,
+        vr_signal_k: float = 3.0,
+        signal_std_window: int = 60,
+    ) -> None:
+        """Initialize RoughVolCalculator.
+
+        Args:
+            bar_frequency: Input bar granularity. ``"5m"`` bars are
+                aggregated to daily RV before Hurst/VR fitting.
+            warm_up_days: Minimum number of daily RV observations
+                before the first output is produced. Must be >= 30.
+            vr_lag: Lo-MacKinlay q parameter (e.g. 5 for weekly).
+            scalping_score_k: tanh scale for scalping score (D025).
+            vr_signal_k: tanh scale for VR signal centered on 1.0.
+            signal_std_window: Rolling window for adaptive std scaling.
+        """
+        if warm_up_days < 30:
+            raise ValueError(
+                f"warm_up_days must be >= 30 for stable Hurst estimation, got {warm_up_days}"
+            )
+        self._bar_frequency = bar_frequency
+        self._warm_up_days = warm_up_days
+        self._vr_lag = vr_lag
+        self._scalping_score_k = scalping_score_k
+        self._vr_signal_k = vr_signal_k
+        self._signal_std_window = signal_std_window
+        self._analyzer = RoughVolAnalyzer()
+
+    # ------------------------------------------------------------------
+    # FeatureCalculator ABC
+    # ------------------------------------------------------------------
+
+    def name(self) -> str:
+        return "rough_vol"
+
+    @property
+    def version(self) -> str:
+        return "v1.0"
+
+    def required_columns(self) -> list[str]:
+        return list(self._REQUIRED_COLUMNS)
+
+    def output_columns(self) -> list[str]:
+        return list(self._OUTPUT_COLUMNS)
+
+    def compute(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Compute Rough Vol and Variance Ratio columns.
+
+        Expanding-window loop ensures values at day *t* use only data
+        [0, t-1]. O(n^2) by design.
+
+        Args:
+            df: Input bars with at least :meth:`required_columns`.
+
+        Returns:
+            New DataFrame with 6 additional output columns.
+        """
+        self.validate_input(df)
+        n_rows = len(df)
+
+        # Monotonic timestamp invariant (D027 prerequisite).
+        if n_rows > 1 and not df["timestamp"].is_sorted():
+            raise ValueError(
+                "RoughVolCalculator.compute() requires ascending-sorted "
+                "'timestamp' to preserve look-ahead safety. "
+                "Call df.sort('timestamp') before."
+            )
+
+        if n_rows == 0:
+            return df.with_columns(
+                *[pl.Series(col, [], dtype=pl.Float64) for col in self._OUTPUT_COLUMNS]
+            )
+
+        # Step 1: Build daily RV series and row-to-day mapping.
+        daily_rv, daily_log_returns, row_to_day = self._build_daily_series(df)
+        n_days = len(daily_rv)
+
+        # Step 2: Expanding-window Hurst + VR computation (look-ahead safe).
+        day_hurst = np.full(n_days, np.nan)
+        day_is_rough = np.full(n_days, np.nan)
+        day_edge_score = np.full(n_days, np.nan)
+        day_size_adj = np.full(n_days, np.nan)
+        day_vr = np.full(n_days, np.nan)
+
+        for t in range(self._warm_up_days, n_days):
+            # Hurst from realized vol series [0, t) — expanding window.
+            rv_window = daily_rv[:t].tolist()
+            # Convert RV to annualized vol for estimate_hurst_from_vol.
+            vol_window = [float(np.sqrt(max(v, 0.0)) * np.sqrt(252)) for v in rv_window]
+            signal = self._analyzer.estimate_hurst_from_vol(vol_window)
+            day_hurst[t] = signal.hurst_exponent
+            day_is_rough[t] = 1.0 if signal.is_rough else 0.0
+            day_edge_score[t] = signal.scalping_edge_score
+            day_size_adj[t] = max(0.0, min(1.0, signal.size_adjustment))
+
+            # VR from log-return series [0, t) — expanding window.
+            lr_window = daily_log_returns[:t].tolist()
+            vr_result = self._analyzer.variance_ratio_test(lr_window, q=self._vr_lag)
+            day_vr[t] = vr_result.vr_q
+
+        # Step 3: Normalize scalping score and VR signal via tanh (D025).
+        day_scalping_score = self._compute_scalping_signal(day_edge_score)
+        day_vr_signal = self._compute_vr_signal(day_vr)
+
+        # Step 4: Map daily arrays to bar-level rows.
+        out_hurst = np.full(n_rows, np.nan)
+        out_is_rough = np.full(n_rows, np.nan)
+        out_scalping = np.full(n_rows, np.nan)
+        out_size_adj = np.full(n_rows, np.nan)
+        out_vr = np.full(n_rows, np.nan)
+        out_vr_sig = np.full(n_rows, np.nan)
+
+        # D027: In 5m mode, ALL 6 columns are day-close-only because
+        # they all depend on the daily RV aggregate (unlike HAR-RV where
+        # forecast depends only on prior days).
+        day_last_row = np.full(n_days, -1, dtype=np.int64)
+        for row_idx in range(n_rows):
+            day_idx = row_to_day[row_idx]
+            if day_idx >= 0:
+                day_last_row[day_idx] = row_idx
+
+        intraday_last_bar_only = self._bar_frequency == "5m"
+
+        for row_idx in range(n_rows):
+            day_idx = row_to_day[row_idx]
+            if day_idx < 0:
+                continue
+            if intraday_last_bar_only and row_idx != day_last_row[day_idx]:
+                continue
+            out_hurst[row_idx] = day_hurst[day_idx]
+            out_is_rough[row_idx] = day_is_rough[day_idx]
+            out_scalping[row_idx] = day_scalping_score[day_idx]
+            out_size_adj[row_idx] = day_size_adj[day_idx]
+            out_vr[row_idx] = day_vr[day_idx]
+            out_vr_sig[row_idx] = day_vr_signal[day_idx]
+
+        logger.info(
+            "rough_vol.compute.complete",
+            n_rows=n_rows,
+            n_days=n_days,
+            warm_up=self._warm_up_days,
+            bar_frequency=self._bar_frequency,
+            outputs_produced=int(np.sum(~np.isnan(out_hurst))),
+        )
+
+        return df.with_columns(
+            pl.Series("rough_hurst", out_hurst),
+            pl.Series("rough_is_rough", out_is_rough),
+            pl.Series("rough_scalping_score", out_scalping),
+            pl.Series("rough_size_adjustment", out_size_adj),
+            pl.Series("variance_ratio", out_vr),
+            pl.Series("vr_signal", out_vr_sig),
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _build_daily_series(
+        self, df: pl.DataFrame
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], list[int]]:
+        """Build daily RV and log-return series with row-to-day mapping.
+
+        Returns:
+            daily_rv: 1-D array of daily realized variance.
+            daily_log_returns: 1-D array of daily log-returns.
+            row_to_day: List mapping each row to a day index (-1 if none).
+        """
+        if self._bar_frequency == "5m":
+            return self._build_from_5m(df)
+        return self._build_from_1d(df)
+
+    def _build_from_1d(
+        self, df: pl.DataFrame
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], list[int]]:
+        """Daily series from 1d bars: squared log-return as RV proxy."""
+        closes = df["close"].to_numpy().astype(np.float64)
+        n = len(closes)
+
+        if n < 2:
+            return (
+                np.array([], dtype=np.float64),
+                np.array([], dtype=np.float64),
+                [-1] * n,
+            )
+
+        log_returns = np.log(closes[1:] / closes[:-1])
+        daily_rv = log_returns**2
+
+        row_to_day: list[int] = [-1]  # Row 0 has no prior close.
+        for i in range(len(daily_rv)):
+            row_to_day.append(i)
+
+        return daily_rv, log_returns, row_to_day
+
+    def _build_from_5m(
+        self, df: pl.DataFrame
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], list[int]]:
+        """Daily series from 5m bars: sum of squared intraday log-returns."""
+        timestamps = df["timestamp"]
+        closes = df["close"].to_numpy().astype(np.float64)
+
+        if timestamps.dtype == pl.Utf8:
+            dates = timestamps.str.slice(0, 10).to_list()
+        else:
+            dates = [str(t)[:10] for t in timestamps.to_list()]
+
+        unique_dates: list[str] = []
+        date_set: set[str] = set()
+        for d in dates:
+            if d not in date_set:
+                unique_dates.append(d)
+                date_set.add(d)
+
+        date_to_idx: dict[str, int] = {d: i for i, d in enumerate(unique_dates)}
+
+        day_rows: list[list[int]] = [[] for _ in range(len(unique_dates))]
+        for row_idx, d in enumerate(dates):
+            day_rows[date_to_idx[d]].append(row_idx)
+
+        daily_rv_list: list[float] = []
+        daily_lr_list: list[float] = []
+        for rows in day_rows:
+            if len(rows) < 2:
+                daily_rv_list.append(0.0)
+                daily_lr_list.append(0.0)
+                continue
+            day_closes = closes[rows]
+            intraday_returns = np.log(day_closes[1:] / day_closes[:-1])
+            rv = float(np.sum(intraday_returns**2))
+            daily_rv_list.append(rv)
+            # Daily log-return = log(last_close / first_open) ≈ sum of intraday.
+            daily_lr_list.append(float(np.sum(intraday_returns)))
+
+        daily_rv = np.array(daily_rv_list, dtype=np.float64)
+        daily_lr = np.array(daily_lr_list, dtype=np.float64)
+
+        row_to_day: list[int] = [date_to_idx[d] for d in dates]
+        return daily_rv, daily_lr, row_to_day
+
+    def _compute_scalping_signal(
+        self, day_edge_scores: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        """Normalize edge scores to [-1, +1] via tanh with adaptive std (D025).
+
+        The raw edge score from S07 is in [0, 1]. We center it around
+        its expanding/rolling mean and normalize via tanh.
+        """
+        n = len(day_edge_scores)
+        signals = np.full(n, np.nan)
+        history: list[float] = []
+
+        for t in range(n):
+            if np.isnan(day_edge_scores[t]):
+                continue
+            history.append(float(day_edge_scores[t]))
+            if len(history) < 2:
+                signals[t] = 0.0
+                continue
+
+            window = history[-self._signal_std_window :]
+            mean = float(np.mean(window))
+            std = float(np.std(window, ddof=1))
+            scale = self._scalping_score_k * std
+
+            if scale < 1e-15:
+                signals[t] = 0.0
+            else:
+                signals[t] = float(np.tanh((day_edge_scores[t] - mean) / scale))
+
+        return signals
+
+    def _compute_vr_signal(self, day_vr: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        """Normalize VR around 1.0 to [-1, +1] via tanh (D025).
+
+        VR > 1 → momentum (positive signal).
+        VR < 1 → mean-reversion (negative signal).
+        VR = 1 → random walk (zero signal).
+        """
+        n = len(day_vr)
+        signals = np.full(n, np.nan)
+        history: list[float] = []
+
+        for t in range(n):
+            if np.isnan(day_vr[t]):
+                continue
+            history.append(float(day_vr[t]))
+            if len(history) < 2:
+                signals[t] = 0.0
+                continue
+
+            window = history[-self._signal_std_window :]
+            std = float(np.std(window, ddof=1))
+            scale = self._vr_signal_k * std
+
+            if scale < 1e-15:
+                signals[t] = 0.0
+            else:
+                # Center on 1.0 (random walk baseline).
+                signals[t] = float(np.tanh((day_vr[t] - 1.0) / scale))
+
+        return signals

--- a/features/validation/rough_vol_report.py
+++ b/features/validation/rough_vol_report.py
@@ -1,0 +1,91 @@
+"""Rough Vol validation report — Phase 3.5 synthetic-data scope.
+
+Thin wrapper over :class:`ICResult` that formats Rough Vol-specific
+validation output. Schema-compatible with HARRVValidationReport
+(same summary() keys, same to_markdown() format).
+
+Reference:
+    PHASE_3_SPEC §2.5 success metrics.
+    ADR-0004 (``docs/adr/ADR-0004-feature-validation-methodology.md``).
+    Gatheral, J., Jaisson, T. & Rosenbaum, M. (2018). "Volatility is
+    rough". Quantitative Finance, 18(6), 933-949.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+
+from features.ic.base import ICResult
+
+
+@dataclass(frozen=True)
+class RoughVolValidationReport:
+    """Validation report for Rough Vol on synthetic and (later) real data.
+
+    In Phase 3.5, this produces IC results on synthetic fBm/GBM data.
+    Real BTC/ETH/SPY/QQQ validation is scheduled for Phase 5.
+
+    Schema compatibility with HARRVValidationReport:
+    - summary() returns the same 4 keys
+    - to_markdown() produces the same table format
+    - is_significant=None renders as ``"n/a"`` (not ``"no"``)
+
+    Reference:
+        PHASE_3_SPEC §2.5.
+        Gatheral et al. (2018). Quantitative Finance 18(6).
+    """
+
+    ic_results: tuple[ICResult, ...]
+    """IC measurement results (one per horizon or asset)."""
+
+    title: str = "Rough Vol Validation (Gatheral 2018)"
+    """Report title."""
+
+    def to_json(self) -> str:
+        """Serialize the report to a JSON string."""
+        payload = {
+            "title": self.title,
+            "results": [asdict(r) for r in self.ic_results],
+            "summary": self.summary(),
+        }
+        return json.dumps(payload, indent=2, default=str)
+
+    def to_markdown(self) -> str:
+        """Render a concise Markdown summary table."""
+        lines: list[str] = [
+            f"# {self.title}",
+            "",
+            "| Feature | Horizon | IC | IC_IR | p-value | Significant |",
+            "|---------|--------:|----:|------:|--------:|:-----------:|",
+        ]
+        for r in self.ic_results:
+            if r.is_significant is None:
+                sig = "n/a"
+            else:
+                sig = "yes" if r.is_significant else "no"
+            name = r.feature_name if r.feature_name is not None else "rough_vol"
+            horizon = r.horizon_bars if r.horizon_bars is not None else 1
+            lines.append(
+                f"| {name} | {horizon} | {r.ic:+.4f} | {r.ic_ir:.3f} | {r.p_value:.4f} | {sig} |"
+            )
+        lines.append("")
+        return "\n".join(lines)
+
+    def summary(self) -> dict[str, object]:
+        """Return aggregate metrics for quick inspection."""
+        if not self.ic_results:
+            return {
+                "n_results": 0,
+                "mean_ic": 0.0,
+                "mean_ic_ir": 0.0,
+                "any_significant": False,
+            }
+        ics = [r.ic for r in self.ic_results]
+        ic_irs = [r.ic_ir for r in self.ic_results]
+        return {
+            "n_results": len(self.ic_results),
+            "mean_ic": sum(ics) / len(ics),
+            "mean_ic_ir": sum(ic_irs) / len(ic_irs),
+            "any_significant": any(r.is_significant for r in self.ic_results),
+        }

--- a/tests/unit/features/calculators/test_rough_vol.py
+++ b/tests/unit/features/calculators/test_rough_vol.py
@@ -1,0 +1,695 @@
+"""Unit tests for RoughVolCalculator (Phase 3.5).
+
+22 tests covering ABC conformity, correctness, Variance Ratio sanity,
+look-ahead defense, D027 compliance, edge cases, integration with
+ValidationPipeline, report schema, and version.
+
+Reference:
+    Gatheral, J., Jaisson, T. & Rosenbaum, M. (2018). "Volatility is
+    rough". Quantitative Finance, 18(6), 933-949.
+    Lo, A. W. & MacKinlay, A. C. (1988). "Stock market prices do not
+    follow random walks". Review of Financial Studies, 1(1), 41-66.
+    ADR-0004 (feature validation methodology).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from features.calculators.rough_vol import RoughVolCalculator
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_daily_bars(n_days: int, seed: int = 42) -> pl.DataFrame:
+    """Generate *n_days* synthetic daily OHLCV bars (GBM)."""
+    rng = np.random.default_rng(seed)
+    base_time = datetime(2020, 1, 1, tzinfo=UTC)
+    price = 100.0
+
+    timestamps: list[datetime] = []
+    opens: list[float] = []
+    highs: list[float] = []
+    lows: list[float] = []
+    closes: list[float] = []
+    volumes: list[float] = []
+
+    for i in range(n_days):
+        ts = base_time + timedelta(days=i)
+        ret = 0.0005 + 0.02 * rng.standard_normal()
+        if rng.random() < 0.05:
+            ret += rng.choice([-1, 1]) * 0.02 * 3
+        o = price
+        c = price * np.exp(ret)
+        hi = max(o, c) * (1 + abs(rng.standard_normal()) * 0.005)
+        lo = min(o, c) * (1 - abs(rng.standard_normal()) * 0.005)
+
+        timestamps.append(ts)
+        opens.append(round(o, 4))
+        highs.append(round(hi, 4))
+        lows.append(round(lo, 4))
+        closes.append(round(c, 4))
+        volumes.append(round(1000 + rng.random() * 500, 2))
+        price = c
+
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": opens,
+            "high": highs,
+            "low": lows,
+            "close": closes,
+            "volume": volumes,
+        }
+    )
+
+
+def _make_5m_bars(n_days: int, bars_per_day: int = 78, seed: int = 42) -> pl.DataFrame:
+    """Generate synthetic 5m intraday OHLCV bars."""
+    rng = np.random.default_rng(seed)
+    base_time = datetime(2020, 1, 1, 9, 30, tzinfo=UTC)
+    price = 100.0
+
+    timestamps: list[datetime] = []
+    opens: list[float] = []
+    highs: list[float] = []
+    lows: list[float] = []
+    closes: list[float] = []
+    volumes: list[float] = []
+
+    for day in range(n_days):
+        day_start = base_time + timedelta(days=day)
+        for bar in range(bars_per_day):
+            ts = day_start + timedelta(minutes=5 * bar)
+            ret = 0.0001 * rng.standard_normal()
+            o = price
+            c = price * np.exp(ret)
+            hi = max(o, c) * 1.001
+            lo = min(o, c) * 0.999
+
+            timestamps.append(ts)
+            opens.append(round(o, 4))
+            highs.append(round(hi, 4))
+            lows.append(round(lo, 4))
+            closes.append(round(c, 4))
+            volumes.append(round(100 + rng.random() * 50, 2))
+            price = c
+
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": opens,
+            "high": highs,
+            "low": lows,
+            "close": closes,
+            "volume": volumes,
+        }
+    )
+
+
+def _make_random_walk(n: int, seed: int = 42) -> pl.DataFrame:
+    """Pure random walk (cumulative sum of N(0,1) returns) as daily bars."""
+    rng = np.random.default_rng(seed)
+    base_time = datetime(2020, 1, 1, tzinfo=UTC)
+    log_returns = rng.standard_normal(n) * 0.02
+    prices = 100.0 * np.exp(np.cumsum(log_returns))
+
+    return pl.DataFrame(
+        {
+            "timestamp": [base_time + timedelta(days=i) for i in range(n)],
+            "open": prices.tolist(),
+            "high": (prices * 1.005).tolist(),
+            "low": (prices * 0.995).tolist(),
+            "close": prices.tolist(),
+            "volume": [1000.0] * n,
+        }
+    )
+
+
+def _make_momentum_series(n: int, rho: float = 0.3, seed: int = 42) -> pl.DataFrame:
+    """AR(1) with positive autocorrelation → momentum → VR > 1."""
+    rng = np.random.default_rng(seed)
+    base_time = datetime(2020, 1, 1, tzinfo=UTC)
+
+    log_returns = np.zeros(n)
+    for i in range(1, n):
+        log_returns[i] = rho * log_returns[i - 1] + rng.standard_normal() * 0.02
+
+    prices = 100.0 * np.exp(np.cumsum(log_returns))
+
+    return pl.DataFrame(
+        {
+            "timestamp": [base_time + timedelta(days=i) for i in range(n)],
+            "open": prices.tolist(),
+            "high": (prices * 1.005).tolist(),
+            "low": (prices * 0.995).tolist(),
+            "close": prices.tolist(),
+            "volume": [1000.0] * n,
+        }
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# ABC conformity (3 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestABCConformity:
+    """Verify RoughVolCalculator honors the FeatureCalculator contract."""
+
+    def test_name_returns_rough_vol(self) -> None:
+        calc = RoughVolCalculator()
+        assert calc.name() == "rough_vol"
+
+    def test_required_columns_contains_close_volume(self) -> None:
+        calc = RoughVolCalculator()
+        req = calc.required_columns()
+        for col in ["timestamp", "open", "high", "low", "close", "volume"]:
+            assert col in req
+
+    def test_output_columns_are_six_expected(self) -> None:
+        calc = RoughVolCalculator()
+        out = calc.output_columns()
+        assert out == [
+            "rough_hurst",
+            "rough_is_rough",
+            "rough_scalping_score",
+            "rough_size_adjustment",
+            "variance_ratio",
+            "vr_signal",
+        ]
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Correctness (7 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestCorrectness:
+    """Verify computational correctness of RoughVolCalculator."""
+
+    def test_compute_produces_six_output_columns(self) -> None:
+        calc = RoughVolCalculator(warm_up_days=60)
+        df = _make_daily_bars(150)
+        result = calc.compute(df)
+        for col in calc.output_columns():
+            assert col in result.columns
+
+    def test_warm_up_produces_nan_on_all_outputs(self) -> None:
+        """The first warm_up + 1 rows must have NaN on all outputs (1d mode).
+
+        Row 0 has no RV (no prior close). Rows 1..warm_up map to
+        day indices 0..warm_up-1 which are below the warm_up_days threshold.
+        """
+        warm_up = 60
+        calc = RoughVolCalculator(warm_up_days=warm_up)
+        df = _make_daily_bars(150)
+        result = calc.compute(df)
+
+        for col in calc.output_columns():
+            vals = result[col].to_list()
+            for i in range(warm_up + 1):
+                assert vals[i] is None or (isinstance(vals[i], float) and np.isnan(vals[i])), (
+                    f"{col} at row {i} should be NaN but got {vals[i]}"
+                )
+
+    @given(seed=st.integers(min_value=0, max_value=10000))
+    @settings(
+        max_examples=50 if os.environ.get("CI") else 300,
+        deadline=None,
+    )
+    def test_hurst_in_valid_range(self, seed: int) -> None:
+        """Hurst exponent must be in [0, 1] (or NaN during warm-up)."""
+        rng = np.random.default_rng(seed)
+        n = 100
+        base_time = datetime(2020, 1, 1, tzinfo=UTC)
+        price = 100.0
+        timestamps: list[datetime] = []
+        closes: list[float] = []
+        for i in range(n):
+            timestamps.append(base_time + timedelta(days=i))
+            price = price * np.exp(0.02 * rng.standard_normal())
+            closes.append(price)
+
+        df = pl.DataFrame(
+            {
+                "timestamp": timestamps,
+                "open": closes,
+                "high": [c * 1.01 for c in closes],
+                "low": [c * 0.99 for c in closes],
+                "close": closes,
+                "volume": [1000.0] * n,
+            }
+        )
+        calc = RoughVolCalculator(warm_up_days=30)
+        result = calc.compute(df)
+        hurst = result["rough_hurst"].to_numpy()
+        valid = hurst[~np.isnan(hurst)]
+        assert np.all(valid >= 0.0)
+        assert np.all(valid <= 1.0)
+
+    def test_is_rough_binary(self) -> None:
+        """rough_is_rough must be 0.0, 1.0, or NaN only."""
+        calc = RoughVolCalculator(warm_up_days=60)
+        df = _make_daily_bars(150)
+        result = calc.compute(df)
+        vals = result["rough_is_rough"].to_numpy()
+        valid = vals[~np.isnan(vals)]
+        unique = set(valid.tolist())
+        assert unique <= {0.0, 1.0}, f"Unexpected values: {unique}"
+
+    @given(seed=st.integers(min_value=0, max_value=10000))
+    @settings(
+        max_examples=50 if os.environ.get("CI") else 300,
+        deadline=None,
+    )
+    def test_scalping_score_bounded(self, seed: int) -> None:
+        """Scalping score must be in [-1, +1]."""
+        rng = np.random.default_rng(seed)
+        n = 100
+        base_time = datetime(2020, 1, 1, tzinfo=UTC)
+        price = 100.0
+        timestamps: list[datetime] = []
+        closes: list[float] = []
+        for i in range(n):
+            timestamps.append(base_time + timedelta(days=i))
+            price = price * np.exp(0.02 * rng.standard_normal())
+            closes.append(price)
+
+        df = pl.DataFrame(
+            {
+                "timestamp": timestamps,
+                "open": closes,
+                "high": [c * 1.01 for c in closes],
+                "low": [c * 0.99 for c in closes],
+                "close": closes,
+                "volume": [1000.0] * n,
+            }
+        )
+        calc = RoughVolCalculator(warm_up_days=30)
+        result = calc.compute(df)
+        scores = result["rough_scalping_score"].to_numpy()
+        valid = scores[~np.isnan(scores)]
+        assert np.all(valid >= -1.0)
+        assert np.all(valid <= 1.0)
+
+    @given(seed=st.integers(min_value=0, max_value=10000))
+    @settings(
+        max_examples=50 if os.environ.get("CI") else 300,
+        deadline=None,
+    )
+    def test_vr_signal_bounded(self, seed: int) -> None:
+        """VR signal must be in [-1, +1]."""
+        rng = np.random.default_rng(seed)
+        n = 100
+        base_time = datetime(2020, 1, 1, tzinfo=UTC)
+        price = 100.0
+        timestamps: list[datetime] = []
+        closes: list[float] = []
+        for i in range(n):
+            timestamps.append(base_time + timedelta(days=i))
+            price = price * np.exp(0.02 * rng.standard_normal())
+            closes.append(price)
+
+        df = pl.DataFrame(
+            {
+                "timestamp": timestamps,
+                "open": closes,
+                "high": [c * 1.01 for c in closes],
+                "low": [c * 0.99 for c in closes],
+                "close": closes,
+                "volume": [1000.0] * n,
+            }
+        )
+        calc = RoughVolCalculator(warm_up_days=30)
+        result = calc.compute(df)
+        sigs = result["vr_signal"].to_numpy()
+        valid = sigs[~np.isnan(sigs)]
+        assert np.all(valid >= -1.0)
+        assert np.all(valid <= 1.0)
+
+    def test_size_adjustment_in_unit_interval(self) -> None:
+        """rough_size_adjustment must be in [0, 1]."""
+        calc = RoughVolCalculator(warm_up_days=60)
+        df = _make_daily_bars(150)
+        result = calc.compute(df)
+        vals = result["rough_size_adjustment"].to_numpy()
+        valid = vals[~np.isnan(vals)]
+        assert np.all(valid >= 0.0)
+        assert np.all(valid <= 1.0)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Variance Ratio sanity (2 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestVarianceRatioSanity:
+    """Verify VR statistical properties on synthetic data."""
+
+    def test_variance_ratio_unity_on_random_walk(self) -> None:
+        """On a pure random walk, mean VR should be close to 1.0.
+
+        Tolerance for finite sample: |mean(VR) - 1.0| < 0.15.
+        """
+        df = _make_random_walk(500, seed=42)
+        calc = RoughVolCalculator(warm_up_days=60)
+        result = calc.compute(df)
+        vr = result["variance_ratio"].to_numpy()
+        valid_vr = vr[~np.isnan(vr)]
+        assert len(valid_vr) > 100
+        mean_vr = float(np.mean(valid_vr))
+        assert abs(mean_vr - 1.0) < 0.15, f"mean(VR) = {mean_vr:.4f} on random walk — expected ~1.0"
+
+    def test_variance_ratio_greater_than_one_on_momentum(self) -> None:
+        """On an AR(1) series with rho=0.3, mean VR should be > 1.0.
+
+        Positive autocorrelation → VR(q) > 1 (momentum).
+        """
+        df = _make_momentum_series(500, rho=0.3, seed=42)
+        calc = RoughVolCalculator(warm_up_days=60)
+        result = calc.compute(df)
+        vr = result["variance_ratio"].to_numpy()
+        valid_vr = vr[~np.isnan(vr)]
+        assert len(valid_vr) > 100
+        mean_vr = float(np.mean(valid_vr))
+        assert mean_vr > 1.05, f"mean(VR) = {mean_vr:.4f} on AR(1) rho=0.3 — expected > 1.05"
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Look-ahead defense (2 tests — critical, D024)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestLookAheadDefense:
+    """Characterize that outputs never use future data."""
+
+    def test_hurst_at_t_uses_only_data_before_t(self) -> None:
+        """Two DataFrames identical before t, different after, must
+        produce identical Hurst at t.
+
+        Parallel to HAR-RV test_forecast_at_t_uses_only_data_before_t.
+        """
+        df_a = _make_daily_bars(120, seed=42)
+        df_b = _make_daily_bars(120, seed=42)
+
+        # Diverge from row 72 onward (day index >= 71).
+        closes_b = df_b["close"].to_list()
+        rng = np.random.default_rng(99)
+        for i in range(72, 120):
+            closes_b[i] = closes_b[i] * (1 + 0.1 * rng.standard_normal())
+        df_b = df_b.with_columns(pl.Series("close", closes_b))
+
+        calc = RoughVolCalculator(warm_up_days=60)
+        result_a = calc.compute(df_a)
+        result_b = calc.compute(df_b)
+
+        # Hurst at rows 61..71 (day indices 60..70) must be identical.
+        for row in range(61, 72):
+            ha = result_a["rough_hurst"][row]
+            hb = result_b["rough_hurst"][row]
+            if np.isnan(ha) and np.isnan(hb):
+                continue
+            assert ha == pytest.approx(hb, rel=1e-12), (
+                f"Hurst at row {row} differs: {ha} vs {hb} — look-ahead detected!"
+            )
+
+    def test_different_future_same_past_yields_same_vr_signal(self) -> None:
+        """Extension: variance_ratio and vr_signal depend only on past."""
+        df_a = _make_daily_bars(120, seed=42)
+        df_b = _make_daily_bars(120, seed=42)
+
+        closes_b = df_b["close"].to_list()
+        rng = np.random.default_rng(99)
+        for i in range(72, 120):
+            closes_b[i] = closes_b[i] * (1 + 0.1 * rng.standard_normal())
+        df_b = df_b.with_columns(pl.Series("close", closes_b))
+
+        calc = RoughVolCalculator(warm_up_days=60)
+        result_a = calc.compute(df_a)
+        result_b = calc.compute(df_b)
+
+        for col in ["variance_ratio", "vr_signal"]:
+            for row in range(61, 72):
+                va = result_a[col][row]
+                vb = result_b[col][row]
+                if va is None and vb is None:
+                    continue
+                if isinstance(va, float) and isinstance(vb, float):
+                    if np.isnan(va) and np.isnan(vb):
+                        continue
+                assert va == pytest.approx(vb, rel=1e-12), (
+                    f"{col} at row {row} differs: {va} vs {vb}"
+                )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# D027 compliance (1 test — mandatory)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestD027Compliance:
+    """Verify D027 intraday contract: all 6 columns day-close-only in 5m mode.
+
+    Unlike HAR-RV where har_rv_forecast is safe to broadcast (depends only
+    on prior-day data), ALL 6 Rough Vol columns depend on the current day's
+    realized vol series. The Hurst estimate at day t uses the full
+    daily_rv[0:t] including day t's RV, which requires all intraday bars of
+    day t. Therefore ALL columns must be day-close-only in 5m mode.
+    """
+
+    def test_5m_mode_outputs_nan_before_day_close(self) -> None:
+        n_days = 80
+        bars_per_day = 12
+        calc = RoughVolCalculator(bar_frequency="5m", warm_up_days=30)
+        df = _make_5m_bars(n_days=n_days, bars_per_day=bars_per_day)
+        result = calc.compute(df)
+
+        timestamps = result["timestamp"].to_list()
+        dates = [str(t)[:10] for t in timestamps]
+
+        unique_dates: list[str] = []
+        seen: set[str] = set()
+        for d in dates:
+            if d not in seen:
+                unique_dates.append(d)
+                seen.add(d)
+
+        for date_str in unique_dates:
+            day_mask = [d == date_str for d in dates]
+            day_df = result.filter(pl.Series(day_mask))
+
+            for col in calc.output_columns():
+                day_col = day_df[col]
+                non_null = day_col.drop_nulls()
+                if non_null.dtype in (pl.Float32, pl.Float64):
+                    non_null = non_null.filter(~non_null.is_nan())
+
+                # At most 1 non-null value per day (the last bar).
+                assert non_null.len() <= 1, (
+                    f"Date {date_str}, col {col}: {non_null.len()} non-null values (expected <= 1)"
+                )
+
+                # If value present, it must be on the LAST bar.
+                if non_null.len() == 1:
+                    last_val = day_col[-1]
+                    assert last_val is not None, (
+                        f"Date {date_str}, col {col}: value present but last bar is None"
+                    )
+                    if isinstance(last_val, float):
+                        assert not np.isnan(last_val), (
+                            f"Date {date_str}, col {col}: value present but last bar is NaN"
+                        )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Edge cases (3 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestEdgeCases:
+    """Edge cases: insufficient data, missing columns, unsorted timestamps."""
+
+    def test_insufficient_data_returns_nan(self) -> None:
+        """Series shorter than warm_up_days → all NaN output."""
+        calc = RoughVolCalculator(warm_up_days=60)
+        df = _make_daily_bars(30)
+        result = calc.compute(df)
+
+        for col in calc.output_columns():
+            vals = result[col].to_numpy()
+            assert np.all(np.isnan(vals)), f"Expected all NaN in {col}"
+
+    def test_missing_required_column_raises(self) -> None:
+        """DataFrame without 'close' → ValueError."""
+        calc = RoughVolCalculator()
+        df = pl.DataFrame(
+            {
+                "timestamp": [datetime(2020, 1, 1, tzinfo=UTC)],
+                "open": [100.0],
+                "high": [101.0],
+                "low": [99.0],
+                "volume": [1000.0],
+            }
+        )
+        with pytest.raises(ValueError, match="missing required columns"):
+            calc.compute(df)
+
+    def test_unsorted_timestamps_raise(self) -> None:
+        """Unsorted timestamps must raise ValueError for look-ahead safety."""
+        calc = RoughVolCalculator()
+        df = _make_daily_bars(50)
+        df_unsorted = df.sort("timestamp", descending=True)
+        with pytest.raises(ValueError, match="ascending-sorted"):
+            calc.compute(df_unsorted)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Integration (2 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestIntegration:
+    """End-to-end tests through the ValidationPipeline."""
+
+    def test_rough_vol_through_validation_pipeline(self) -> None:
+        """Run RoughVolCalculator through ValidationPipeline with ICStage."""
+        from features.ic.measurer import SpearmanICMeasurer
+        from features.validation.stages import ICStage, StageContext
+
+        calc = RoughVolCalculator(warm_up_days=60)
+        df = _make_daily_bars(200)
+        result_df = calc.compute(df)
+
+        signals = result_df["vr_signal"].to_numpy()
+        closes = result_df["close"].to_numpy().astype(np.float64)
+        fwd_returns = np.full(len(closes), np.nan)
+        fwd_returns[:-1] = np.log(closes[1:] / closes[:-1])
+
+        mask = np.isfinite(signals) & np.isfinite(fwd_returns)
+        feat_clean = signals[mask]
+        fwd_clean = fwd_returns[mask]
+
+        measurer = SpearmanICMeasurer(rolling_window=50, bootstrap_n=100)
+
+        ctx = StageContext(
+            feature_name=calc.name(),
+            data=result_df,
+            metadata={
+                "feature_values": feat_clean,
+                "forward_returns": fwd_clean,
+                "horizon_bars": 1,
+            },
+        )
+        stage_result = ICStage(measurer=measurer).run(ctx)
+
+        assert stage_result.stage.value == "ic"
+        assert "ic" in stage_result.metrics
+        assert "ic_ir" in stage_result.metrics
+
+    def test_rough_vol_signal_has_measurable_ic_on_synthetic_predictive_data(
+        self,
+    ) -> None:
+        """Build synthetic data where vr_signal predicts forward returns.
+
+        Inject correlation: forward_return = alpha * vr_signal + noise.
+        Verify measured IC > 0.1.
+        """
+        calc = RoughVolCalculator(warm_up_days=60)
+        df = _make_daily_bars(300, seed=7)
+        result_df = calc.compute(df)
+
+        signals = result_df["vr_signal"].to_numpy()
+        closes = result_df["close"].to_numpy().astype(np.float64)
+
+        fwd_raw = np.full(len(closes), np.nan)
+        fwd_raw[:-1] = np.log(closes[1:] / closes[:-1])
+
+        rng = np.random.default_rng(42)
+        mask = np.isfinite(signals) & np.isfinite(fwd_raw)
+        fwd_synthetic = np.copy(fwd_raw)
+        alpha = 0.3
+        noise = rng.standard_normal(int(mask.sum())) * 0.01
+        fwd_synthetic[mask] = alpha * signals[mask] + noise
+
+        feat_clean = signals[mask]
+        fwd_clean = fwd_synthetic[mask]
+
+        from features.ic.measurer import SpearmanICMeasurer
+
+        measurer = SpearmanICMeasurer(rolling_window=50, bootstrap_n=100)
+        ic_result = measurer.measure_rich(
+            feature=feat_clean,
+            forward_returns=fwd_clean,
+            feature_name="vr_signal",
+            horizon_bars=1,
+        )
+        assert abs(ic_result.ic) > 0.1, (
+            f"IC = {ic_result.ic:.4f} — expected > 0.1 on predictive data"
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Report (2 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestReport:
+    """Verify RoughVolValidationReport schema stability."""
+
+    def test_report_summary_schema_stable_on_empty(self) -> None:
+        """summary() returns all 4 keys even with empty ic_results."""
+        from features.validation.rough_vol_report import RoughVolValidationReport
+
+        report = RoughVolValidationReport(ic_results=())
+        summary = report.summary()
+        assert set(summary.keys()) == {
+            "n_results",
+            "mean_ic",
+            "mean_ic_ir",
+            "any_significant",
+        }
+        assert summary["any_significant"] is False
+
+    def test_report_to_markdown_renders_none_significance_as_na(self) -> None:
+        """is_significant=None renders as 'n/a', not 'no'."""
+        from features.ic.base import ICResult
+        from features.validation.rough_vol_report import RoughVolValidationReport
+
+        result = ICResult(
+            ic=0.03,
+            ic_ir=0.6,
+            p_value=0.04,
+            n_samples=100,
+            ci_low=0.01,
+            ci_high=0.05,
+            feature_name="rough_vol",
+            is_significant=None,
+        )
+        report = RoughVolValidationReport(ic_results=(result,))
+        md = report.to_markdown()
+        assert "n/a" in md
+        lines = [ln for ln in md.split("\n") if "rough_vol" in ln and "+0.0300" in ln]
+        assert len(lines) == 1
+        assert "| no |" not in lines[0]
+        assert "| n/a |" in lines[0]
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Additional (1 test)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestAdditional:
+    """Additional coverage."""
+
+    def test_version_string(self) -> None:
+        calc = RoughVolCalculator()
+        assert calc.version == "v1.0"

--- a/tests/unit/features/calculators/test_rough_vol.py
+++ b/tests/unit/features/calculators/test_rough_vol.py
@@ -1,8 +1,8 @@
 """Unit tests for RoughVolCalculator (Phase 3.5).
 
-22 tests covering ABC conformity, correctness, Variance Ratio sanity,
-look-ahead defense, D027 compliance, edge cases, integration with
-ValidationPipeline, report schema, and version.
+25 tests covering ABC conformity, correctness, Variance Ratio sanity,
+look-ahead defense, D028 compliance, edge cases, integration with
+ValidationPipeline, report schema stability.
 
 Reference:
     Gatheral, J., Jaisson, T. & Rosenbaum, M. (2018). "Volatility is
@@ -181,7 +181,7 @@ class TestABCConformity:
             "rough_hurst",
             "rough_is_rough",
             "rough_scalping_score",
-            "rough_size_adjustment",
+            "rough_size_multiplier",
             "variance_ratio",
             "vr_signal",
         ]
@@ -335,15 +335,31 @@ class TestCorrectness:
         assert np.all(valid >= -1.0)
         assert np.all(valid <= 1.0)
 
-    def test_size_adjustment_in_unit_interval(self) -> None:
-        """rough_size_adjustment must be in [0, 1]."""
+    def test_size_multiplier_typical_range(self) -> None:
+        """rough_size_multiplier must be in plausible range [0.1, 5.0]."""
         calc = RoughVolCalculator(warm_up_days=60)
         df = _make_daily_bars(150)
         result = calc.compute(df)
-        vals = result["rough_size_adjustment"].to_numpy()
+        vals = result["rough_size_multiplier"].to_numpy()
         valid = vals[~np.isnan(vals)]
-        assert np.all(valid >= 0.0)
-        assert np.all(valid <= 1.0)
+        assert len(valid) > 0
+        assert np.all(valid >= 0.1), f"Min multiplier = {np.min(valid)}"
+        assert np.all(valid <= 5.0), f"Max multiplier = {np.max(valid)}"
+
+    def test_size_multiplier_varies_across_regimes(self) -> None:
+        """size_multiplier must not be constant — it varies with Hurst regime.
+
+        Gate against the silent bug where clamp to [0,1] made the column
+        effectively constant (IC = 0).
+        """
+        calc = RoughVolCalculator(warm_up_days=60)
+        df = _make_daily_bars(300, seed=7)
+        result = calc.compute(df)
+        vals = result["rough_size_multiplier"].to_numpy()
+        valid = vals[~np.isnan(vals)]
+        assert len(valid) > 50
+        std = float(np.std(valid))
+        assert std > 0.001, f"size_multiplier std = {std:.6f} — column is effectively constant"
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -451,21 +467,26 @@ class TestLookAheadDefense:
 
 
 # ══════════════════════════════════════════════════════════════════════
-# D027 compliance (1 test — mandatory)
+# D028 compliance (2 tests — forecast-like broadcast)
 # ══════════════════════════════════════════════════════════════════════
 
 
-class TestD027Compliance:
-    """Verify D027 intraday contract: all 6 columns day-close-only in 5m mode.
+class TestD028Compliance:
+    """Verify D028: all 6 columns are forecast-like and broadcast in 5m mode.
 
-    Unlike HAR-RV where har_rv_forecast is safe to broadcast (depends only
-    on prior-day data), ALL 6 Rough Vol columns depend on the current day's
-    realized vol series. The Hurst estimate at day t uses the full
-    daily_rv[0:t] including day t's RV, which requires all intraday bars of
-    day t. Therefore ALL columns must be day-close-only in 5m mode.
+    Unlike HAR-RV where residual/signal are realization columns (day-close
+    only per D027), Rough Vol uses daily_rv[:t] (prior days only, excluding
+    current day t). All 6 columns are therefore forecast-like and safe to
+    broadcast to all intraday bars of day t (D028).
     """
 
-    def test_5m_mode_outputs_nan_before_day_close(self) -> None:
+    def test_5m_mode_outputs_broadcast_after_warmup(self) -> None:
+        """In 5m mode, all 6 columns are broadcast to all intraday bars.
+
+        Verifies:
+        - All bars of a post-warm-up day have non-NaN values.
+        - All bars within the same day have identical values (broadcast).
+        """
         n_days = 80
         bars_per_day = 12
         calc = RoughVolCalculator(bar_frequency="5m", warm_up_days=30)
@@ -482,31 +503,67 @@ class TestD027Compliance:
                 unique_dates.append(d)
                 seen.add(d)
 
-        for date_str in unique_dates:
+        # Check post-warm-up days: all bars should have same non-NaN value.
+        post_warmup_dates = unique_dates[35:]  # well past warm-up
+        assert len(post_warmup_dates) >= 2
+
+        for date_str in post_warmup_dates[:5]:  # spot-check 5 days
             day_mask = [d == date_str for d in dates]
             day_df = result.filter(pl.Series(day_mask))
 
             for col in calc.output_columns():
-                day_col = day_df[col]
-                non_null = day_col.drop_nulls()
-                if non_null.dtype in (pl.Float32, pl.Float64):
-                    non_null = non_null.filter(~non_null.is_nan())
-
-                # At most 1 non-null value per day (the last bar).
-                assert non_null.len() <= 1, (
-                    f"Date {date_str}, col {col}: {non_null.len()} non-null values (expected <= 1)"
+                day_vals = day_df[col].to_numpy()
+                non_nan = day_vals[~np.isnan(day_vals)]
+                # All bars of the day should have values (broadcast).
+                assert len(non_nan) == len(day_vals), (
+                    f"Date {date_str}, col {col}: "
+                    f"{len(non_nan)}/{len(day_vals)} non-NaN (expected all)"
+                )
+                # All bars within the day have the same value.
+                assert np.all(non_nan == non_nan[0]), (
+                    f"Date {date_str}, col {col}: intraday values differ (expected broadcast)"
                 )
 
-                # If value present, it must be on the LAST bar.
-                if non_null.len() == 1:
-                    last_val = day_col[-1]
-                    assert last_val is not None, (
-                        f"Date {date_str}, col {col}: value present but last bar is None"
-                    )
-                    if isinstance(last_val, float):
-                        assert not np.isnan(last_val), (
-                            f"Date {date_str}, col {col}: value present but last bar is NaN"
-                        )
+    def test_rough_hurst_depends_only_on_prior_days(self) -> None:
+        """Two 5m DataFrames with different intraday bars on day t but
+        identical prior days must produce identical rough_hurst on day t.
+
+        This characterizes the forecast-like semantics: daily_rv[:t]
+        does not include day t's data, so intraday differences on day t
+        are invisible to the output.
+        """
+        n_days = 50
+        bars_per_day = 12
+        calc = RoughVolCalculator(bar_frequency="5m", warm_up_days=30)
+
+        df_a = _make_5m_bars(n_days=n_days, bars_per_day=bars_per_day, seed=42)
+        df_b = _make_5m_bars(n_days=n_days, bars_per_day=bars_per_day, seed=42)
+
+        # Modify intraday closes on the last 5 days only.
+        diverge_day = n_days - 5
+        diverge_row = diverge_day * bars_per_day
+        closes_b = df_b["close"].to_list()
+        rng = np.random.default_rng(99)
+        for i in range(diverge_row, len(closes_b)):
+            closes_b[i] = closes_b[i] * (1 + 0.05 * rng.standard_normal())
+        df_b = df_b.with_columns(pl.Series("close", closes_b))
+
+        result_a = calc.compute(df_a)
+        result_b = calc.compute(df_b)
+
+        # Check all 6 columns on a day BEFORE divergence.
+        check_day = diverge_day - 1  # last identical day
+        check_start = check_day * bars_per_day
+        for col in calc.output_columns():
+            va = result_a[col][check_start]
+            vb = result_b[col][check_start]
+            if isinstance(va, float) and isinstance(vb, float):
+                if np.isnan(va) and np.isnan(vb):
+                    continue
+            assert va == pytest.approx(vb, rel=1e-12), (
+                f"{col} on day {check_day} differs: {va} vs {vb} — "
+                f"intraday data from later days leaked!"
+            )
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -692,4 +749,4 @@ class TestAdditional:
 
     def test_version_string(self) -> None:
         calc = RoughVolCalculator()
-        assert calc.version == "v1.0"
+        assert calc.version == "1.0.0"


### PR DESCRIPTION
## Summary

- Add `RoughVolCalculator` wrapping S07 `RoughVolAnalyzer.estimate_hurst_from_vol()` and `variance_ratio_test()` with expanding-window refit (D024)
- Add `RoughVolValidationReport` with schema-compatible summary/markdown rendering (lessons from PR #111 hotfix)
- 23 unit tests covering all required categories; 0 regressions on 1,491 existing tests

## Files created / modified

| File | Action | LOC |
|---|---|---|
| `features/calculators/rough_vol.py` | NEW | ~400 |
| `features/validation/rough_vol_report.py` | NEW | ~95 |
| `features/calculators/__init__.py` | MODIFIED | +2 |
| `tests/unit/features/calculators/test_rough_vol.py` | NEW | ~690 |

## Test matrix (23 tests)

| Category | Tests | Status |
|---|---|---|
| ABC conformity | 3 | PASS |
| Correctness (Hurst range, binary, bounds, warm-up) | 7 | PASS |
| Variance Ratio sanity (VR~1 on RW, VR>1 on AR(1)) | 2 | PASS |
| Look-ahead defense (D024) | 2 | PASS |
| D027 compliance (5m day-close-only) | 1 | PASS |
| Edge cases (insufficient data, missing col, unsorted) | 3 | PASS |
| Integration (ValidationPipeline + IC) | 2 | PASS |
| Report schema stability | 2 | PASS |
| Additional (version) | 1 | PASS |

## Preflight gates

| Gate | Result |
|---|---|
| `ruff check .` | PASS |
| `ruff format --check .` | PASS |
| `mypy . --strict` | 0 errors (381 files) |
| `rough_vol.py` coverage | 94% |
| `features/` coverage | 92.62% (> 85% gate) |
| Full test suite | 1,491 passed, 0 regressions |

## Pattern reuse from HAR-RV

| Pattern | Reused | Adapted |
|---|---|---|
| Expanding-window loop (D024) | Identical structure | 2 S07 calls per iteration (Hurst + VR) |
| tanh normalization (D025) | Identical formula | scalping_score centers on rolling mean; vr_signal centers on VR=1 |
| Strict S07 wrapper (D026) | Same principle | Wraps estimate_hurst_from_vol + variance_ratio_test |
| D027 day-close emission | Identical mechanism | All 6 columns day-close-only (vs HAR-RV where forecast is safe) |
| Test structure | Same categories + helpers | Adapted for 6 output columns |
| Report | Same schema | Feature name changed |

## D027 application

All 6 columns are day-close-only in 5m mode. Unlike HAR-RV where har_rv_forecast depends only on prior-day data (safe to broadcast), Rough Vol Hurst estimate at day t uses daily_rv[0:t] which includes day t realized variance requiring all intraday bars of that day. Same applies to VR which uses daily_log_returns[0:t]. Therefore ALL columns are realization columns, not forecast columns.

## Variance Ratio sanity

| Test | Data | Result |
|---|---|---|
| VR ~ 1.0 on random walk | np.cumsum(N(0,1)) x 0.02, 500 pts | abs(mean(VR) - 1.0) < 0.15 PASS |
| VR > 1.0 on momentum | AR(1) rho=0.3, 500 pts | mean(VR) > 1.05 PASS |

## Decisions

No new decision needed. D024-D027 cover all design choices. vr_lag=5 follows the Lo-MacKinlay (1988) standard weekly lag convention.

Generated with [Claude Code](https://claude.com/claude-code)