### PR TITLE
[Phase 3.7] CVD + Kyle Lambda Validation (Kyle 1985) (#93)

### DIFF
--- a/docs/claude_memory/CONTEXT.md
+++ b/docs/claude_memory/CONTEXT.md
@@ -1,7 +1,7 @@
 # APEX Project Context Snapshot
 
 **Last updated**: 2026-04-13
-**Updated by**: Session 017
+**Updated by**: Session 018
 
 ---
 
@@ -9,7 +9,7 @@
 
 | Metric | Value |
 |---|---|
-| Active Phase | Phase 3 — Feature Validation Harness (3.6 PR #113 OPEN) |
+| Active Phase | Phase 3 — Feature Validation Harness (3.7 PR #114 OPEN) |
 | Previous Phase | Phase 2 — Universal Data Infrastructure (DONE) |
 | Total tests | 1,546+ (1,491 unit + 55 integration) |
 | Production LOC | ~35,300 |
@@ -18,7 +18,7 @@
 | Services scaffolded | 10/10 (S01-S10) |
 | S01 fully implemented | Yes (78 files, 9,583 LOC) |
 | ADRs accepted | 10 (+ ADR-0004 Feature Validation Methodology) |
-| features/ coverage | 92.22% (232 tests) |
+| features/ coverage | 92.28% (267 tests) |
 
 ## Audit Status
 

--- a/docs/claude_memory/DECISIONS.md
+++ b/docs/claude_memory/DECISIONS.md
@@ -798,3 +798,41 @@ For every FeatureCalculator constructor parameter:
 
 - PR #113 Copilot review comment #1
 - D026 (strict wrapper)
+
+---
+
+## D032 — CVD/Kyle Lambda Implemented Directly (Not Wrapping S02) (2026-04-13)
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Session | 018 |
+| Decision | CVDKyleCalculator implements CVD and Kyle lambda directly, not wrapping S02 microstructure.py |
+| Status | ACCEPTED |
+
+### Context
+
+Phase 3.7 CVDKyleCalculator needs (a) raw cumulative CVD, (b) Kyle lambda via OLS with intercept on a strict-past rolling window. S02 provides both functions but with different semantics:
+
+- S02 `cvd()` returns a normalized ratio `Σ(buy-sell)/total_vol` ∈ [-1,1] — not the raw cumulative sum needed for divergence tracking.
+- S02 `kyle_lambda()` uses `Cov(ΔP,Q)/Var(Q)` without intercept and without rolling/expanding window protection — no look-ahead defense.
+
+### Why Not Wrap S02
+
+- S02's formulas answer different questions than what feature validation requires
+- Wrapping would require either modifying S02 (anti-scope-creep) or applying ad-hoc corrections that negate the wrapper benefit
+- Same pattern as D030 (OFI) where S02's price-delta proxy differs from Cont 2014 canonical formula
+
+### Justification
+
+- S02 is NOT modified (anti-scope-creep, same as D030)
+- D026 (wrapper strict) honored in spirit — we would wrap if formulas matched
+- OLS with intercept captures baseline price drift, producing a cleaner lambda estimate
+- Rolling window with strict past exclusion enforces D024 look-ahead safety
+
+### References
+
+- D026 (strict wrapper — honored where applicable)
+- D030 (OFI precedent: implement directly when S02 formula differs)
+- Kyle (1985) Econometrica 53(6)
+- S02 `services/s02_signal_engine/microstructure.py` lines 83-126

--- a/docs/claude_memory/PHASE_3_NOTES.md
+++ b/docs/claude_memory/PHASE_3_NOTES.md
@@ -16,7 +16,7 @@
 | 3.4 HAR-RV | IN_PROGRESS | PR #111 open — 20 tests, 91% coverage |
 | 3.5 Rough Vol | IN_PROGRESS | PR #112 open — 23 tests, 94% coverage |
 | 3.6 OFI | IN_PROGRESS | PR #113 open — 23 tests, 93% coverage |
-| 3.7 CVD + Kyle | PENDING | S02 cvd(), kyle_lambda() ready |
+| 3.7 CVD + Kyle | IN_PROGRESS | PR #114 open — 31 tests, 94% coverage |
 | 3.8 GEX | PENDING | Risk: options data availability |
 | 3.9 Multicollinearity | PENDING | |
 | 3.10 CPCV | PENDING | |
@@ -84,3 +84,12 @@
 - 3.6 hotfix: dynamic column names from self._windows (D031), remove dead max_window param, fix comment
 - D031: configurable params must honor configurability everywhere. HAR-RV/Rough Vol audited: NOT affected
 - 236 tests on features/, 27 OFI tests (0 regressions after hotfix)
+- CVDKyleCalculator: implements CVD + Kyle lambda directly (D032), NOT wrapping S02 (formulas differ)
+- S02 cvd() = normalized ratio Σ(buy-sell)/total_vol; we need raw cumulative sum
+- S02 kyle_lambda() = Cov(ΔP,Q)/Var(Q) no intercept; we need OLS with intercept on strict past window
+- D028 applied: cvd/cvd_divergence realization at tick t; kyle_lambda and derivatives forecast-like
+- D029 variance gates × 3: cvd_divergence, liquidity_signal, combined_signal (each signal can degenerate independently)
+- D030 proactive: 4 ValueError constraints (cvd_window, kyle_window, kyle_zscore_lookback, combined_weights)
+- Kyle lambda clamped ≥ 0 (negative = economically unphysical), logged via structlog warning
+- CVD divergence = tanh(-corr(price_changes, cvd_changes)) — negative correlation = divergence = positive signal
+- 267 tests on features/, 31 CVD/Kyle tests, 1,546+ total tests (0 regressions)

--- a/docs/claude_memory/PHASE_3_NOTES.md
+++ b/docs/claude_memory/PHASE_3_NOTES.md
@@ -93,3 +93,6 @@
 - Kyle lambda clamped ≥ 0 (negative = economically unphysical), logged via structlog warning
 - CVD divergence = tanh(-corr(price_changes, cvd_changes)) — negative correlation = divergence = positive signal
 - 267 tests on features/, 31 CVD/Kyle tests, 1,546+ total tests (0 regressions)
+- 3.7 hotfix: doc "expanding" → "rolling window" for Kyle lambda, test rename. Zero real bugs found by Copilot.
+- 3 perf suggestions deferred to Phase 5 (ADR-0002 correctness-first). Tracking issue #115.
+- Kyle lambda clamp rate: 50-73% on random walk (expected), 0% on illiquid data (correct). Not a bug.

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -797,3 +797,47 @@ Each entry follows the template in `templates/SESSION_TEMPLATE.md`.
 
 - Await Copilot re-review on PR #113
 - Phase 3.7 CVD + Kyle after merge
+
+---
+
+## Session 018 — 2026-04-13
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Mission | Phase 3.7 — CVD + Kyle Lambda Validation (#93) |
+| Agent Model | Claude Opus 4.6 |
+| Duration | ~1 hour |
+
+### Decisions Made
+
+1. D032: S02 cvd() and kyle_lambda() not wrapped — S02's cvd() is normalized ratio, we need raw cumulative; S02's kyle_lambda() uses Cov/Var without intercept or expanding window. Implemented directly (same pattern as D030/OFI).
+
+### What Changed
+
+- CREATED: `features/calculators/cvd_kyle.py` (478 LOC) — CVDKyleCalculator with 6 output columns
+- CREATED: `features/validation/cvd_kyle_report.py` (93 LOC) — ICResult wrapper
+- CREATED: `tests/unit/features/calculators/test_cvd_kyle.py` (745 LOC) — 31 tests
+- MODIFIED: `features/calculators/__init__.py` — register CVDKyleCalculator
+
+### Key Implementation Details
+
+- Kyle lambda: rolling-window OLS (delta_P = lambda * signed_vol + alpha) on [t-kw, t-1] exclusive of current tick (forecast-like)
+- Lambda clamped ≥ 0 with structlog warning when negative OLS result (economic constraint)
+- CVD divergence: tanh(-corr(price_changes, cvd_changes)) — negative correlation = divergence = positive signal
+- D028 classification: cvd/cvd_divergence realization-like, kyle_lambda and derivatives forecast-like
+- D029 variance gates: 3 separate tests, one per signal column
+- D030 proactive: 4 ValueError constraints in constructor
+
+### Quality Gates
+
+- ruff check + format: clean
+- mypy --strict: 0 errors (387 files)
+- cvd_kyle.py coverage: 94%
+- features/ coverage: 92.28% (> 85% gate)
+- 267 features/ tests passed, 0 regressions
+
+### Next Steps
+
+- Await Copilot review on PR #114
+- Phase 3.8 GEX after merge (risk: options data availability)

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -841,3 +841,37 @@ Each entry follows the template in `templates/SESSION_TEMPLATE.md`.
 
 - Await Copilot review on PR #114
 - Phase 3.8 GEX after merge (risk: options data availability)
+
+---
+
+## Session 019 — 2026-04-13
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Mission | PR #114 Copilot review hotfix — doc/naming nits |
+| Agent Model | Claude Opus 4.6 |
+| Duration | ~15 min |
+
+### What Changed
+
+- MODIFIED: `features/calculators/cvd_kyle.py` — "expanding window" → "fixed-length rolling window" in module docstring and `_compute_kyle_lambda` docstring. Explicitly documents difference from HAR-RV/Rough Vol expanding windows.
+- MODIFIED: `tests/unit/features/calculators/test_cvd_kyle.py` — rename `test_cvd_is_monotonic_cumulative` → `test_cvd_diff_equals_signed_volume` (body was already correct).
+
+### Key Findings
+
+- Copilot found 0 bugs (math, look-ahead, semantics). First sub-phase with no real bug.
+- 3 perf suggestions deferred to Phase 5 per ADR-0002 (correctness-first). Tracking issue #115 created.
+- Kyle lambda clamp rate investigation: 50-73% on random-walk data (expected, no structural relationship), 0% on illiquid data (structural impact). Not a bug — property of data.
+
+### Quality Gates
+
+- ruff check + format: clean
+- mypy --strict: 0 errors (387 files)
+- 267 features/ tests passed, 0 regressions
+- features/ coverage: 92.28%
+
+### Next Steps
+
+- Await Copilot re-review on PR #114
+- Phase 3.8 GEX after merge

--- a/features/calculators/__init__.py
+++ b/features/calculators/__init__.py
@@ -8,8 +8,14 @@ Reference:
     PHASE_3_SPEC §2.4-2.8.
 """
 
+from features.calculators.cvd_kyle import CVDKyleCalculator
 from features.calculators.har_rv import HARRVCalculator
 from features.calculators.ofi import OFICalculator
 from features.calculators.rough_vol import RoughVolCalculator
 
-__all__ = ["HARRVCalculator", "OFICalculator", "RoughVolCalculator"]
+__all__ = [
+    "CVDKyleCalculator",
+    "HARRVCalculator",
+    "OFICalculator",
+    "RoughVolCalculator",
+]

--- a/features/calculators/cvd_kyle.py
+++ b/features/calculators/cvd_kyle.py
@@ -8,11 +8,13 @@ Note on S02 MicrostructureAnalyzer.cvd() and kyle_lambda():
     bounded in [-1, 1]. This calculator needs the *raw* cumulative sum
     of signed volume (unbounded, monotonically evolving). S02's
     kyle_lambda() uses Cov(delta_P, Q)/Var(Q) without intercept and
-    without expanding-window protection against look-ahead. Since feature
+    without strict-past protection against look-ahead. Since feature
     validation requires (a) raw CVD, (b) OLS with intercept, and (c)
-    strict past expanding window, this calculator implements both
-    directly rather than wrapping S02. S02 is NOT modified
-    (anti-scope-creep). Decision documented as D032.
+    a strict past fixed-length rolling window of kyle_window ticks
+    (rolling, NOT expanding -- different statistical properties),
+    this calculator implements both directly rather than wrapping S02.
+    S02 is NOT modified (anti-scope-creep). Decision documented as
+    D032.
 
 Output columns (6):
     cvd: Cumulative signed volume from t=0. Realization at tick t.
@@ -329,10 +331,16 @@ class CVDKyleCalculator(FeatureCalculator):
         delta_p: npt.NDArray[np.float64],
         signed_vol: npt.NDArray[np.float64],
     ) -> npt.NDArray[np.float64]:
-        """Compute Kyle's lambda via rolling-window OLS.
+        """Compute Kyle's lambda via fixed-length rolling-window OLS.
+
+        Uses a strict past rolling window of kyle_window ticks
+        [t-kyle_window, t-1], EXCLUSIVE of tick t. This differs from
+        HAR-RV/Rough Vol which use expanding windows (fit on [0, t-1]).
+        The rolling convention captures local liquidity regime;
+        expanding would average across regime shifts.
 
         For each tick t, fits: delta_P = lambda * signed_vol + alpha
-        on ticks [t-kyle_window, t-1] (strict past, excluding t).
+        on the kyle_window ticks immediately preceding t.
 
         Lambda is clamped to >= 0: negative lambda is economically
         unphysical (means "buy pressure lowers price"). When clamping

--- a/features/calculators/cvd_kyle.py
+++ b/features/calculators/cvd_kyle.py
@@ -1,0 +1,465 @@
+"""CVD + Kyle Lambda feature calculator (Kyle 1985).
+
+Computes Cumulative Volume Delta and Kyle's lambda (price impact
+coefficient) from tick-level trade data.
+
+Note on S02 MicrostructureAnalyzer.cvd() and kyle_lambda():
+    S02's cvd() returns a *normalized* ratio (sum(buy-sell)/total_vol)
+    bounded in [-1, 1]. This calculator needs the *raw* cumulative sum
+    of signed volume (unbounded, monotonically evolving). S02's
+    kyle_lambda() uses Cov(delta_P, Q)/Var(Q) without intercept and
+    without expanding-window protection against look-ahead. Since feature
+    validation requires (a) raw CVD, (b) OLS with intercept, and (c)
+    strict past expanding window, this calculator implements both
+    directly rather than wrapping S02. S02 is NOT modified
+    (anti-scope-creep). Decision documented as D032.
+
+Output columns (6):
+    cvd: Cumulative signed volume from t=0. Realization at tick t.
+    cvd_divergence: tanh-normalized divergence score of price vs CVD
+        trends over the past cvd_window ticks, in [-1, +1].
+        Positive = accumulation (CVD up, price flat/down).
+        Negative = distribution (CVD down, price flat/up).
+        Realization at tick t (uses [t-cvd_window+1, t] inclusive).
+    kyle_lambda: Price impact coefficient from OLS regression
+        delta_P = lambda * signed_volume + alpha + epsilon over the
+        past kyle_window ticks [t-kyle_window, t-1] EXCLUSIVE of
+        current tick. Forecast-like at tick t. Always >= 0 (clamped;
+        negative lambda is economically unphysical).
+    kyle_lambda_zscore: z-score of kyle_lambda vs its rolling history
+        over kyle_zscore_lookback ticks.
+    liquidity_signal: tanh-normalized kyle_lambda_zscore in [-1, +1].
+        Positive = low liquidity (high lambda). Negative = high
+        liquidity (low lambda).
+    combined_signal: Weighted combination of cvd_divergence and
+        liquidity_signal, tanh in [-1, +1].
+
+D028 classification:
+    cvd, cvd_divergence: realization at tick t (include current tick,
+        no intra-tick look-ahead).
+    kyle_lambda, kyle_lambda_zscore, liquidity_signal,
+    combined_signal: forecast-like at tick t (OLS fit uses strict
+        past [t-kyle_window, t-1], excluding current tick).
+
+Look-ahead defense:
+    Kyle regression uses a rolling window of kyle_window ticks ending
+    at t-1 (exclusive of t). The OLS coefficients at tick t never see
+    data at or after t. Characterized by dedicated look-ahead test.
+
+Fallback for equities without L2:
+    Uses Lee-Ready-style classification: trade direction inferred from
+    ``side`` column. Reused pattern from OFI 3.6 trade-based fallback.
+
+Reference:
+    Kyle, A. S. (1985). "Continuous Auctions and Insider Trading".
+    Econometrica, 53(6), 1315-1335.
+    Hasbrouck, J. (2007). Empirical Market Microstructure, Ch. 8.
+    Lee, C. M. C. & Ready, M. J. (1991). "Inferring Trade Direction
+    from Intraday Data". Journal of Finance, 46(2).
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import numpy as np
+import numpy.typing as npt
+import polars as pl
+import structlog
+
+from features.base import FeatureCalculator
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+
+class CVDKyleCalculator(FeatureCalculator):
+    """CVD + Kyle Lambda calculator (Kyle 1985).
+
+    Computes:
+      - Cumulative Volume Delta (CVD) and price-CVD divergence signal
+      - Kyle's lambda (price impact per unit of order flow) via
+        rolling-window OLS regression
+      - Combined liquidity/directional signal
+
+    Output contract (D028):
+        cvd, cvd_divergence: realization at tick t (include current
+            tick). No data from ticks after t is used.
+        kyle_lambda, kyle_lambda_zscore, liquidity_signal,
+        combined_signal: forecast-like at tick t (OLS fit uses strict
+            past [t-kyle_window, t-1], excluding current tick).
+
+    Reference:
+        Kyle, A. S. (1985). "Continuous Auctions and Insider Trading".
+        Econometrica, 53(6), 1315-1335.
+        Hasbrouck, J. (2007). Empirical Market Microstructure, Ch. 8.
+        Lee, C. M. C. & Ready, M. J. (1991). "Inferring Trade
+        Direction from Intraday Data". Journal of Finance, 46(2).
+    """
+
+    _REQUIRED_COLUMNS: ClassVar[list[str]] = [
+        "timestamp",
+        "price",
+        "quantity",
+        "side",
+    ]
+
+    def __init__(
+        self,
+        cvd_window: int = 20,
+        kyle_window: int = 100,
+        kyle_zscore_lookback: int = 252,
+        cvd_divergence_k: float = 3.0,
+        liquidity_signal_k: float = 3.0,
+        combined_weights: tuple[float, float] = (0.5, 0.5),
+    ) -> None:
+        """Initialize CVDKyleCalculator.
+
+        Args:
+            cvd_window: Rolling window for CVD-price divergence
+                computation. Must be >= 2.
+            kyle_window: Number of past ticks for Kyle OLS regression.
+                Must be >= 10 for stable OLS.
+            kyle_zscore_lookback: Rolling lookback for kyle_lambda
+                z-score. Must be >= 2 * kyle_window.
+            cvd_divergence_k: Scaling factor for tanh normalization
+                of CVD divergence (D025 pattern).
+            liquidity_signal_k: Scaling factor for tanh normalization
+                of kyle_lambda_zscore (D025 pattern).
+            combined_weights: Weights (w_cvd, w_liquidity) for the
+                combined signal. Must sum to 1.0.
+        """
+        if cvd_window < 2:
+            raise ValueError(f"cvd_window must be >= 2, got {cvd_window}")
+        if kyle_window < 10:
+            raise ValueError(f"kyle_window must be >= 10 for stable OLS, got {kyle_window}")
+        if kyle_zscore_lookback < kyle_window * 2:
+            raise ValueError(
+                f"kyle_zscore_lookback must be >= 2 * kyle_window, "
+                f"got {kyle_zscore_lookback} < {2 * kyle_window}"
+            )
+        if abs(sum(combined_weights) - 1.0) > 1e-9:
+            raise ValueError(f"combined_weights must sum to 1.0, got {sum(combined_weights)}")
+        self._cvd_window = cvd_window
+        self._kyle_window = kyle_window
+        self._kyle_zscore_lookback = kyle_zscore_lookback
+        self._cvd_divergence_k = cvd_divergence_k
+        self._liquidity_signal_k = liquidity_signal_k
+        self._combined_weights = combined_weights
+
+    # ------------------------------------------------------------------
+    # FeatureCalculator ABC
+    # ------------------------------------------------------------------
+
+    def name(self) -> str:
+        return "cvd_kyle"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    def required_columns(self) -> list[str]:
+        return list(self._REQUIRED_COLUMNS)
+
+    def output_columns(self) -> list[str]:
+        return [
+            "cvd",
+            "cvd_divergence",
+            "kyle_lambda",
+            "kyle_lambda_zscore",
+            "liquidity_signal",
+            "combined_signal",
+        ]
+
+    def compute(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Compute CVD, Kyle lambda, and derived signals.
+
+        Args:
+            df: Input ticks with at least :meth:`required_columns`.
+
+        Returns:
+            New DataFrame with 6 additional output columns.
+        """
+        self.validate_input(df)
+        n_rows = len(df)
+
+        # Monotonic timestamp invariant (Phase 3.4+ pattern).
+        if n_rows > 1 and not df["timestamp"].is_sorted():
+            raise ValueError(
+                "CVDKyleCalculator.compute() requires ascending-sorted "
+                "'timestamp' to preserve look-ahead safety. "
+                "Call df.sort('timestamp') before."
+            )
+
+        if n_rows == 0:
+            return df.with_columns(
+                *[pl.Series(col, [], dtype=pl.Float64) for col in self.output_columns()]
+            )
+
+        # Step 1: Signed volume per tick.
+        signed_vol = self._compute_signed_volume(df)
+
+        # Step 2: Cumulative CVD.
+        cvd = np.cumsum(signed_vol)
+
+        # Step 3: CVD-price divergence (realization at tick t).
+        prices = df["price"].to_numpy().astype(np.float64)
+        cvd_divergence = self._compute_cvd_divergence(prices, cvd)
+
+        # Step 4: Price changes for Kyle regression.
+        delta_p = np.zeros(n_rows, dtype=np.float64)
+        delta_p[1:] = np.diff(prices)
+
+        # Step 5: Kyle lambda via rolling-window OLS on [t-kyle_window, t-1].
+        kyle_lambda = self._compute_kyle_lambda(delta_p, signed_vol)
+
+        # Step 6: Kyle z-score over kyle_zscore_lookback.
+        kyle_lambda_zscore = self._compute_kyle_zscore(kyle_lambda)
+
+        # Step 7: tanh normalizations.
+        liquidity_signal = self._tanh_normalize_signal(kyle_lambda_zscore, self._liquidity_signal_k)
+
+        # Step 8: Combined signal.
+        combined_signal = self._compute_combined_signal(cvd_divergence, liquidity_signal)
+
+        logger.info(
+            "cvd_kyle.compute.complete",
+            n_rows=n_rows,
+            kyle_window=self._kyle_window,
+            cvd_window=self._cvd_window,
+            valid_kyle=int(np.sum(~np.isnan(kyle_lambda))),
+            valid_cvd_div=int(np.sum(~np.isnan(cvd_divergence))),
+        )
+
+        return df.with_columns(
+            pl.Series("cvd", cvd),
+            pl.Series("cvd_divergence", cvd_divergence),
+            pl.Series("kyle_lambda", kyle_lambda),
+            pl.Series("kyle_lambda_zscore", kyle_lambda_zscore),
+            pl.Series("liquidity_signal", liquidity_signal),
+            pl.Series("combined_signal", combined_signal),
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_signed_volume(df: pl.DataFrame) -> npt.NDArray[np.float64]:
+        """Compute per-tick signed volume: +qty for BUY, -qty for SELL.
+
+        Args:
+            df: DataFrame with ``side`` and ``quantity`` columns.
+
+        Returns:
+            1-D array of signed volume per tick.
+        """
+        quantities = df["quantity"].to_numpy().astype(np.float64)
+        sides = df["side"].to_list()
+
+        signs = np.ones(len(quantities), dtype=np.float64)
+        for i, side in enumerate(sides):
+            s = str(side).upper()
+            if s in ("SELL", "S", "ASK"):
+                signs[i] = -1.0
+
+        return quantities * signs
+
+    def _compute_cvd_divergence(
+        self,
+        prices: npt.NDArray[np.float64],
+        cvd: npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.float64]:
+        """Compute CVD-price divergence score over rolling window.
+
+        Divergence = -correlation(price_changes, cvd_changes) over
+        the last cvd_window ticks. Negative correlation means CVD
+        and price move in opposite directions (divergence).
+
+        Score is tanh-normalized to [-1, +1]:
+        - Positive: accumulation (CVD rising, price flat/falling)
+        - Negative: distribution (CVD falling, price flat/rising)
+
+        Realization at tick t: uses [t-cvd_window+1, t] inclusive.
+
+        Args:
+            prices: Price array.
+            cvd: Cumulative volume delta array.
+
+        Returns:
+            Divergence signal in [-1, +1] (NaN during warm-up).
+        """
+        n = len(prices)
+        w = self._cvd_window
+        result = np.full(n, np.nan, dtype=np.float64)
+
+        if n < w:
+            return result
+
+        # Precompute tick-level changes.
+        price_changes = np.zeros(n, dtype=np.float64)
+        cvd_changes = np.zeros(n, dtype=np.float64)
+        price_changes[1:] = np.diff(prices)
+        cvd_changes[1:] = np.diff(cvd)
+
+        for t in range(w - 1, n):
+            pc_win = price_changes[t - w + 1 : t + 1]
+            cc_win = cvd_changes[t - w + 1 : t + 1]
+
+            std_p = float(np.std(pc_win))
+            std_c = float(np.std(cc_win))
+
+            if std_p < 1e-15 or std_c < 1e-15:
+                result[t] = 0.0
+                continue
+
+            corr = float(np.corrcoef(pc_win, cc_win)[0, 1])
+
+            if np.isnan(corr):
+                result[t] = 0.0
+                continue
+
+            # Negative correlation = divergence → positive signal.
+            # Scale by k to control tanh spread.
+            result[t] = float(np.tanh(-corr * self._cvd_divergence_k))
+
+        return result
+
+    def _compute_kyle_lambda(
+        self,
+        delta_p: npt.NDArray[np.float64],
+        signed_vol: npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.float64]:
+        """Compute Kyle's lambda via rolling-window OLS.
+
+        For each tick t, fits: delta_P = lambda * signed_vol + alpha
+        on ticks [t-kyle_window, t-1] (strict past, excluding t).
+
+        Lambda is clamped to >= 0: negative lambda is economically
+        unphysical (means "buy pressure lowers price"). When clamping
+        occurs, a warning is logged.
+
+        Args:
+            delta_p: Per-tick price changes.
+            signed_vol: Per-tick signed volume.
+
+        Returns:
+            Kyle lambda array (NaN during warm-up).
+        """
+        n = len(delta_p)
+        kw = self._kyle_window
+        result = np.full(n, np.nan, dtype=np.float64)
+        n_clamped = 0
+
+        for t in range(kw, n):
+            # Window: [t-kw, t-1] = kw ticks, all strictly before t.
+            start = t - kw
+            end = t  # exclusive
+
+            y = delta_p[start:end]
+            x = signed_vol[start:end]
+
+            # OLS with intercept: [x, 1] @ [lambda, alpha] = y.
+            x_mat = np.column_stack([x, np.ones(kw, dtype=np.float64)])
+            coeffs, _, _, _ = np.linalg.lstsq(x_mat, y, rcond=None)
+            lam = float(coeffs[0])
+
+            if lam < 0.0:
+                lam = 0.0
+                n_clamped += 1
+
+            result[t] = lam
+
+        if n_clamped > 0:
+            logger.warning(
+                "kyle_lambda.negative_ols_clamped",
+                n_clamped=n_clamped,
+                total_fits=max(0, n - kw),
+            )
+
+        return result
+
+    def _compute_kyle_zscore(
+        self,
+        kyle_lambda: npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.float64]:
+        """Compute z-score of kyle_lambda vs rolling history.
+
+        Args:
+            kyle_lambda: Kyle lambda array (may contain NaN).
+
+        Returns:
+            Z-score array (NaN where insufficient history).
+        """
+        n = len(kyle_lambda)
+        result = np.full(n, np.nan, dtype=np.float64)
+        lookback = self._kyle_zscore_lookback
+
+        # Collect valid lambda history for rolling z-score.
+        history: list[float] = []
+
+        for t in range(n):
+            if np.isnan(kyle_lambda[t]):
+                continue
+
+            history.append(float(kyle_lambda[t]))
+
+            if len(history) < 2:
+                continue
+
+            window = history[-lookback:]
+            mean = float(np.mean(window))
+            std = float(np.std(window, ddof=1))
+
+            if std < 1e-15:
+                result[t] = 0.0
+            else:
+                result[t] = (float(kyle_lambda[t]) - mean) / std
+
+        return result
+
+    @staticmethod
+    def _tanh_normalize_signal(
+        zscore: npt.NDArray[np.float64],
+        k: float,
+    ) -> npt.NDArray[np.float64]:
+        """Normalize z-scores to [-1, +1] via tanh(zscore / k).
+
+        Args:
+            zscore: Z-score array (may contain NaN).
+            k: Scaling factor (D025 pattern).
+
+        Returns:
+            Signal in [-1, +1] (NaN where zscore is NaN).
+        """
+        n = len(zscore)
+        result = np.full(n, np.nan, dtype=np.float64)
+        valid = ~np.isnan(zscore)
+        result[valid] = np.tanh(zscore[valid] / k)
+        return result
+
+    def _compute_combined_signal(
+        self,
+        cvd_divergence: npt.NDArray[np.float64],
+        liquidity_signal: npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.float64]:
+        """Compute weighted combination of CVD divergence and liquidity.
+
+        combined = tanh(w0 * cvd_divergence + w1 * liquidity_signal)
+
+        NaN if either input is NaN.
+
+        Args:
+            cvd_divergence: CVD divergence signal.
+            liquidity_signal: Liquidity signal.
+
+        Returns:
+            Combined signal in [-1, +1].
+        """
+        n = len(cvd_divergence)
+        result = np.full(n, np.nan, dtype=np.float64)
+        w0, w1 = self._combined_weights
+
+        valid = ~np.isnan(cvd_divergence) & ~np.isnan(liquidity_signal)
+        result[valid] = np.tanh(w0 * cvd_divergence[valid] + w1 * liquidity_signal[valid])
+
+        return result

--- a/features/validation/cvd_kyle_report.py
+++ b/features/validation/cvd_kyle_report.py
@@ -1,0 +1,92 @@
+"""CVD + Kyle Lambda validation report -- Phase 3.7 synthetic-data scope.
+
+Thin wrapper over :class:`ICResult` that formats CVD/Kyle-specific
+validation output. Schema-compatible with HARRVValidationReport,
+RoughVolValidationReport, and OFIValidationReport (same summary()
+keys, same to_markdown() format).
+
+Reference:
+    PHASE_3_SPEC Section 2.7 success metrics.
+    ADR-0004 (``docs/adr/ADR-0004-feature-validation-methodology.md``).
+    Kyle, A. S. (1985). "Continuous Auctions and Insider Trading".
+    Econometrica, 53(6), 1315-1335.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+
+from features.ic.base import ICResult
+
+
+@dataclass(frozen=True)
+class CVDKyleValidationReport:
+    """Validation report for CVD + Kyle Lambda on synthetic data.
+
+    In Phase 3.7, this produces IC results on synthetic tick data.
+    Real BTC/ETH/SPY/QQQ validation is scheduled for Phase 5.
+
+    Schema compatibility with previous reports:
+    - summary() returns the same 4 keys
+    - to_markdown() produces the same table format
+    - is_significant=None renders as ``"n/a"`` (not ``"no"``)
+
+    Reference:
+        PHASE_3_SPEC Section 2.7.
+        Kyle (1985). Econometrica 53(6).
+    """
+
+    ic_results: tuple[ICResult, ...]
+    """IC measurement results (one per horizon or asset)."""
+
+    title: str = "CVD + Kyle Lambda Validation (Kyle 1985)"
+    """Report title."""
+
+    def to_json(self) -> str:
+        """Serialize the report to a JSON string."""
+        payload = {
+            "title": self.title,
+            "results": [asdict(r) for r in self.ic_results],
+            "summary": self.summary(),
+        }
+        return json.dumps(payload, indent=2, default=str)
+
+    def to_markdown(self) -> str:
+        """Render a concise Markdown summary table."""
+        lines: list[str] = [
+            f"# {self.title}",
+            "",
+            "| Feature | Horizon | IC | IC_IR | p-value | Significant |",
+            "|---------|--------:|----:|------:|--------:|:-----------:|",
+        ]
+        for r in self.ic_results:
+            if r.is_significant is None:
+                sig = "n/a"
+            else:
+                sig = "yes" if r.is_significant else "no"
+            name = r.feature_name if r.feature_name is not None else "cvd_kyle"
+            horizon = r.horizon_bars if r.horizon_bars is not None else 1
+            lines.append(
+                f"| {name} | {horizon} | {r.ic:+.4f} | {r.ic_ir:.3f} | {r.p_value:.4f} | {sig} |"
+            )
+        lines.append("")
+        return "\n".join(lines)
+
+    def summary(self) -> dict[str, object]:
+        """Return aggregate metrics for quick inspection."""
+        if not self.ic_results:
+            return {
+                "n_results": 0,
+                "mean_ic": 0.0,
+                "mean_ic_ir": 0.0,
+                "any_significant": False,
+            }
+        ics = [r.ic for r in self.ic_results]
+        ic_irs = [r.ic_ir for r in self.ic_results]
+        return {
+            "n_results": len(self.ic_results),
+            "mean_ic": sum(ics) / len(ics),
+            "mean_ic_ir": sum(ic_irs) / len(ic_irs),
+            "any_significant": any(r.is_significant for r in self.ic_results),
+        }

--- a/tests/unit/features/calculators/test_cvd_kyle.py
+++ b/tests/unit/features/calculators/test_cvd_kyle.py
@@ -1,0 +1,757 @@
+"""Unit tests for CVDKyleCalculator (Phase 3.7).
+
+31 tests covering ABC conformity, constructor validation (D030),
+correctness, look-ahead defense, D028 compliance, D029 variance
+gates, CVD pattern sanity, Kyle lambda sanity, edge cases,
+integration with ValidationPipeline, report schema, and version.
+
+Reference:
+    Kyle, A. S. (1985). "Continuous Auctions and Insider Trading".
+    Econometrica, 53(6), 1315-1335.
+    Hasbrouck, J. (2007). Empirical Market Microstructure, Ch. 8.
+    Lee, C. M. C. & Ready, M. J. (1991). JoF 46(2).
+    ADR-0004 (feature validation methodology).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from features.calculators.cvd_kyle import CVDKyleCalculator
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_ticks(
+    n_ticks: int,
+    seed: int = 42,
+    buy_ratio: float = 0.5,
+    price_impact: float = 0.0001,
+) -> pl.DataFrame:
+    """Generate synthetic tick data for CVD/Kyle testing.
+
+    Args:
+        n_ticks: Number of ticks.
+        seed: RNG seed.
+        buy_ratio: Proportion of ticks classified as BUY.
+        price_impact: Volatility per tick for price random walk.
+    """
+    rng = np.random.default_rng(seed)
+    base_time = datetime(2020, 1, 1, 9, 30, tzinfo=UTC)
+
+    timestamps: list[datetime] = []
+    prices: list[float] = []
+    quantities: list[float] = []
+    sides: list[str] = []
+
+    price = 100.0
+    for i in range(n_ticks):
+        ts = base_time + timedelta(milliseconds=i * 100)
+        ret = price_impact * rng.standard_normal()
+        price *= np.exp(ret)
+        qty = abs(rng.standard_normal() * 10) + 1.0
+        side = "BUY" if rng.random() < buy_ratio else "SELL"
+
+        timestamps.append(ts)
+        prices.append(round(price, 6))
+        quantities.append(round(qty, 4))
+        sides.append(side)
+
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "price": prices,
+            "quantity": quantities,
+            "side": sides,
+        }
+    )
+
+
+def _make_illiquid_ticks(
+    n_ticks: int,
+    seed: int = 42,
+    impact_scale: float = 0.01,
+) -> pl.DataFrame:
+    """Generate ticks where price moves strongly with order flow.
+
+    Higher impact_scale = more illiquid (price responds more to volume).
+    """
+    rng = np.random.default_rng(seed)
+    base_time = datetime(2020, 1, 1, 9, 30, tzinfo=UTC)
+
+    timestamps: list[datetime] = []
+    prices: list[float] = []
+    quantities: list[float] = []
+    sides: list[str] = []
+
+    price = 100.0
+    for i in range(n_ticks):
+        ts = base_time + timedelta(milliseconds=i * 100)
+        qty = abs(rng.standard_normal() * 10) + 1.0
+        side = "BUY" if rng.random() < 0.5 else "SELL"
+        sign = 1.0 if side == "BUY" else -1.0
+        # Price moves proportional to signed volume.
+        price += sign * qty * impact_scale + rng.standard_normal() * 0.001
+        price = max(price, 1.0)
+
+        timestamps.append(ts)
+        prices.append(round(price, 6))
+        quantities.append(round(qty, 4))
+        sides.append(side)
+
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "price": prices,
+            "quantity": quantities,
+            "side": sides,
+        }
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# ABC conformity (3 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestABCConformity:
+    """Verify CVDKyleCalculator honors the FeatureCalculator contract."""
+
+    def test_name_returns_cvd_kyle(self) -> None:
+        calc = CVDKyleCalculator()
+        assert calc.name() == "cvd_kyle"
+
+    def test_required_columns_contains_price_quantity_side(self) -> None:
+        calc = CVDKyleCalculator()
+        req = calc.required_columns()
+        for col in ["timestamp", "price", "quantity", "side"]:
+            assert col in req
+
+    def test_output_columns_are_six_expected(self) -> None:
+        calc = CVDKyleCalculator()
+        out = calc.output_columns()
+        assert out == [
+            "cvd",
+            "cvd_divergence",
+            "kyle_lambda",
+            "kyle_lambda_zscore",
+            "liquidity_signal",
+            "combined_signal",
+        ]
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Constructor validation — D030 (4 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestConstructorValidation:
+    """D030: all configurable params validated in __init__."""
+
+    def test_cvd_window_too_small_raises(self) -> None:
+        with pytest.raises(ValueError, match="cvd_window must be >= 2"):
+            CVDKyleCalculator(cvd_window=1)
+
+    def test_kyle_window_too_small_raises(self) -> None:
+        with pytest.raises(ValueError, match="kyle_window must be >= 10"):
+            CVDKyleCalculator(kyle_window=5)
+
+    def test_kyle_zscore_lookback_too_small_raises(self) -> None:
+        with pytest.raises(ValueError, match="kyle_zscore_lookback must be >= 2"):
+            CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=15)
+
+    def test_combined_weights_not_summing_to_one_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"sum to 1\.0"):
+            CVDKyleCalculator(combined_weights=(0.6, 0.6))
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Correctness (8 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestCorrectness:
+    """Verify computational correctness of CVDKyleCalculator."""
+
+    def test_compute_produces_six_output_columns(self) -> None:
+        calc = CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=20)
+        df = _make_ticks(200)
+        result = calc.compute(df)
+        for col in calc.output_columns():
+            assert col in result.columns
+
+    def test_warm_up_produces_nan(self) -> None:
+        """First kyle_window ticks have NaN on kyle_lambda."""
+        kw = 20
+        calc = CVDKyleCalculator(kyle_window=kw, kyle_zscore_lookback=kw * 2)
+        df = _make_ticks(200)
+        result = calc.compute(df)
+
+        kyle_arr = result["kyle_lambda"].to_numpy()
+        for i in range(kw):
+            assert np.isnan(kyle_arr[i]), f"kyle_lambda at tick {i} should be NaN during warm-up"
+        # After warm-up, should have values.
+        assert not np.isnan(kyle_arr[kw])
+
+    def test_cvd_is_monotonic_cumulative(self) -> None:
+        """CVD is cumulative: diff(cvd) = signed_volume per tick."""
+        calc = CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=20)
+        df = _make_ticks(100, seed=42)
+        result = calc.compute(df)
+
+        cvd_arr = result["cvd"].to_numpy()
+        quantities = df["quantity"].to_numpy().astype(np.float64)
+        sides = df["side"].to_list()
+
+        for i in range(1, len(cvd_arr)):
+            sign = 1.0 if str(sides[i]).upper() == "BUY" else -1.0
+            expected_diff = sign * quantities[i]
+            actual_diff = cvd_arr[i] - cvd_arr[i - 1]
+            np.testing.assert_allclose(actual_diff, expected_diff, rtol=1e-10)
+
+    @given(seed=st.integers(min_value=0, max_value=10000))
+    @settings(
+        max_examples=50 if os.environ.get("CI") else 300,
+        deadline=None,
+    )
+    def test_cvd_divergence_bounded(self, seed: int) -> None:
+        """cvd_divergence must be strictly in [-1, +1]."""
+        df = _make_ticks(50, seed=seed)
+        calc = CVDKyleCalculator(cvd_window=10, kyle_window=10, kyle_zscore_lookback=20)
+        result = calc.compute(df)
+        vals = result["cvd_divergence"].to_numpy()
+        valid = vals[~np.isnan(vals)]
+        if len(valid) > 0:
+            assert np.all(valid >= -1.0)
+            assert np.all(valid <= 1.0)
+
+    @given(seed=st.integers(min_value=0, max_value=10000))
+    @settings(
+        max_examples=50 if os.environ.get("CI") else 300,
+        deadline=None,
+    )
+    def test_kyle_lambda_non_negative(self, seed: int) -> None:
+        """kyle_lambda must always be >= 0 (or NaN during warm-up)."""
+        df = _make_ticks(200, seed=seed)
+        calc = CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=20)
+        result = calc.compute(df)
+        vals = result["kyle_lambda"].to_numpy()
+        valid = vals[~np.isnan(vals)]
+        if len(valid) > 0:
+            assert np.all(valid >= 0.0), f"Found negative kyle_lambda: {valid[valid < 0]}"
+
+    @given(seed=st.integers(min_value=0, max_value=10000))
+    @settings(
+        max_examples=50 if os.environ.get("CI") else 300,
+        deadline=None,
+    )
+    def test_liquidity_signal_bounded(self, seed: int) -> None:
+        """liquidity_signal must be strictly in [-1, +1]."""
+        df = _make_ticks(200, seed=seed)
+        calc = CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=20)
+        result = calc.compute(df)
+        vals = result["liquidity_signal"].to_numpy()
+        valid = vals[~np.isnan(vals)]
+        if len(valid) > 0:
+            assert np.all(valid >= -1.0)
+            assert np.all(valid <= 1.0)
+
+    @given(seed=st.integers(min_value=0, max_value=10000))
+    @settings(
+        max_examples=50 if os.environ.get("CI") else 300,
+        deadline=None,
+    )
+    def test_combined_signal_bounded(self, seed: int) -> None:
+        """combined_signal must be strictly in [-1, +1]."""
+        df = _make_ticks(200, seed=seed)
+        calc = CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=20)
+        result = calc.compute(df)
+        vals = result["combined_signal"].to_numpy()
+        valid = vals[~np.isnan(vals)]
+        if len(valid) > 0:
+            assert np.all(valid >= -1.0)
+            assert np.all(valid <= 1.0)
+
+    def test_determinism(self) -> None:
+        """Same inputs must produce identical outputs."""
+        df = _make_ticks(200, seed=42)
+        calc = CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=20)
+        r1 = calc.compute(df)
+        r2 = calc.compute(df)
+        for col in calc.output_columns():
+            v1 = r1[col].to_numpy()
+            v2 = r2[col].to_numpy()
+            mask = ~np.isnan(v1) & ~np.isnan(v2)
+            np.testing.assert_array_equal(v1[mask], v2[mask])
+            np.testing.assert_array_equal(np.isnan(v1), np.isnan(v2))
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Look-ahead defense (2 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestLookAheadDefense:
+    """Characterize that outputs never use future data."""
+
+    def test_kyle_lambda_at_t_uses_only_ticks_before_t(self) -> None:
+        """Two DataFrames identical on [0, 150], divergent on [151, 200].
+        kyle_lambda at ticks 120-150 must be bitwise identical.
+        """
+        df_a = _make_ticks(200, seed=42)
+        df_b = _make_ticks(200, seed=42)
+
+        # Diverge from tick 151 onward.
+        rng = np.random.default_rng(99)
+        quantities_b = df_b["quantity"].to_list()
+        sides_b = df_b["side"].to_list()
+        prices_b = df_b["price"].to_list()
+        for i in range(151, 200):
+            quantities_b[i] = abs(rng.standard_normal() * 100) + 1.0
+            sides_b[i] = "BUY" if rng.random() > 0.5 else "SELL"
+            prices_b[i] = 100.0 + rng.standard_normal() * 5.0
+        df_b = df_b.with_columns(
+            pl.Series("quantity", quantities_b),
+            pl.Series("side", sides_b),
+            pl.Series("price", prices_b),
+        )
+
+        calc = CVDKyleCalculator(kyle_window=20, kyle_zscore_lookback=40)
+        result_a = calc.compute(df_a)
+        result_b = calc.compute(df_b)
+
+        for col in ["kyle_lambda", "kyle_lambda_zscore", "liquidity_signal"]:
+            for t in range(120, 151):
+                va = result_a[col][t]
+                vb = result_b[col][t]
+                if va is None and vb is None:
+                    continue
+                if isinstance(va, float) and isinstance(vb, float):
+                    if np.isnan(va) and np.isnan(vb):
+                        continue
+                assert va == pytest.approx(vb, rel=1e-12), (
+                    f"{col} at tick {t} differs: {va} vs {vb} — look-ahead detected!"
+                )
+
+    def test_cvd_divergence_realization_includes_current_tick(self) -> None:
+        """CVD divergence at tick t uses ticks [t-cvd_window+1, t].
+        Two DataFrames identical on [0, 19], tick 20 different.
+        cvd_divergence[20] must differ (proves current tick is used).
+        """
+        df_a = _make_ticks(30, seed=42)
+        df_b = _make_ticks(30, seed=42)
+
+        # Change tick 20 only.
+        quantities_b = df_b["quantity"].to_list()
+        sides_b = df_b["side"].to_list()
+        quantities_b[20] = 999.0  # Extreme quantity.
+        sides_b[20] = "SELL" if sides_b[20] == "BUY" else "BUY"
+        df_b = df_b.with_columns(
+            pl.Series("quantity", quantities_b),
+            pl.Series("side", sides_b),
+        )
+
+        calc = CVDKyleCalculator(cvd_window=10, kyle_window=10, kyle_zscore_lookback=20)
+        result_a = calc.compute(df_a)
+        result_b = calc.compute(df_b)
+
+        div_a = result_a["cvd_divergence"][20]
+        div_b = result_b["cvd_divergence"][20]
+
+        # At least one should not be NaN.
+        if isinstance(div_a, float) and isinstance(div_b, float):
+            if not np.isnan(div_a) and not np.isnan(div_b):
+                assert div_a != pytest.approx(div_b, rel=1e-6), (
+                    f"cvd_divergence at tick 20 is identical "
+                    f"({div_a} vs {div_b}) — current tick not included!"
+                )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# D028 compliance (1 test)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestD028Compliance:
+    """Verify D028: documentation declares correct classification."""
+
+    def test_docstring_declares_classification(self) -> None:
+        """CVDKyleCalculator docstring must declare realization at tick t
+        for cvd/divergence and forecast-like for kyle columns.
+        """
+        import inspect
+
+        source = inspect.getsource(CVDKyleCalculator)
+        assert "realization at tick t" in source, (
+            "Must document cvd/cvd_divergence as 'realization at tick t'"
+        )
+        assert "forecast-like at tick t" in source, (
+            "Must document kyle columns as 'forecast-like at tick t'"
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# D029 variance gates (3 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestSignalVarianceGates:
+    """D029: output signal columns must vary across inputs."""
+
+    def test_cvd_divergence_varies_across_inputs(self) -> None:
+        """Over 100 DataFrames, std of mean(cvd_divergence) > 0.01."""
+        means: list[float] = []
+        calc = CVDKyleCalculator(cvd_window=10, kyle_window=10, kyle_zscore_lookback=20)
+        for seed in range(100):
+            df = _make_ticks(80, seed=seed)
+            result = calc.compute(df)
+            vals = result["cvd_divergence"].to_numpy()
+            valid = vals[~np.isnan(vals)]
+            if len(valid) > 0:
+                means.append(float(np.mean(valid)))
+
+        assert len(means) >= 90
+        std_of_means = float(np.std(means))
+        assert std_of_means > 0.01, (
+            f"std(mean(cvd_divergence)) = {std_of_means:.6f} — D029 variance gate violation"
+        )
+
+    def test_liquidity_signal_varies_across_inputs(self) -> None:
+        """Over 100 DataFrames, std of mean(liquidity_signal) > 0.01."""
+        means: list[float] = []
+        calc = CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=20)
+        for seed in range(100):
+            df = _make_ticks(200, seed=seed)
+            result = calc.compute(df)
+            vals = result["liquidity_signal"].to_numpy()
+            valid = vals[~np.isnan(vals)]
+            if len(valid) > 0:
+                means.append(float(np.mean(valid)))
+
+        assert len(means) >= 90
+        std_of_means = float(np.std(means))
+        assert std_of_means > 0.01, (
+            f"std(mean(liquidity_signal)) = {std_of_means:.6f} — D029 variance gate violation"
+        )
+
+    def test_combined_signal_varies_across_inputs(self) -> None:
+        """Over 100 DataFrames, std of mean(combined_signal) > 0.01."""
+        means: list[float] = []
+        calc = CVDKyleCalculator(cvd_window=10, kyle_window=10, kyle_zscore_lookback=20)
+        for seed in range(100):
+            df = _make_ticks(200, seed=seed)
+            result = calc.compute(df)
+            vals = result["combined_signal"].to_numpy()
+            valid = vals[~np.isnan(vals)]
+            if len(valid) > 0:
+                means.append(float(np.mean(valid)))
+
+        assert len(means) >= 90
+        std_of_means = float(np.std(means))
+        assert std_of_means > 0.01, (
+            f"std(mean(combined_signal)) = {std_of_means:.6f} — D029 variance gate violation"
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# CVD-price divergence sanity (1 test)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestCVDDivergenceSanity:
+    """Verify CVD divergence detects known accumulation/distribution."""
+
+    def test_cvd_divergence_detects_known_pattern(self) -> None:
+        """Divergent vs convergent price-CVD relationship.
+
+        The divergence formula is tanh(-corr(price_changes, cvd_changes))
+        over a rolling window. The correlation is computed on tick-level
+        changes, so the test must inject tick-level correlation structure.
+
+        - Divergent: price moves AGAINST order flow (buy → price drops).
+          corr(price_changes, cvd_changes) < 0 → divergence > 0.
+        - Convergent: price moves WITH order flow (buy → price rises).
+          corr(price_changes, cvd_changes) > 0 → divergence < 0.
+        """
+        rng = np.random.default_rng(42)
+        base_time = datetime(2020, 1, 1, 9, 30, tzinfo=UTC)
+        n = 100
+
+        # Helper: build ticks where price change = direction * impact.
+        def _build(direction: float, seed: int) -> pl.DataFrame:
+            r = np.random.default_rng(seed)
+            ts: list[datetime] = []
+            pr: list[float] = []
+            qt: list[float] = []
+            sd: list[str] = []
+            price = 100.0
+            for i in range(n):
+                ts.append(base_time + timedelta(milliseconds=i * 100))
+                qty = 5.0 + r.random() * 10.0
+                side = "BUY" if r.random() < 0.6 else "SELL"
+                sign = 1.0 if side == "BUY" else -1.0
+                # Price change = direction * signed_vol + noise.
+                # direction > 0: price follows CVD (convergent).
+                # direction < 0: price opposes CVD (divergent).
+                price += direction * sign * qty * 0.01 + r.standard_normal() * 0.001
+                price = max(price, 1.0)
+                pr.append(round(price, 6))
+                qt.append(round(qty, 4))
+                sd.append(side)
+            return pl.DataFrame(
+                {
+                    "timestamp": ts,
+                    "price": pr,
+                    "quantity": qt,
+                    "side": sd,
+                }
+            )
+
+        df_divergent = _build(direction=-1.0, seed=42)
+        df_convergent = _build(direction=1.0, seed=42)
+
+        calc = CVDKyleCalculator(cvd_window=20, kyle_window=10, kyle_zscore_lookback=20)
+
+        result_div = calc.compute(df_divergent)
+        result_conv = calc.compute(df_convergent)
+
+        div_arr = result_div["cvd_divergence"].to_numpy()
+        conv_arr = result_conv["cvd_divergence"].to_numpy()
+
+        valid_div = div_arr[-30:]
+        valid_conv = conv_arr[-30:]
+        valid_div = valid_div[~np.isnan(valid_div)]
+        valid_conv = valid_conv[~np.isnan(valid_conv)]
+
+        mean_div = float(np.mean(valid_div))
+        mean_conv = float(np.mean(valid_conv))
+
+        assert mean_div > 0.0, f"Divergent pattern score = {mean_div:.4f}, expected > 0"
+        assert mean_conv < 0.0, f"Convergent pattern score = {mean_conv:.4f}, expected < 0"
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Kyle lambda sanity (1 test)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestKyleLambdaSanity:
+    """Verify Kyle lambda is higher on illiquid data."""
+
+    def test_kyle_lambda_higher_on_illiquid_data(self) -> None:
+        """Illiquid market (large price impact per unit volume) should
+        produce higher mean kyle_lambda than liquid market.
+        """
+        kw = 20
+        calc = CVDKyleCalculator(kyle_window=kw, kyle_zscore_lookback=kw * 2)
+
+        df_liquid = _make_illiquid_ticks(300, seed=42, impact_scale=0.0001)
+        df_illiquid = _make_illiquid_ticks(300, seed=42, impact_scale=0.01)
+
+        result_liquid = calc.compute(df_liquid)
+        result_illiquid = calc.compute(df_illiquid)
+
+        lam_liquid = result_liquid["kyle_lambda"].to_numpy()
+        lam_illiquid = result_illiquid["kyle_lambda"].to_numpy()
+
+        mean_liquid = float(np.nanmean(lam_liquid))
+        mean_illiquid = float(np.nanmean(lam_illiquid))
+
+        assert mean_illiquid > mean_liquid, (
+            f"Expected illiquid lambda ({mean_illiquid:.6f}) > liquid lambda ({mean_liquid:.6f})"
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Edge cases (3 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestEdgeCases:
+    """Edge cases: insufficient data, missing columns, unsorted ts."""
+
+    def test_insufficient_data_returns_nan(self) -> None:
+        """DataFrame smaller than kyle_window → all NaN on kyle_lambda."""
+        calc = CVDKyleCalculator(kyle_window=100, kyle_zscore_lookback=200)
+        df = _make_ticks(50)
+        result = calc.compute(df)
+
+        kyle_arr = result["kyle_lambda"].to_numpy()
+        assert np.all(np.isnan(kyle_arr)), (
+            "Expected all NaN on kyle_lambda with < kyle_window ticks"
+        )
+
+    def test_missing_required_column_raises(self) -> None:
+        """DataFrame without 'side' must raise ValueError."""
+        calc = CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=20)
+        df = pl.DataFrame(
+            {
+                "timestamp": [datetime(2020, 1, 1, tzinfo=UTC)],
+                "price": [100.0],
+                "quantity": [10.0],
+            }
+        )
+        with pytest.raises(ValueError, match="missing required columns"):
+            calc.compute(df)
+
+    def test_unsorted_timestamps_raise(self) -> None:
+        """Unsorted timestamps must raise ValueError."""
+        calc = CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=20)
+        df = _make_ticks(50)
+        df_unsorted = df.sort("timestamp", descending=True)
+        with pytest.raises(ValueError, match="ascending-sorted"):
+            calc.compute(df_unsorted)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Integration (2 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestIntegration:
+    """End-to-end tests through the ValidationPipeline."""
+
+    def test_cvd_kyle_through_validation_pipeline(self) -> None:
+        """Run CVDKyleCalculator through ICStage end-to-end."""
+        from features.ic.measurer import SpearmanICMeasurer
+        from features.validation.stages import ICStage, StageContext
+
+        calc = CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=20)
+        df = _make_ticks(500, seed=42)
+        result_df = calc.compute(df)
+
+        signals = result_df["combined_signal"].to_numpy()
+        prices = result_df["price"].to_numpy().astype(np.float64)
+        fwd_returns = np.full(len(prices), np.nan)
+        fwd_returns[:-1] = np.log(prices[1:] / prices[:-1])
+
+        mask = np.isfinite(signals) & np.isfinite(fwd_returns)
+        feat_clean = signals[mask]
+        fwd_clean = fwd_returns[mask]
+
+        measurer = SpearmanICMeasurer(rolling_window=50, bootstrap_n=100)
+        ctx = StageContext(
+            feature_name=calc.name(),
+            data=result_df,
+            metadata={
+                "feature_values": feat_clean,
+                "forward_returns": fwd_clean,
+                "horizon_bars": 1,
+            },
+        )
+        stage_result = ICStage(measurer=measurer).run(ctx)
+
+        assert stage_result.stage.value == "ic"
+        assert "ic" in stage_result.metrics
+        assert "ic_ir" in stage_result.metrics
+
+    def test_combined_signal_has_measurable_ic_on_synthetic_predictive_data(
+        self,
+    ) -> None:
+        """Build synthetic data where combined_signal predicts
+        forward returns. Verify measured IC > 0.1.
+        """
+        calc = CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=20)
+        df = _make_ticks(500, seed=42)
+        result_df = calc.compute(df)
+
+        signals = result_df["combined_signal"].to_numpy()
+        prices = result_df["price"].to_numpy().astype(np.float64)
+
+        fwd_raw = np.full(len(prices), np.nan)
+        fwd_raw[:-1] = np.log(prices[1:] / prices[:-1])
+
+        rng = np.random.default_rng(42)
+        mask = np.isfinite(signals) & np.isfinite(fwd_raw)
+        fwd_synthetic = np.copy(fwd_raw)
+        alpha = 0.3
+        noise = rng.standard_normal(int(mask.sum())) * 0.01
+        fwd_synthetic[mask] = alpha * signals[mask] + noise
+
+        feat_clean = signals[mask]
+        fwd_clean = fwd_synthetic[mask]
+
+        from features.ic.measurer import SpearmanICMeasurer
+
+        measurer = SpearmanICMeasurer(rolling_window=50, bootstrap_n=100)
+        ic_result = measurer.measure_rich(
+            feature=feat_clean,
+            forward_returns=fwd_clean,
+            feature_name="combined_signal",
+            horizon_bars=1,
+        )
+        assert abs(ic_result.ic) > 0.1, (
+            f"IC = {ic_result.ic:.4f} — expected > 0.1 on predictive data"
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Report (2 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestReport:
+    """Verify CVDKyleValidationReport schema stability."""
+
+    def test_report_summary_schema_stable_on_empty(self) -> None:
+        """summary() returns all 4 keys even with empty ic_results."""
+        from features.validation.cvd_kyle_report import (
+            CVDKyleValidationReport,
+        )
+
+        report = CVDKyleValidationReport(ic_results=())
+        summary = report.summary()
+        assert set(summary.keys()) == {
+            "n_results",
+            "mean_ic",
+            "mean_ic_ir",
+            "any_significant",
+        }
+        assert summary["any_significant"] is False
+
+    def test_report_to_markdown_renders_none_significance_as_na(
+        self,
+    ) -> None:
+        """is_significant=None renders as 'n/a', not 'no'."""
+        from features.ic.base import ICResult
+        from features.validation.cvd_kyle_report import (
+            CVDKyleValidationReport,
+        )
+
+        result = ICResult(
+            ic=0.03,
+            ic_ir=0.6,
+            p_value=0.04,
+            n_samples=100,
+            ci_low=0.01,
+            ci_high=0.05,
+            feature_name="combined_signal",
+            is_significant=None,
+        )
+        report = CVDKyleValidationReport(ic_results=(result,))
+        md = report.to_markdown()
+        assert "n/a" in md
+        lines = [ln for ln in md.split("\n") if "combined_signal" in ln and "+0.0300" in ln]
+        assert len(lines) == 1
+        assert "| no |" not in lines[0]
+        assert "| n/a |" in lines[0]
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Additional (1 test)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestAdditional:
+    """Miscellaneous tests."""
+
+    def test_version_is_semver(self) -> None:
+        calc = CVDKyleCalculator()
+        assert calc.version == "1.0.0"

--- a/tests/unit/features/calculators/test_cvd_kyle.py
+++ b/tests/unit/features/calculators/test_cvd_kyle.py
@@ -200,7 +200,7 @@ class TestCorrectness:
         # After warm-up, should have values.
         assert not np.isnan(kyle_arr[kw])
 
-    def test_cvd_is_monotonic_cumulative(self) -> None:
+    def test_cvd_diff_equals_signed_volume(self) -> None:
         """CVD is cumulative: diff(cvd) = signed_volume per tick."""
         calc = CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=20)
         df = _make_ticks(100, seed=42)


### PR DESCRIPTION
## Summary

- Add `CVDKyleCalculator` with 6 output columns: `cvd`, `cvd_divergence`, `kyle_lambda`, `kyle_lambda_zscore`, `liquidity_signal`, `combined_signal`
- Kyle lambda via rolling-window OLS on strict past `[t-kyle_window, t-1]` (forecast-like at tick t, D024). Lambda clamped ≥ 0 (economic constraint)
- CVD divergence via `tanh(-corr(price_changes, cvd_changes))` over rolling window (realization at tick t)
- 31 unit tests, 92.28% features/ coverage, 0 regressions

## Files Created/Modified

| File | LOC | Purpose |
|------|-----|---------|
| `features/calculators/cvd_kyle.py` | 478 | CVDKyleCalculator implementation |
| `features/validation/cvd_kyle_report.py` | 93 | Validation report (ICResult wrapper) |
| `features/calculators/__init__.py` | +5 | Register CVDKyleCalculator |
| `tests/unit/features/calculators/test_cvd_kyle.py` | 745 | 31 unit tests |

## CVD/Kyle Source Paths

S02 `cvd()` (`services/s02_signal_engine/microstructure.py:83`) and `kyle_lambda()` (`:100`) were **NOT wrapped**:
- S02 `cvd()` returns normalized ratio `Σ(buy-sell)/total_vol` ∈ [-1,1]. We need raw cumulative sum (unbounded).
- S02 `kyle_lambda()` uses `Cov(ΔP,Q)/Var(Q)` without intercept or expanding window. We need OLS with intercept on strict past window.
- Decision D032 (same pattern as D030/OFI): implement directly, do not modify S02.

## D028 Classification

| Column | Classification | Justification |
|--------|---------------|---------------|
| `cvd` | realization at tick t | Cumulative sum includes tick t |
| `cvd_divergence` | realization at tick t | Uses window [t-w+1, t] inclusive |
| `kyle_lambda` | **forecast-like** at tick t | OLS fit on [t-kw, t-1], excludes tick t |
| `kyle_lambda_zscore` | forecast-like at tick t | Derived from kyle_lambda |
| `liquidity_signal` | forecast-like at tick t | tanh(kyle_lambda_zscore) |
| `combined_signal` | forecast-like at tick t | Follows strictest parent class |

## D029 Variance Gates (3 tests)

Each signal output has its own variance gate (100 DataFrames, `std(mean) > 0.01`):
- `test_cvd_divergence_varies_across_inputs` — CVD divergence can degenerate to 0 if price and CVD always co-move
- `test_liquidity_signal_varies_across_inputs` — liquidity signal can degenerate if lambda is stable across regimes
- `test_combined_signal_varies_across_inputs` — combined signal inherits risk from both parents

## D030 Constructor Validation (4 invariants)

| Parameter | Constraint | Error |
|-----------|-----------|-------|
| `cvd_window` | ≥ 2 | Correlation needs ≥ 2 data points |
| `kyle_window` | ≥ 10 | OLS stability |
| `kyle_zscore_lookback` | ≥ 2 × kyle_window | Meaningful z-score needs sufficient history |
| `combined_weights` | sum = 1.0 | Convex combination |

## Kyle Lambda Physical Constraints

Lambda is clamped to ≥ 0 when OLS returns negative (can happen on short/noisy windows). Negative lambda means "buy pressure lowers price" — economically unphysical. Clamping is logged via `structlog.warning("kyle_lambda.negative_ols_clamped", n_clamped=...)`.

## Tests (31)

| Category | Count | Tests |
|----------|-------|-------|
| ABC conformity | 3 | name, required_columns, output_columns |
| Constructor (D030) | 4 | cvd_window, kyle_window, zscore_lookback, weights |
| Correctness | 8 | columns, warm-up, CVD cumulative, bounds×4 (Hypothesis), determinism |
| Look-ahead | 2 | kyle_lambda strict past, cvd_divergence includes current tick |
| D028 doc | 1 | docstring classification keywords |
| D029 variance | 3 | cvd_divergence, liquidity_signal, combined_signal |
| CVD pattern | 1 | divergent vs convergent tick data |
| Kyle sanity | 1 | illiquid > liquid lambda |
| Edge cases | 3 | insufficient data, missing column, unsorted timestamps |
| Integration | 2 | ICStage pipeline, IC > 0.1 on predictive synthetic |
| Report | 2 | empty schema, None significance → "n/a" |
| Additional | 1 | version SemVer |

## Preflight

```
ruff check .              ✅ All checks passed
ruff format --check .     ✅ 385 files formatted
mypy . --strict           ✅ 0 errors (387 files)
pytest features/ tests    ✅ 267 passed, 0 regressions
coverage features/        ✅ 92.28% (cvd_kyle.py 94%)
```

## Test plan

- [ ] Copilot review
- [ ] CI passes (ruff, mypy, pytest, coverage ≥ 85%)
- [ ] Verify kyle_lambda ≥ 0 on all Hypothesis seeds (property test)
- [ ] Verify look-ahead defense: kyle_lambda independent of future ticks
- [ ] Verify D029 variance gates pass (not silently constant)
- [ ] **Do NOT merge** — wait for Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)