### PR TITLE
[Phase 3.8] GEX Validation (Barbon & Buraschi 2020) (#94)

### DIFF
--- a/docs/claude_memory/CONTEXT.md
+++ b/docs/claude_memory/CONTEXT.md
@@ -1,7 +1,7 @@
 # APEX Project Context Snapshot
 
 **Last updated**: 2026-04-13
-**Updated by**: Session 018
+**Updated by**: Session 020
 
 ---
 
@@ -9,16 +9,16 @@
 
 | Metric | Value |
 |---|---|
-| Active Phase | Phase 3 — Feature Validation Harness (3.7 PR #114 OPEN) |
+| Active Phase | Phase 3 — Feature Validation Harness (3.8 PR #116 OPEN) |
 | Previous Phase | Phase 2 — Universal Data Infrastructure (DONE) |
-| Total tests | 1,546+ (1,491 unit + 55 integration) |
+| Total tests | 1,582+ (1,522 unit + 55 integration + skips) |
 | Production LOC | ~35,300 |
 | Test LOC | ~22,700 |
 | mypy strict | 0 errors |
 | Services scaffolded | 10/10 (S01-S10) |
 | S01 fully implemented | Yes (78 files, 9,583 LOC) |
 | ADRs accepted | 10 (+ ADR-0004 Feature Validation Methodology) |
-| features/ coverage | 92.28% (267 tests) |
+| features/ coverage | 92.32% (298 tests) |
 
 ## Audit Status
 

--- a/docs/claude_memory/DECISIONS.md
+++ b/docs/claude_memory/DECISIONS.md
@@ -876,3 +876,43 @@ Phase 3.8 GEXCalculator needs dealer-adjusted gamma exposure per Barbon-Buraschi
 - D030 (OFI precedent), D032 (CVD/Kyle precedent)
 - Barbon & Buraschi (2020) "Gamma Fragility"
 - S02 `services/s02_signal_engine/crowd_behavior.py` lines 43-79
+
+---
+
+## D034 — Snapshot-Level IC Measurement for Snapshot-Granularity Features (2026-04-13)
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Session | 021 |
+| Decision | For features with multiple rows per timestamp, IC must be computed at snapshot level (one row per unique timestamp) |
+| Status | ACCEPTED |
+
+### Context
+
+PR #116 Copilot review caught that GEX integration tests computed forward returns by row-shifting `result_df`, which has `n_options_per_snapshot` rows per timestamp. Most adjacent rows shared the same snapshot, producing artificial zero returns (`log(spot/spot) = 0`) and IC sensitive to option chain density. The IC measurement was semantically incorrect.
+
+### Rule
+
+For features whose output columns are broadcast across multiple rows sharing the same timestamp (e.g., GEX across option rows):
+1. Aggregate result DataFrame by timestamp (one row per snapshot)
+2. Take signal value (broadcast = identical within snapshot)
+3. Compute forward returns at snapshot level
+4. Measure IC on snapshot-level pairs
+
+Row-level IC on such features produces artificial zero returns on same-snapshot adjacent rows and IC sensitive to broadcast density.
+
+### Applies To
+
+- GEX (3.8): multiple option rows per timestamp
+- Future snapshot-based features (OI imbalance, IV surface features)
+
+### Does NOT Apply To
+
+- Bar-level features (HAR-RV, Rough Vol): one row per bar
+- Tick-level features (OFI, CVD+Kyle): one row per tick
+
+### References
+
+- PR #116 Copilot review comment #4
+- PHASE_3_SPEC §2.8

--- a/docs/claude_memory/DECISIONS.md
+++ b/docs/claude_memory/DECISIONS.md
@@ -836,3 +836,43 @@ Phase 3.7 CVDKyleCalculator needs (a) raw cumulative CVD, (b) Kyle lambda via OL
 - D030 (OFI precedent: implement directly when S02 formula differs)
 - Kyle (1985) Econometrica 53(6)
 - S02 `services/s02_signal_engine/microstructure.py` lines 83-126
+
+---
+
+## D033 — GEX Implemented Directly (Not Wrapping S02) (2026-04-13)
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Session | 020 |
+| Decision | GEXCalculator implements GEX directly, not wrapping S02 CrowdBehaviorAnalyzer.update_gex() |
+| Status | ACCEPTED |
+
+### Context
+
+Phase 3.8 GEXCalculator needs dealer-adjusted gamma exposure per Barbon-Buraschi (2020): calls contribute negatively, puts positively, with S² dollar scaling and strict-past z-score. S02 provides `update_gex()` but with fundamentally different semantics:
+
+- S02 sign convention: calls = +1, puts = -1 (**opposite** of Barbon-Buraschi)
+- S02 formula: `gamma * OI * 100` (no S² scaling for dollar GEX)
+- S02 uses `float`, no strict-past protection, no rolling z-score
+
+### Why Not Wrap S02
+
+- Sign convention is **inverted** — wrapping would require negating the result and re-signing every option, defeating the wrapper purpose
+- Formula lacks S² factor for proper dollar GEX — wrapping would require multiplying by S² post-hoc
+- No rolling z-score or regime classification in S02
+- Same pattern as D030 (OFI) and D032 (CVD/Kyle): implement directly when S02 formula differs
+
+### Justification
+
+- S02 is NOT modified (anti-scope-creep)
+- D026 (wrapper strict) honored in spirit — would wrap if sign convention and formula matched
+- Barbon-Buraschi sign convention characterized by 2 dedicated tests
+- GEX formula: `Σ(sign_i * OI_i * gamma_i * S² * multiplier)` where sign = -1 calls, +1 puts
+
+### References
+
+- D026 (strict wrapper — honored where applicable)
+- D030 (OFI precedent), D032 (CVD/Kyle precedent)
+- Barbon & Buraschi (2020) "Gamma Fragility"
+- S02 `services/s02_signal_engine/crowd_behavior.py` lines 43-79

--- a/docs/claude_memory/PHASE_3_NOTES.md
+++ b/docs/claude_memory/PHASE_3_NOTES.md
@@ -17,7 +17,7 @@
 | 3.5 Rough Vol | IN_PROGRESS | PR #112 open — 23 tests, 94% coverage |
 | 3.6 OFI | IN_PROGRESS | PR #113 open — 23 tests, 93% coverage |
 | 3.7 CVD + Kyle | IN_PROGRESS | PR #114 open — 31 tests, 94% coverage |
-| 3.8 GEX | PENDING | Risk: options data availability |
+| 3.8 GEX | IN_PROGRESS | PR #116 open — 31 tests, 98% coverage |
 | 3.9 Multicollinearity | PENDING | |
 | 3.10 CPCV | PENDING | |
 | 3.11 DSR/PBO | PENDING | backtesting/metrics.py has PSR/DSR |
@@ -96,3 +96,12 @@
 - 3.7 hotfix: doc "expanding" → "rolling window" for Kyle lambda, test rename. Zero real bugs found by Copilot.
 - 3 perf suggestions deferred to Phase 5 (ADR-0002 correctness-first). Tracking issue #115.
 - Kyle lambda clamp rate: 50-73% on random walk (expected), 0% on illiquid data (correct). Not a bug.
+- GEXCalculator: implements GEX inline (D033), NOT wrapping S02 (sign convention inverted, no S² formula)
+- S02 update_gex() sign: calls=+1, puts=-1. Barbon-Buraschi: calls=-1, puts=+1. Irreconcilable.
+- D028 applied: gex_raw/gex_normalized realization at t; gex_zscore/gex_regime/gex_signal forecast-like
+- D029 variance gates × 3: gex_raw, gex_zscore, gex_signal
+- D030 proactive: 3 ValueError constraints (zscore_lookback, regime thresholds, contract_multiplier)
+- Magnitude sanity: SPY-like chain → |gex_raw| ∈ [1e7, 1e12], confirmed by dedicated test
+- 298 tests on features/, 31 GEX tests, 1,582+ total tests (0 regressions)
+- **Phase 3.4-3.8 calculator wave COMPLETE**: 5/5 calculators validated (HAR-RV, Rough Vol, OFI, CVD+Kyle, GEX)
+- Route open for Phase 3.9 Multicollinearity + Orthogonalization

--- a/docs/claude_memory/PHASE_3_NOTES.md
+++ b/docs/claude_memory/PHASE_3_NOTES.md
@@ -105,3 +105,6 @@
 - 298 tests on features/, 31 GEX tests, 1,582+ total tests (0 regressions)
 - **Phase 3.4-3.8 calculator wave COMPLETE**: 5/5 calculators validated (HAR-RV, Rough Vol, OFI, CVD+Kyle, GEX)
 - Route open for Phase 3.9 Multicollinearity + Orthogonalization
+- 3.8 hotfix: data quality gate (spot_price constant per timestamp), case-insensitive option_type
+- D034: snapshot-level IC measurement for features with multiple rows per timestamp (GEX). Row-level IC produces artificial zero returns. Applies to all future snapshot-granularity features.
+- 300 tests on features/, 33 GEX tests, 1,584+ total tests (0 regressions after hotfix)

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -921,3 +921,38 @@ Each entry follows the template in `templates/SESSION_TEMPLATE.md`.
 
 - Await Copilot review on PR #116
 - Phase 3.9 Multicollinearity + Orthogonalization after merge
+
+---
+
+## Session 021 — 2026-04-13
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Mission | PR #116 Copilot review hotfix |
+| Agent Model | Claude Opus 4.6 |
+| Duration | ~20 min |
+
+### What Changed
+
+- MODIFIED: `features/calculators/gex.py` — spot_price consistency validation (data quality gate), case-insensitive option_type normalization, strike/expiry requirement documented.
+- MODIFIED: `tests/unit/features/calculators/test_gex.py` — snapshot-level IC measurement in integration tests (D034), 2 new tests (33 total).
+
+### Key Findings
+
+- Copilot found 2 real bugs: (1) spot_price inconsistency within timestamp silently produces wrong GEX, (2) integration tests computed forward returns at row level instead of snapshot level (IC was measuring noise).
+- D034 pattern: snapshot-level IC is the correct default for features with multiple rows per timestamp (GEX). Row-level IC only for tick/bar features.
+- First hotfix with a test design bug (not calculator bug).
+
+### Quality Gates
+
+- ruff check + format: clean
+- mypy --strict: 0 errors
+- 300 features/ tests passed (33 GEX), 0 regressions
+- features/ coverage: 92.35%
+- Full suite: 1,584 passed, 0 regressions
+
+### Next Steps
+
+- Await Copilot re-review on PR #116
+- Phase 3.9 after merge

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -875,3 +875,49 @@ Each entry follows the template in `templates/SESSION_TEMPLATE.md`.
 
 - Await Copilot re-review on PR #114
 - Phase 3.8 GEX after merge
+
+---
+
+## Session 020 — 2026-04-13
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Mission | Phase 3.8 — GEX Validation (Barbon & Buraschi 2020) (#94) |
+| Agent Model | Claude Opus 4.6 |
+| Duration | ~45 min |
+
+### Decisions Made
+
+1. D033: GEX implemented inline (not wrapping S02 update_gex). S02 uses opposite sign convention (calls=+1, puts=-1 vs Barbon-Buraschi calls=-1, puts=+1), simpler formula (no S²), no strict-past protection.
+
+### Files Created
+
+- `features/calculators/gex.py` — GEXCalculator (310 LOC)
+- `features/validation/gex_report.py` — GEX validation report (107 LOC)
+- `tests/unit/features/calculators/test_gex.py` — 31 tests (719 LOC)
+
+### Files Modified
+
+- `features/calculators/__init__.py` — added GEXCalculator export
+
+### Key Findings
+
+- S02 `CrowdBehaviorAnalyzer.update_gex()` has **inverted** sign convention vs Barbon-Buraschi 2020. S02: calls=+1, puts=-1. Academic: calls=-1, puts=+1. Cannot wrap.
+- S07 has no options/GEX logic at all (gamma references are HMM forward-backward).
+- GEX magnitude sanity: synthetic SPY chain (S=400, 500 options, OI~1000, gamma~0.02) → |gex_raw| ∈ [1e7, 1e12]. Unit test confirms.
+- This completes the 3.4-3.8 calculator wave (5/5 calculators validated).
+
+### Quality Gates
+
+- ruff check + format: clean
+- mypy --strict: 0 errors (390 files)
+- 298 features/ tests passed (31 new GEX), 0 regressions
+- features/ coverage: 92.32%
+- gex.py coverage: 98%
+- Full suite: 1,582 passed, 0 regressions
+
+### Next Steps
+
+- Await Copilot review on PR #116
+- Phase 3.9 Multicollinearity + Orthogonalization after merge

--- a/features/calculators/__init__.py
+++ b/features/calculators/__init__.py
@@ -9,12 +9,14 @@ Reference:
 """
 
 from features.calculators.cvd_kyle import CVDKyleCalculator
+from features.calculators.gex import GEXCalculator
 from features.calculators.har_rv import HARRVCalculator
 from features.calculators.ofi import OFICalculator
 from features.calculators.rough_vol import RoughVolCalculator
 
 __all__ = [
     "CVDKyleCalculator",
+    "GEXCalculator",
     "HARRVCalculator",
     "OFICalculator",
     "RoughVolCalculator",

--- a/features/calculators/gex.py
+++ b/features/calculators/gex.py
@@ -1,0 +1,363 @@
+"""Gamma Exposure (GEX) feature calculator (Barbon & Buraschi 2020).
+
+Computes aggregate dealer gamma exposure from option chain snapshots.
+Dealer-adjusted sign convention: calls contribute negatively (dealers
+short calls sold to retail), puts positively (dealers long puts bought
+for hedge).
+
+Note on S02 CrowdBehaviorAnalyzer.update_gex():
+    S02's update_gex() uses the *opposite* sign convention (calls +1,
+    puts -1) and a simpler formula (gamma * OI * 100, no S^2 factor).
+    It also uses float, not Decimal, and has no strict-past protection.
+    Since feature validation requires (a) dealer-adjusted Barbon-Buraschi
+    sign convention, (b) S^2 scaling for dollar GEX, and (c) strict-past
+    z-score for forecast-like columns, this calculator implements GEX
+    directly rather than wrapping S02.
+    S02 is NOT modified (anti-scope-creep). Decision documented as D033.
+
+GEX = Sigma_i (sign_i * OI_i * gamma_i * S^2 * multiplier)
+where sign_i = -1 for calls, +1 for puts (Barbon-Buraschi 2020).
+
+Output columns (5):
+    gex_raw: Raw dollar GEX at timestamp t. Realization at t (uses
+        OI/gamma observed at t). Unit: dollars.
+    gex_normalized: gex_raw / spot_price, cross-asset comparable.
+        Realization at t.
+    gex_zscore: z-score of gex_raw over strict-past zscore_lookback
+        window [t-lookback, t-1] (forecast-like). Excludes current t.
+    gex_regime: Discrete {-1, 0, +1} based on zscore thresholds.
+        -1 = short gamma (amplifying), 0 = neutral, +1 = long gamma
+        (stabilizing). Forecast-like (derived from gex_zscore).
+    gex_signal: tanh-normalized zscore in [-1, +1] (forecast-like).
+
+D028 classification:
+    gex_raw, gex_normalized: realization at t (uses OI/gamma at t).
+    gex_zscore, gex_regime, gex_signal: forecast-like (use strict
+        past window [t-lookback, t-1]).
+
+Sign convention (dealer-adjusted):
+    Calls: dealers typically short (sold to retail) -> contribute
+        negatively to GEX.
+    Puts: dealers typically long (bought as hedge) -> contribute
+        positively.
+    This is the Barbon-Buraschi (2020) standard. See also
+    Baltussen et al. (2019) for alternative conventions.
+
+Reference:
+    Barbon, A. & Buraschi, A. (2020). "Gamma Fragility".
+        Working Paper, University of St. Gallen.
+    Baltussen, G., van Bekkum, S. & Da, Z. (2019). "Indexing and
+        Stock Market Serial Dependence Around the World".
+        Journal of Financial and Quantitative Analysis, 54(3).
+    Ni, Pearson & Poteshman (2005). "Stock price clustering on
+        option expiration dates". Journal of Financial
+        Economics, 78(2), 49-87.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import numpy as np
+import numpy.typing as npt
+import polars as pl
+import structlog
+
+from features.base import FeatureCalculator
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+
+class GEXCalculator(FeatureCalculator):
+    """Gamma Exposure calculator (Barbon & Buraschi 2020).
+
+    Computes aggregate dealer gamma exposure from option chain
+    snapshots. Dealer-adjusted sign convention: calls contribute
+    negatively (dealers short calls sold to retail), puts positively
+    (dealers long puts bought for hedge).
+
+    Output contract (D028):
+        gex_raw, gex_normalized: realization at t (snapshot-based,
+            uses OI/gamma observed at t).
+        gex_zscore, gex_regime, gex_signal: forecast-like (strict
+            past zscore_lookback window [t-lookback, t-1]).
+
+    Input format:
+        DataFrame with columns [timestamp, spot_price, strike, expiry,
+        option_type ('call'|'put'), open_interest, gamma]. Multiple
+        rows per timestamp (one per active option). Calculator
+        aggregates per timestamp.
+
+    Sign convention (dealer-adjusted):
+        Calls: -1 (dealers short). Puts: +1 (dealers long).
+        Characterized by test_calls_contribute_negatively and
+        test_puts_contribute_positively.
+
+    Reference:
+        Barbon, A. & Buraschi, A. (2020). "Gamma Fragility".
+        Working Paper, University of St. Gallen.
+        Baltussen et al. (2019). JFQA 54(3).
+        Ni, Pearson & Poteshman (2005). JFE 78(2).
+    """
+
+    _REQUIRED_COLUMNS: ClassVar[list[str]] = [
+        "timestamp",
+        "spot_price",
+        "strike",
+        "expiry",
+        "option_type",
+        "open_interest",
+        "gamma",
+    ]
+
+    _OUTPUT_COLUMNS: ClassVar[list[str]] = [
+        "gex_raw",
+        "gex_normalized",
+        "gex_zscore",
+        "gex_regime",
+        "gex_signal",
+    ]
+
+    def __init__(
+        self,
+        zscore_lookback: int = 252,
+        regime_lower_threshold: float = -1.0,
+        regime_upper_threshold: float = 1.0,
+        signal_k: float = 3.0,
+        contract_multiplier: int = 100,
+    ) -> None:
+        """Initialize GEXCalculator.
+
+        Args:
+            zscore_lookback: Number of past timestamps for z-score
+                rolling window. Must be >= 20.
+            regime_lower_threshold: Z-score below which regime is -1
+                (short gamma / amplifying).
+            regime_upper_threshold: Z-score above which regime is +1
+                (long gamma / stabilizing).
+            signal_k: Scaling factor for tanh normalization (D025).
+            contract_multiplier: Standard US equity option multiplier
+                (typically 100 shares per contract).
+        """
+        # D030 constructor validation.
+        if zscore_lookback < 20:
+            raise ValueError(f"zscore_lookback must be >= 20, got {zscore_lookback}")
+        if regime_lower_threshold >= regime_upper_threshold:
+            raise ValueError(
+                f"regime_lower_threshold must be < regime_upper_threshold, "
+                f"got {regime_lower_threshold} >= {regime_upper_threshold}"
+            )
+        if contract_multiplier <= 0:
+            raise ValueError(f"contract_multiplier must be > 0, got {contract_multiplier}")
+        self._zscore_lookback = zscore_lookback
+        self._regime_lower = regime_lower_threshold
+        self._regime_upper = regime_upper_threshold
+        self._signal_k = signal_k
+        self._contract_multiplier = contract_multiplier
+
+    # ------------------------------------------------------------------
+    # FeatureCalculator ABC
+    # ------------------------------------------------------------------
+
+    def name(self) -> str:
+        return "gex"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    def required_columns(self) -> list[str]:
+        return list(self._REQUIRED_COLUMNS)
+
+    def output_columns(self) -> list[str]:
+        return list(self._OUTPUT_COLUMNS)
+
+    def compute(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Compute GEX and derived signals from option chain snapshots.
+
+        Each timestamp may have multiple rows (one per active option).
+        The calculator aggregates per timestamp and broadcasts the
+        result back to all rows of that timestamp.
+
+        Args:
+            df: Input option chain with at least :meth:`required_columns`.
+
+        Returns:
+            New DataFrame with 5 additional output columns.
+        """
+        self.validate_input(df)
+        n_rows = len(df)
+
+        if n_rows == 0:
+            return df.with_columns(
+                *[pl.Series(col, [], dtype=pl.Float64) for col in self.output_columns()]
+            )
+
+        # Monotonic timestamp invariant (Phase 3.4+ pattern).
+        # Options chain has multiple rows per timestamp — we only
+        # require non-decreasing order (ties allowed within snapshot).
+        # Use is_sorted() which handles Duration/Datetime natively.
+        if n_rows > 1 and not df["timestamp"].is_sorted():
+            raise ValueError(
+                "GEXCalculator.compute() requires non-decreasing "
+                "'timestamp' to preserve look-ahead safety. "
+                "Call df.sort('timestamp') before."
+            )
+
+        # Validate option_type values.
+        unique_types = df.select(pl.col("option_type").unique()).to_series().to_list()
+        invalid = set(unique_types) - {"call", "put"}
+        if invalid:
+            raise ValueError(f"option_type must be 'call' or 'put', got invalid values: {invalid}")
+
+        # Step 1: Per-option contribution (dealer-adjusted sign).
+        # sign = -1 for calls, +1 for puts (Barbon-Buraschi 2020).
+        # contribution = sign * OI * gamma * S^2 * multiplier
+        sign_expr = (
+            pl.when(pl.col("option_type") == "call").then(pl.lit(-1.0)).otherwise(pl.lit(1.0))
+        )
+        df_with_contrib = df.with_columns(
+            (
+                sign_expr
+                * pl.col("open_interest").cast(pl.Float64)
+                * pl.col("gamma").cast(pl.Float64)
+                * pl.col("spot_price").cast(pl.Float64).pow(2)
+                * pl.lit(float(self._contract_multiplier))
+            ).alias("_gex_contribution")
+        )
+
+        # Step 2: Aggregate per timestamp -> per-snapshot GEX.
+        agg_df = df_with_contrib.group_by("timestamp", maintain_order=True).agg(
+            pl.col("_gex_contribution").sum().alias("gex_raw"),
+            pl.col("spot_price").first().alias("_spot_first"),
+        )
+
+        # Step 3: gex_normalized = gex_raw / spot_price.
+        agg_df = agg_df.with_columns(
+            (pl.col("gex_raw") / pl.col("_spot_first")).alias("gex_normalized")
+        )
+
+        # Steps 4-6: zscore, regime, signal (numpy for rolling logic).
+        gex_raw_arr = agg_df["gex_raw"].to_numpy().astype(np.float64)
+        n_snapshots = len(gex_raw_arr)
+
+        gex_zscore = self._compute_zscore(gex_raw_arr)
+        gex_regime = self._compute_regime(gex_zscore)
+        gex_signal = self._compute_signal(gex_zscore)
+
+        agg_df = agg_df.with_columns(
+            pl.Series("gex_zscore", gex_zscore),
+            pl.Series("gex_regime", gex_regime),
+            pl.Series("gex_signal", gex_signal),
+        )
+
+        # Step 7: Join back — broadcast per-timestamp aggregates.
+        join_cols = [
+            "gex_raw",
+            "gex_normalized",
+            "gex_zscore",
+            "gex_regime",
+            "gex_signal",
+        ]
+        result = df_with_contrib.drop("_gex_contribution").join(
+            agg_df.select(["timestamp", *join_cols]),
+            on="timestamp",
+            how="left",
+        )
+
+        logger.info(
+            "gex.compute.complete",
+            n_rows=n_rows,
+            n_snapshots=n_snapshots,
+            zscore_lookback=self._zscore_lookback,
+            valid_zscore=int(np.sum(~np.isnan(gex_zscore))),
+        )
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _compute_zscore(
+        self,
+        gex_raw: npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.float64]:
+        """Z-score of gex_raw over strict past window.
+
+        At timestamp t, uses gex_raw values from [t-lookback, t-1]
+        (excluding t). Forecast-like: never sees current observation.
+
+        Args:
+            gex_raw: Per-snapshot GEX values.
+
+        Returns:
+            Z-score array (NaN during warm-up).
+        """
+        n = len(gex_raw)
+        result = np.full(n, np.nan, dtype=np.float64)
+
+        for t in range(1, n):
+            start = max(0, t - self._zscore_lookback)
+            window = gex_raw[start:t]  # strict past, excludes t
+
+            if len(window) < 2:
+                continue
+
+            mean = float(np.mean(window))
+            std = float(np.std(window, ddof=1))
+
+            if std < 1e-15:
+                result[t] = 0.0
+            else:
+                result[t] = (gex_raw[t] - mean) / std
+
+        return result
+
+    def _compute_regime(
+        self,
+        zscore: npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.float64]:
+        """Map z-score to discrete regime {-1, 0, +1}.
+
+        -1 = short gamma (amplifying moves).
+         0 = neutral.
+        +1 = long gamma (stabilizing / dampening).
+
+        NaN where zscore is NaN.
+
+        Args:
+            zscore: Z-score array.
+
+        Returns:
+            Regime array.
+        """
+        n = len(zscore)
+        result = np.full(n, np.nan, dtype=np.float64)
+        valid = ~np.isnan(zscore)
+
+        result[valid & (zscore < self._regime_lower)] = -1.0
+        result[valid & (zscore > self._regime_upper)] = 1.0
+        result[valid & (zscore >= self._regime_lower) & (zscore <= self._regime_upper)] = 0.0
+
+        return result
+
+    def _compute_signal(
+        self,
+        zscore: npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.float64]:
+        """Normalize z-score to [-1, +1] via tanh(zscore / k).
+
+        NaN where zscore is NaN. D025 pattern.
+
+        Args:
+            zscore: Z-score array.
+
+        Returns:
+            Signal in [-1, +1].
+        """
+        n = len(zscore)
+        result = np.full(n, np.nan, dtype=np.float64)
+        valid = ~np.isnan(zscore)
+        result[valid] = np.tanh(zscore[valid] / self._signal_k)
+        return result

--- a/features/calculators/gex.py
+++ b/features/calculators/gex.py
@@ -103,12 +103,18 @@ class GEXCalculator(FeatureCalculator):
     _REQUIRED_COLUMNS: ClassVar[list[str]] = [
         "timestamp",
         "spot_price",
-        "strike",
-        "expiry",
+        "strike",  # Not used in GEX formula but required for audit trail
+        "expiry",  # and forward-compatibility (0DTE filtering, strike-buckets).
         "option_type",
         "open_interest",
         "gamma",
     ]
+    # Note: strike and expiry are not currently used in the GEX formula
+    # (GEX = sign * OI * gamma * S^2 * multiplier), but they are required
+    # inputs for auditability (reconstruct per-option contributions) and
+    # forward-compatibility with future features like 0DTE filtering or
+    # strike-distance bucketing. Keeping them required now avoids a
+    # breaking schema change later.
 
     _OUTPUT_COLUMNS: ClassVar[list[str]] = [
         "gex_raw",
@@ -204,11 +210,42 @@ class GEXCalculator(FeatureCalculator):
                 "Call df.sort('timestamp') before."
             )
 
-        # Validate option_type values.
+        # Normalize option_type to lowercase (case-insensitive acceptance).
+        df = df.with_columns(
+            pl.col("option_type").cast(pl.Utf8).str.strip_chars().str.to_lowercase()
+        )
+
+        # Validate option_type values (post-normalization).
         unique_types = df.select(pl.col("option_type").unique()).to_series().to_list()
         invalid = set(unique_types) - {"call", "put"}
         if invalid:
-            raise ValueError(f"option_type must be 'call' or 'put', got invalid values: {invalid}")
+            raise ValueError(
+                f"option_type must be 'call' or 'put' (case-insensitive), "
+                f"got invalid values: {invalid}"
+            )
+
+        # Data quality invariant: spot_price must be constant within a timestamp.
+        # Multiple options at the same timestamp reference the same underlying,
+        # so their spot must be identical. Variance within a timestamp indicates
+        # upstream data quality issues (stale quotes, unsynced snapshots).
+        spot_consistency = df.group_by("timestamp").agg(
+            pl.col("spot_price").n_unique().alias("_spot_uniques")
+        )
+        max_uniques = spot_consistency.select(pl.col("_spot_uniques").max()).item()
+        if isinstance(max_uniques, int) and max_uniques > 1:
+            bad_timestamps = (
+                spot_consistency.filter(pl.col("_spot_uniques") > 1)
+                .select("timestamp")
+                .limit(3)
+                .to_series()
+                .to_list()
+            )
+            raise ValueError(
+                f"spot_price must be constant within each timestamp, "
+                f"found {max_uniques} distinct spots. "
+                f"Sample offending timestamps: {bad_timestamps}. "
+                f"Upstream data quality issue — synchronize option chain snapshots."
+            )
 
         # Step 1: Per-option contribution (dealer-adjusted sign).
         # sign = -1 for calls, +1 for puts (Barbon-Buraschi 2020).

--- a/features/validation/gex_report.py
+++ b/features/validation/gex_report.py
@@ -1,0 +1,99 @@
+"""GEX validation report -- Phase 3.8 synthetic-data scope.
+
+Thin wrapper over :class:`ICResult` that formats GEX-specific
+validation output. Schema-compatible with HARRVValidationReport,
+RoughVolValidationReport, OFIValidationReport, and
+CVDKyleValidationReport (same summary() keys, same to_markdown()
+format).
+
+Reference:
+    PHASE_3_SPEC Section 2.8 success metrics.
+    ADR-0004 (``docs/adr/ADR-0004-feature-validation-methodology.md``).
+    Barbon, A. & Buraschi, A. (2020). "Gamma Fragility".
+    Working Paper, University of St. Gallen.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+
+from features.ic.base import ICResult
+
+
+@dataclass(frozen=True)
+class GEXValidationReport:
+    """Validation report for GEX on synthetic data.
+
+    In Phase 3.8, this produces IC results on synthetic option chain
+    data. Real SPY/QQQ validation is scheduled for Phase 5 (pending
+    options data source decision).
+
+    Schema compatibility with previous reports:
+    - summary() returns the same 4 keys
+    - to_markdown() produces the same table format
+    - is_significant=None renders as ``"n/a"`` (not ``"no"``)
+
+    Sign convention note:
+        Dealer-adjusted (Barbon-Buraschi 2020): calls -1, puts +1.
+
+    Reference:
+        PHASE_3_SPEC Section 2.8.
+        Barbon & Buraschi (2020). "Gamma Fragility".
+    """
+
+    ic_results: tuple[ICResult, ...]
+    """IC measurement results (one per horizon or asset)."""
+
+    title: str = "GEX Validation (Barbon & Buraschi 2020)"
+    """Report title."""
+
+    def to_json(self) -> str:
+        """Serialize the report to a JSON string."""
+        payload = {
+            "title": self.title,
+            "results": [asdict(r) for r in self.ic_results],
+            "summary": self.summary(),
+        }
+        return json.dumps(payload, indent=2, default=str)
+
+    def to_markdown(self) -> str:
+        """Render a concise Markdown summary table."""
+        lines: list[str] = [
+            f"# {self.title}",
+            "",
+            "| Feature | Horizon | IC | IC_IR | p-value | Significant |",
+            "|---------|--------:|----:|------:|--------:|:-----------:|",
+        ]
+        for r in self.ic_results:
+            if r.is_significant is None:
+                sig = "n/a"
+            else:
+                sig = "yes" if r.is_significant else "no"
+            feat_name = r.feature_name if r.feature_name is not None else "gex"
+            horizon = r.horizon_bars if r.horizon_bars is not None else 1
+            lines.append(
+                f"| {feat_name} | {horizon} "
+                f"| {r.ic:+.4f} | {r.ic_ir:.3f} "
+                f"| {r.p_value:.4f} | {sig} |"
+            )
+        lines.append("")
+        return "\n".join(lines)
+
+    def summary(self) -> dict[str, object]:
+        """Return aggregate metrics for quick inspection."""
+        if not self.ic_results:
+            return {
+                "n_results": 0,
+                "mean_ic": 0.0,
+                "mean_ic_ir": 0.0,
+                "any_significant": False,
+            }
+        ics = [r.ic for r in self.ic_results]
+        ic_irs = [r.ic_ir for r in self.ic_results]
+        return {
+            "n_results": len(self.ic_results),
+            "mean_ic": sum(ics) / len(ics),
+            "mean_ic_ir": sum(ic_irs) / len(ic_irs),
+            "any_significant": any(r.is_significant for r in self.ic_results),
+        }

--- a/tests/unit/features/calculators/test_gex.py
+++ b/tests/unit/features/calculators/test_gex.py
@@ -1,0 +1,808 @@
+"""Unit tests for GEXCalculator (Phase 3.8).
+
+31 tests covering ABC conformity, constructor validation (D030),
+input validation, correctness, sign convention sanity, magnitude
+sanity, look-ahead defense, D028 compliance, D029 variance gates,
+edge cases, integration with ValidationPipeline, report schema,
+and version.
+
+Reference:
+    Barbon, A. & Buraschi, A. (2020). "Gamma Fragility".
+    Working Paper, University of St. Gallen.
+    Baltussen et al. (2019). JFQA 54(3).
+    Ni, Pearson & Poteshman (2005). JFE 78(2).
+    ADR-0004 (feature validation methodology).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from features.calculators.gex import GEXCalculator
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_option_chain(
+    n_snapshots: int,
+    n_options_per_snapshot: int = 20,
+    seed: int = 42,
+    spot_base: float = 400.0,
+    spot_drift: float = 0.001,
+    oi_base: float = 1000.0,
+    gamma_base: float = 0.02,
+) -> pl.DataFrame:
+    """Generate synthetic option chain data for GEX testing.
+
+    Produces a DataFrame with multiple rows per timestamp (one per
+    active option). Strikes are spaced around the spot price.
+
+    Args:
+        n_snapshots: Number of timestamps (snapshots).
+        n_options_per_snapshot: Options per snapshot (half calls,
+            half puts).
+        seed: RNG seed.
+        spot_base: Starting spot price (SPY-like ~400).
+        spot_drift: Per-snapshot drift.
+        oi_base: Base open interest per option.
+        gamma_base: Base gamma per option.
+    """
+    rng = np.random.default_rng(seed)
+    base_time = datetime(2020, 1, 1, 16, 0, tzinfo=UTC)
+    expiry = datetime(2020, 2, 21, 16, 0, tzinfo=UTC)
+
+    timestamps: list[datetime] = []
+    spot_prices: list[float] = []
+    strikes: list[float] = []
+    expiries: list[datetime] = []
+    option_types: list[str] = []
+    open_interests: list[float] = []
+    gammas: list[float] = []
+
+    spot = spot_base
+    n_half = n_options_per_snapshot // 2
+
+    for snap_idx in range(n_snapshots):
+        ts = base_time + timedelta(days=snap_idx)
+        spot *= np.exp(spot_drift * rng.standard_normal())
+
+        for opt_idx in range(n_options_per_snapshot):
+            if opt_idx < n_half:
+                opt_type = "call"
+            else:
+                opt_type = "put"
+
+            # Strikes spread around spot.
+            strike_offset = (opt_idx - n_half) * 5.0
+            strike = round(spot + strike_offset, 2)
+
+            oi = max(1.0, oi_base + rng.standard_normal() * 200.0)
+            # Gamma is always positive; higher near ATM.
+            distance = abs(strike - spot) / spot
+            gamma = max(
+                1e-6,
+                gamma_base * np.exp(-5.0 * distance) + rng.random() * 0.005,
+            )
+
+            timestamps.append(ts)
+            spot_prices.append(round(spot, 4))
+            strikes.append(strike)
+            expiries.append(expiry)
+            option_types.append(opt_type)
+            open_interests.append(round(oi, 2))
+            gammas.append(round(gamma, 6))
+
+    return pl.DataFrame(
+        {
+            "timestamp": timestamps,
+            "spot_price": spot_prices,
+            "strike": strikes,
+            "expiry": expiries,
+            "option_type": option_types,
+            "open_interest": open_interests,
+            "gamma": gammas,
+        }
+    )
+
+
+def _make_calls_only_chain(
+    n_snapshots: int = 5,
+    seed: int = 42,
+) -> pl.DataFrame:
+    """Option chain with ONLY calls (all positive OI, positive gamma)."""
+    return _make_option_chain(
+        n_snapshots=n_snapshots,
+        n_options_per_snapshot=10,
+        seed=seed,
+    ).filter(pl.col("option_type") == "call")
+
+
+def _make_puts_only_chain(
+    n_snapshots: int = 5,
+    seed: int = 42,
+) -> pl.DataFrame:
+    """Option chain with ONLY puts (all positive OI, positive gamma)."""
+    return _make_option_chain(
+        n_snapshots=n_snapshots,
+        n_options_per_snapshot=10,
+        seed=seed,
+    ).filter(pl.col("option_type") == "put")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# ABC conformity (3 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestABCConformity:
+    """Verify GEXCalculator honors the FeatureCalculator contract."""
+
+    def test_name_returns_gex(self) -> None:
+        calc = GEXCalculator()
+        assert calc.name() == "gex"
+
+    def test_required_columns_contains_seven_expected(self) -> None:
+        calc = GEXCalculator()
+        req = calc.required_columns()
+        expected = [
+            "timestamp",
+            "spot_price",
+            "strike",
+            "expiry",
+            "option_type",
+            "open_interest",
+            "gamma",
+        ]
+        for col in expected:
+            assert col in req, f"Missing required column: {col}"
+        assert len(req) == 7
+
+    def test_output_columns_are_five_expected(self) -> None:
+        calc = GEXCalculator()
+        out = calc.output_columns()
+        assert out == [
+            "gex_raw",
+            "gex_normalized",
+            "gex_zscore",
+            "gex_regime",
+            "gex_signal",
+        ]
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Constructor validation — D030 (3 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestConstructorValidation:
+    """D030: all configurable params validated in __init__."""
+
+    def test_zscore_lookback_too_small_raises(self) -> None:
+        with pytest.raises(ValueError, match="zscore_lookback must be >= 20"):
+            GEXCalculator(zscore_lookback=10)
+
+    def test_regime_thresholds_inverted_raises(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="regime_lower_threshold must be < regime_upper_threshold",
+        ):
+            GEXCalculator(
+                regime_lower_threshold=1.0,
+                regime_upper_threshold=-1.0,
+            )
+
+    def test_contract_multiplier_non_positive_raises(self) -> None:
+        with pytest.raises(ValueError, match="contract_multiplier must be > 0"):
+            GEXCalculator(contract_multiplier=0)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Input validation (2 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestInputValidation:
+    """Verify input DataFrame is validated before computation."""
+
+    def test_invalid_option_type_raises(self) -> None:
+        """option_type='straddle' must raise ValueError."""
+        calc = GEXCalculator()
+        df = pl.DataFrame(
+            {
+                "timestamp": [datetime(2020, 1, 1, tzinfo=UTC)],
+                "spot_price": [400.0],
+                "strike": [400.0],
+                "expiry": [datetime(2020, 2, 1, tzinfo=UTC)],
+                "option_type": ["straddle"],
+                "open_interest": [1000.0],
+                "gamma": [0.02],
+            }
+        )
+        with pytest.raises(ValueError, match="option_type must be"):
+            calc.compute(df)
+
+    def test_missing_required_column_raises(self) -> None:
+        """DataFrame without 'gamma' must raise ValueError."""
+        calc = GEXCalculator()
+        df = pl.DataFrame(
+            {
+                "timestamp": [datetime(2020, 1, 1, tzinfo=UTC)],
+                "spot_price": [400.0],
+                "strike": [400.0],
+                "expiry": [datetime(2020, 2, 1, tzinfo=UTC)],
+                "option_type": ["call"],
+                "open_interest": [1000.0],
+            }
+        )
+        with pytest.raises(ValueError, match="missing required columns"):
+            calc.compute(df)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Correctness (7 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestCorrectness:
+    """Verify computational correctness of GEXCalculator."""
+
+    def test_compute_produces_five_output_columns(self) -> None:
+        calc = GEXCalculator(zscore_lookback=20)
+        df = _make_option_chain(50, n_options_per_snapshot=10)
+        result = calc.compute(df)
+        for col in calc.output_columns():
+            assert col in result.columns
+
+    def test_warm_up_produces_nan_on_zscore(self) -> None:
+        """gex_zscore must be NaN at the first timestamp (no prior
+        history). gex_raw/gex_normalized must NOT be NaN.
+        """
+        calc = GEXCalculator(zscore_lookback=20)
+        df = _make_option_chain(30, n_options_per_snapshot=10)
+        result = calc.compute(df)
+
+        # Get unique timestamps and check first one.
+        first_ts = result["timestamp"].unique().sort()[0]
+        first_rows = result.filter(pl.col("timestamp") == first_ts)
+
+        # gex_raw available from first timestamp (no warm-up).
+        raw_vals = first_rows["gex_raw"].to_numpy()
+        assert not np.any(np.isnan(raw_vals)), "gex_raw should be available from first timestamp"
+
+        # gex_normalized also available from first timestamp.
+        norm_vals = first_rows["gex_normalized"].to_numpy()
+        assert not np.any(np.isnan(norm_vals)), (
+            "gex_normalized should be available from first timestamp"
+        )
+
+        # gex_zscore NaN at first timestamp (no prior data).
+        zscore_vals = first_rows["gex_zscore"].to_numpy()
+        assert np.all(np.isnan(zscore_vals)), "gex_zscore should be NaN at the first timestamp"
+
+    def test_gex_raw_available_from_first_timestamp(self) -> None:
+        """gex_raw is a snapshot aggregation — no warm-up needed."""
+        calc = GEXCalculator(zscore_lookback=20)
+        df = _make_option_chain(5, n_options_per_snapshot=10)
+        result = calc.compute(df)
+
+        first_ts = result["timestamp"].unique().sort()[0]
+        first_rows = result.filter(pl.col("timestamp") == first_ts)
+        raw_vals = first_rows["gex_raw"].to_numpy()
+        assert not np.any(np.isnan(raw_vals))
+
+    @given(seed=st.integers(min_value=0, max_value=10000))
+    @settings(
+        max_examples=50 if os.environ.get("CI") else 300,
+        deadline=None,
+    )
+    def test_gex_signal_bounded(self, seed: int) -> None:
+        """gex_signal must be strictly in [-1, +1]."""
+        df = _make_option_chain(30, n_options_per_snapshot=10, seed=seed)
+        calc = GEXCalculator(zscore_lookback=20)
+        result = calc.compute(df)
+        vals = result["gex_signal"].to_numpy()
+        valid = vals[~np.isnan(vals)]
+        if len(valid) > 0:
+            assert np.all(valid >= -1.0)
+            assert np.all(valid <= 1.0)
+
+    def test_gex_regime_in_minus_one_zero_plus_one(self) -> None:
+        """gex_regime values must be {-1, 0, +1} or NaN."""
+        calc = GEXCalculator(zscore_lookback=20)
+        df = _make_option_chain(50, n_options_per_snapshot=10)
+        result = calc.compute(df)
+        vals = result["gex_regime"].to_numpy()
+        valid = vals[~np.isnan(vals)]
+        unique_valid = set(valid.tolist())
+        allowed = {-1.0, 0.0, 1.0}
+        assert unique_valid.issubset(allowed), (
+            f"gex_regime has unexpected values: {unique_valid - allowed}"
+        )
+
+    def test_determinism(self) -> None:
+        """Same inputs must produce identical outputs."""
+        df = _make_option_chain(50, n_options_per_snapshot=10, seed=42)
+        calc = GEXCalculator(zscore_lookback=20)
+        r1 = calc.compute(df)
+        r2 = calc.compute(df)
+        for col in calc.output_columns():
+            v1 = r1[col].to_numpy()
+            v2 = r2[col].to_numpy()
+            mask = ~np.isnan(v1) & ~np.isnan(v2)
+            np.testing.assert_array_equal(v1[mask], v2[mask])
+            np.testing.assert_array_equal(np.isnan(v1), np.isnan(v2))
+
+    def test_version_is_semver(self) -> None:
+        calc = GEXCalculator()
+        assert calc.version == "1.0.0"
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Sign convention sanity (2 tests — CRITICAL for Barbon-Buraschi)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestSignConventionSanity:
+    """Characterize dealer-adjusted sign convention.
+
+    These 2 tests are THE non-negotiable characterization tests.
+    Getting the sign wrong inverts the entire signal.
+    """
+
+    def test_calls_contribute_negatively(self) -> None:
+        """Chain with ONLY calls (positive OI, positive gamma)
+        must produce gex_raw < 0 (dealers short calls).
+        """
+        calc = GEXCalculator(zscore_lookback=20)
+        df = _make_calls_only_chain(n_snapshots=5)
+        result = calc.compute(df)
+
+        # Every row should have gex_raw < 0.
+        raw_vals = result["gex_raw"].to_numpy()
+        valid = raw_vals[~np.isnan(raw_vals)]
+        assert len(valid) > 0
+        assert np.all(valid < 0.0), (
+            f"gex_raw for calls-only chain should be < 0, got {valid[:5]} (dealer short convention)"
+        )
+
+    def test_puts_contribute_positively(self) -> None:
+        """Chain with ONLY puts (positive OI, positive gamma)
+        must produce gex_raw > 0 (dealers long puts).
+        """
+        calc = GEXCalculator(zscore_lookback=20)
+        df = _make_puts_only_chain(n_snapshots=5)
+        result = calc.compute(df)
+
+        # Every row should have gex_raw > 0.
+        raw_vals = result["gex_raw"].to_numpy()
+        valid = raw_vals[~np.isnan(raw_vals)]
+        assert len(valid) > 0
+        assert np.all(valid > 0.0), (
+            f"gex_raw for puts-only chain should be > 0, got {valid[:5]} (dealer long convention)"
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Magnitude sanity (1 test)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestMagnitudeSanity:
+    """Verify GEX magnitude is in a realistic range."""
+
+    def test_gex_magnitude_realistic(self) -> None:
+        """Synthetic SPY-like chain (~500 options, OI~1000, gamma~0.01-0.05,
+        S=400, mult=100) should produce |gex_raw| in [1e7, 1e12].
+
+        Order of magnitude per option:
+        sign * 1000 * 0.02 * 400^2 * 100 = sign * 320,000,000
+        Sum over ~500 options with mixed signs → 1e8 to 1e11 range.
+        """
+        calc = GEXCalculator(zscore_lookback=20, contract_multiplier=100)
+        df = _make_option_chain(
+            n_snapshots=5,
+            n_options_per_snapshot=500,
+            seed=42,
+            spot_base=400.0,
+            oi_base=1000.0,
+            gamma_base=0.02,
+        )
+        result = calc.compute(df)
+
+        first_ts = result["timestamp"].unique().sort()[0]
+        first_rows = result.filter(pl.col("timestamp") == first_ts)
+        gex_raw = first_rows["gex_raw"][0]
+
+        assert abs(gex_raw) >= 1e7, f"|gex_raw| = {abs(gex_raw):.2e} — too small, unit bug?"
+        assert abs(gex_raw) <= 1e12, f"|gex_raw| = {abs(gex_raw):.2e} — too large, unit bug?"
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Look-ahead defense (2 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestLookAheadDefense:
+    """Characterize that forecast-like outputs never use future data."""
+
+    def test_gex_zscore_at_t_uses_only_snapshots_before_t(self) -> None:
+        """Two DataFrames identical on timestamps [0, 50], divergent
+        on [51, 80]. gex_zscore at timestamps 20-50 must be bitwise
+        identical.
+        """
+        df_a = _make_option_chain(80, n_options_per_snapshot=10, seed=42)
+        df_b = _make_option_chain(80, n_options_per_snapshot=10, seed=42)
+
+        # Diverge from snapshot 51 onward: change OI and gamma.
+        unique_ts = df_b["timestamp"].unique().sort()
+        diverge_ts = unique_ts[51]
+        rng = np.random.default_rng(999)
+
+        oi_list = df_b["open_interest"].to_list()
+        gamma_list = df_b["gamma"].to_list()
+        ts_list = df_b["timestamp"].to_list()
+
+        for i in range(len(ts_list)):
+            if ts_list[i] >= diverge_ts:
+                oi_list[i] = max(1.0, abs(rng.standard_normal() * 5000.0))
+                gamma_list[i] = max(1e-6, abs(rng.standard_normal() * 0.1))
+
+        df_b = df_b.with_columns(
+            pl.Series("open_interest", oi_list),
+            pl.Series("gamma", gamma_list),
+        )
+
+        calc = GEXCalculator(zscore_lookback=20)
+        result_a = calc.compute(df_a)
+        result_b = calc.compute(df_b)
+
+        # Compare gex_zscore at timestamps 20-50 (first row per ts).
+        for idx in range(20, 51):
+            ts_val = unique_ts[idx]
+            rows_a = result_a.filter(pl.col("timestamp") == ts_val)
+            rows_b = result_b.filter(pl.col("timestamp") == ts_val)
+
+            va = rows_a["gex_zscore"][0]
+            vb = rows_b["gex_zscore"][0]
+
+            if isinstance(va, float) and isinstance(vb, float):
+                if np.isnan(va) and np.isnan(vb):
+                    continue
+            assert va == pytest.approx(vb, rel=1e-12), (
+                f"gex_zscore at snapshot {idx} differs: {va} vs {vb} — look-ahead detected!"
+            )
+
+    def test_different_future_same_past_yields_same_signal(self) -> None:
+        """Extension to gex_signal: same past → same signal."""
+        df_a = _make_option_chain(80, n_options_per_snapshot=10, seed=42)
+        df_b = _make_option_chain(80, n_options_per_snapshot=10, seed=42)
+
+        unique_ts = df_b["timestamp"].unique().sort()
+        diverge_ts = unique_ts[51]
+        rng = np.random.default_rng(999)
+
+        oi_list = df_b["open_interest"].to_list()
+        gamma_list = df_b["gamma"].to_list()
+        ts_list = df_b["timestamp"].to_list()
+
+        for i in range(len(ts_list)):
+            if ts_list[i] >= diverge_ts:
+                oi_list[i] = max(1.0, abs(rng.standard_normal() * 5000.0))
+                gamma_list[i] = max(1e-6, abs(rng.standard_normal() * 0.1))
+
+        df_b = df_b.with_columns(
+            pl.Series("open_interest", oi_list),
+            pl.Series("gamma", gamma_list),
+        )
+
+        calc = GEXCalculator(zscore_lookback=20)
+        result_a = calc.compute(df_a)
+        result_b = calc.compute(df_b)
+
+        for idx in range(20, 51):
+            ts_val = unique_ts[idx]
+            rows_a = result_a.filter(pl.col("timestamp") == ts_val)
+            rows_b = result_b.filter(pl.col("timestamp") == ts_val)
+
+            va = rows_a["gex_signal"][0]
+            vb = rows_b["gex_signal"][0]
+
+            if isinstance(va, float) and isinstance(vb, float):
+                if np.isnan(va) and np.isnan(vb):
+                    continue
+            assert va == pytest.approx(vb, rel=1e-12), (
+                f"gex_signal at snapshot {idx} differs: {va} vs {vb} — look-ahead detected!"
+            )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# D028 compliance (1 test)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestD028Compliance:
+    """Verify D028: documentation declares correct classification."""
+
+    def test_docstring_declares_classification(self) -> None:
+        """GEXCalculator docstring must declare realization at t
+        for gex_raw/gex_normalized and forecast-like for others.
+        """
+        import inspect
+
+        source = inspect.getsource(GEXCalculator)
+        assert "realization at t" in source.lower(), (
+            "Must document gex_raw/gex_normalized as 'realization at t'"
+        )
+        assert "forecast-like" in source.lower(), (
+            "Must document gex_zscore/gex_regime/gex_signal as 'forecast-like'"
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# D029 variance gates (3 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestSignalVarianceGates:
+    """D029: output signal columns must vary across inputs."""
+
+    def test_gex_raw_varies_across_inputs(self) -> None:
+        """Over 50 DataFrames, std of mean(gex_raw) > 0."""
+        means: list[float] = []
+        calc = GEXCalculator(zscore_lookback=20)
+        for seed in range(50):
+            df = _make_option_chain(30, n_options_per_snapshot=10, seed=seed)
+            result = calc.compute(df)
+            vals = result["gex_raw"].to_numpy()
+            valid = vals[~np.isnan(vals)]
+            if len(valid) > 0:
+                means.append(float(np.mean(valid)))
+
+        assert len(means) >= 40
+        std_of_means = float(np.std(means))
+        assert std_of_means > 0.01, (
+            f"std(mean(gex_raw)) = {std_of_means:.6f} — D029 variance gate violation"
+        )
+
+    def test_gex_zscore_varies_across_inputs(self) -> None:
+        """Over 50 DataFrames, std of mean(gex_zscore) > 0."""
+        means: list[float] = []
+        calc = GEXCalculator(zscore_lookback=20)
+        for seed in range(50):
+            df = _make_option_chain(30, n_options_per_snapshot=10, seed=seed)
+            result = calc.compute(df)
+            vals = result["gex_zscore"].to_numpy()
+            valid = vals[~np.isnan(vals)]
+            if len(valid) > 0:
+                means.append(float(np.mean(valid)))
+
+        assert len(means) >= 40
+        std_of_means = float(np.std(means))
+        assert std_of_means > 0.01, (
+            f"std(mean(gex_zscore)) = {std_of_means:.6f} — D029 variance gate violation"
+        )
+
+    def test_gex_signal_varies_across_inputs(self) -> None:
+        """Over 50 DataFrames, std of mean(gex_signal) > 0."""
+        means: list[float] = []
+        calc = GEXCalculator(zscore_lookback=20)
+        for seed in range(50):
+            df = _make_option_chain(30, n_options_per_snapshot=10, seed=seed)
+            result = calc.compute(df)
+            vals = result["gex_signal"].to_numpy()
+            valid = vals[~np.isnan(vals)]
+            if len(valid) > 0:
+                means.append(float(np.mean(valid)))
+
+        assert len(means) >= 40
+        std_of_means = float(np.std(means))
+        assert std_of_means > 0.01, (
+            f"std(mean(gex_signal)) = {std_of_means:.6f} — D029 variance gate violation"
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Edge cases (3 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestEdgeCases:
+    """Edge cases: single option, unsorted timestamps, empty DataFrame."""
+
+    def test_single_timestamp_single_option(self) -> None:
+        """1 row, 1 snapshot — should not crash."""
+        calc = GEXCalculator(zscore_lookback=20)
+        df = pl.DataFrame(
+            {
+                "timestamp": [datetime(2020, 1, 1, tzinfo=UTC)],
+                "spot_price": [400.0],
+                "strike": [400.0],
+                "expiry": [datetime(2020, 2, 1, tzinfo=UTC)],
+                "option_type": ["call"],
+                "open_interest": [1000.0],
+                "gamma": [0.02],
+            }
+        )
+        result = calc.compute(df)
+        assert len(result) == 1
+        for col in calc.output_columns():
+            assert col in result.columns
+
+        # gex_raw should be non-NaN (snapshot direct).
+        assert not np.isnan(result["gex_raw"][0])
+        # gex_zscore should be NaN (no prior history).
+        assert np.isnan(result["gex_zscore"][0])
+
+    def test_unsorted_timestamps_raise(self) -> None:
+        """Unsorted timestamps must raise ValueError."""
+        calc = GEXCalculator(zscore_lookback=20)
+        df = _make_option_chain(10, n_options_per_snapshot=5)
+        # Reverse the order.
+        df_unsorted = df.sort("timestamp", descending=True)
+        with pytest.raises(ValueError, match="non-decreasing"):
+            calc.compute(df_unsorted)
+
+    def test_empty_dataframe(self) -> None:
+        """Empty DataFrame with correct columns returns empty output."""
+        calc = GEXCalculator(zscore_lookback=20)
+        df = pl.DataFrame(
+            {
+                "timestamp": pl.Series([], dtype=pl.Datetime("us", "UTC")),
+                "spot_price": pl.Series([], dtype=pl.Float64),
+                "strike": pl.Series([], dtype=pl.Float64),
+                "expiry": pl.Series([], dtype=pl.Datetime("us", "UTC")),
+                "option_type": pl.Series([], dtype=pl.Utf8),
+                "open_interest": pl.Series([], dtype=pl.Float64),
+                "gamma": pl.Series([], dtype=pl.Float64),
+            }
+        )
+        result = calc.compute(df)
+        assert len(result) == 0
+        for col in calc.output_columns():
+            assert col in result.columns
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Integration (2 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestIntegration:
+    """End-to-end tests through the ValidationPipeline."""
+
+    def test_gex_through_validation_pipeline(self) -> None:
+        """Run GEXCalculator through ICStage end-to-end."""
+        from features.ic.measurer import SpearmanICMeasurer
+        from features.validation.stages import ICStage, StageContext
+
+        calc = GEXCalculator(zscore_lookback=20)
+        df = _make_option_chain(100, n_options_per_snapshot=20, seed=42)
+        result_df = calc.compute(df)
+
+        # Use gex_signal as the feature, dummy forward returns.
+        signals = result_df["gex_signal"].to_numpy()
+        spot = result_df["spot_price"].to_numpy().astype(np.float64)
+
+        # Create forward returns per row (log return of next row's spot).
+        fwd_returns = np.full(len(spot), np.nan)
+        fwd_returns[:-1] = np.log(spot[1:] / spot[:-1])
+
+        mask = np.isfinite(signals) & np.isfinite(fwd_returns)
+        feat_clean = signals[mask]
+        fwd_clean = fwd_returns[mask]
+
+        measurer = SpearmanICMeasurer(rolling_window=50, bootstrap_n=100)
+        ctx = StageContext(
+            feature_name=calc.name(),
+            data=result_df,
+            metadata={
+                "feature_values": feat_clean,
+                "forward_returns": fwd_clean,
+                "horizon_bars": 1,
+            },
+        )
+        stage_result = ICStage(measurer=measurer).run(ctx)
+
+        assert stage_result.stage.value == "ic"
+        assert "ic" in stage_result.metrics
+        assert "ic_ir" in stage_result.metrics
+
+    def test_gex_signal_has_measurable_ic_on_synthetic_predictive_data(
+        self,
+    ) -> None:
+        """Build synthetic data where gex_signal predicts forward
+        returns. Verify measured IC > 0.1.
+        """
+        calc = GEXCalculator(zscore_lookback=20)
+        df = _make_option_chain(100, n_options_per_snapshot=20, seed=42)
+        result_df = calc.compute(df)
+
+        signals = result_df["gex_signal"].to_numpy()
+        spot = result_df["spot_price"].to_numpy().astype(np.float64)
+
+        fwd_raw = np.full(len(spot), np.nan)
+        fwd_raw[:-1] = np.log(spot[1:] / spot[:-1])
+
+        rng = np.random.default_rng(42)
+        mask = np.isfinite(signals) & np.isfinite(fwd_raw)
+
+        # Inject predictive relationship.
+        fwd_synthetic = np.copy(fwd_raw)
+        alpha = 0.3
+        noise = rng.standard_normal(int(mask.sum())) * 0.01
+        fwd_synthetic[mask] = alpha * signals[mask] + noise
+
+        feat_clean = signals[mask]
+        fwd_clean = fwd_synthetic[mask]
+
+        from features.ic.measurer import SpearmanICMeasurer
+
+        measurer = SpearmanICMeasurer(rolling_window=50, bootstrap_n=100)
+        ic_result = measurer.measure_rich(
+            feature=feat_clean,
+            forward_returns=fwd_clean,
+            feature_name="gex_signal",
+            horizon_bars=1,
+        )
+        assert abs(ic_result.ic) > 0.1, (
+            f"IC = {ic_result.ic:.4f} — expected > 0.1 on predictive data"
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Report (2 tests)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestReport:
+    """Verify GEXValidationReport schema stability."""
+
+    def test_report_summary_schema_stable_on_empty(self) -> None:
+        """summary() returns all 4 keys even with empty ic_results."""
+        from features.validation.gex_report import (
+            GEXValidationReport,
+        )
+
+        report = GEXValidationReport(ic_results=())
+        summary = report.summary()
+        assert set(summary.keys()) == {
+            "n_results",
+            "mean_ic",
+            "mean_ic_ir",
+            "any_significant",
+        }
+        assert summary["any_significant"] is False
+
+    def test_report_to_markdown_renders_none_significance_as_na(
+        self,
+    ) -> None:
+        """is_significant=None renders as 'n/a', not 'no'."""
+        from features.ic.base import ICResult
+        from features.validation.gex_report import (
+            GEXValidationReport,
+        )
+
+        result = ICResult(
+            ic=0.03,
+            ic_ir=0.6,
+            p_value=0.04,
+            n_samples=100,
+            ci_low=0.01,
+            ci_high=0.05,
+            feature_name="gex_signal",
+            is_significant=None,
+        )
+        report = GEXValidationReport(ic_results=(result,))
+        md = report.to_markdown()
+        assert "n/a" in md
+        lines = [ln for ln in md.split("\n") if "gex_signal" in ln and "+0.0300" in ln]
+        assert len(lines) == 1
+        assert "| no |" not in lines[0]
+        assert "| n/a |" in lines[0]

--- a/tests/unit/features/calculators/test_gex.py
+++ b/tests/unit/features/calculators/test_gex.py
@@ -1,6 +1,6 @@
 """Unit tests for GEXCalculator (Phase 3.8).
 
-31 tests covering ABC conformity, constructor validation (D030),
+33 tests covering ABC conformity, constructor validation (D030),
 input validation, correctness, sign convention sanity, magnitude
 sanity, look-ahead defense, D028 compliance, D029 variance gates,
 edge cases, integration with ValidationPipeline, report schema,
@@ -204,7 +204,7 @@ class TestConstructorValidation:
 
 
 # ══════════════════════════════════════════════════════════════════════
-# Input validation (2 tests)
+# Input validation (4 tests)
 # ══════════════════════════════════════════════════════════════════════
 
 
@@ -227,6 +227,41 @@ class TestInputValidation:
         )
         with pytest.raises(ValueError, match="option_type must be"):
             calc.compute(df)
+
+    def test_inconsistent_spot_within_timestamp_raises(self) -> None:
+        """spot_price must be constant within a timestamp — data quality gate."""
+        calc = GEXCalculator()
+        df = pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 1, tzinfo=UTC)] * 2,
+                "spot_price": [400.0, 400.5],  # inconsistent!
+                "strike": [400.0, 400.0],
+                "expiry": [datetime(2024, 2, 1, tzinfo=UTC)] * 2,
+                "option_type": ["call", "put"],
+                "open_interest": [1000.0, 1000.0],
+                "gamma": [0.02, 0.02],
+            }
+        )
+        with pytest.raises(ValueError, match="spot_price must be constant"):
+            calc.compute(df)
+
+    def test_option_type_case_insensitive(self) -> None:
+        """option_type accepts CALL/Call/call and PUT/Put/put."""
+        calc = GEXCalculator(zscore_lookback=20)
+        df = pl.DataFrame(
+            {
+                "timestamp": [datetime(2020, 1, 1, tzinfo=UTC)] * 4,
+                "spot_price": [400.0] * 4,
+                "strike": [395.0, 400.0, 405.0, 410.0],
+                "expiry": [datetime(2020, 2, 1, tzinfo=UTC)] * 4,
+                "option_type": ["CALL", "Call", "PUT", "Put"],
+                "open_interest": [1000.0] * 4,
+                "gamma": [0.02] * 4,
+            }
+        )
+        result = calc.compute(df)
+        # Should not raise, should produce non-NaN gex_raw.
+        assert not np.isnan(result["gex_raw"][0])
 
     def test_missing_required_column_raises(self) -> None:
         """DataFrame without 'gamma' must raise ValueError."""
@@ -678,7 +713,12 @@ class TestIntegration:
     """End-to-end tests through the ValidationPipeline."""
 
     def test_gex_through_validation_pipeline(self) -> None:
-        """Run GEXCalculator through ICStage end-to-end."""
+        """Run GEXCalculator through ICStage end-to-end.
+
+        Forward returns are computed at snapshot level (one per unique
+        timestamp) — not row-level, since GEX has multiple option rows
+        per timestamp (D034 pattern).
+        """
         from features.ic.measurer import SpearmanICMeasurer
         from features.validation.stages import ICStage, StageContext
 
@@ -686,16 +726,23 @@ class TestIntegration:
         df = _make_option_chain(100, n_options_per_snapshot=20, seed=42)
         result_df = calc.compute(df)
 
-        # Use gex_signal as the feature, dummy forward returns.
-        signals = result_df["gex_signal"].to_numpy()
-        spot = result_df["spot_price"].to_numpy().astype(np.float64)
+        # Aggregate to snapshot level for IC measurement.
+        snapshot_df = (
+            result_df.group_by("timestamp", maintain_order=True)
+            .agg(
+                pl.col("spot_price").first(),
+                pl.col("gex_signal").first(),
+            )
+            .sort("timestamp")
+        )
+        snapshot_spot = snapshot_df["spot_price"].to_numpy().astype(np.float64)
+        snapshot_signal = snapshot_df["gex_signal"].to_numpy().astype(np.float64)
 
-        # Create forward returns per row (log return of next row's spot).
-        fwd_returns = np.full(len(spot), np.nan)
-        fwd_returns[:-1] = np.log(spot[1:] / spot[:-1])
+        fwd_returns = np.full(len(snapshot_spot), np.nan)
+        fwd_returns[:-1] = np.log(snapshot_spot[1:] / snapshot_spot[:-1])
 
-        mask = np.isfinite(signals) & np.isfinite(fwd_returns)
-        feat_clean = signals[mask]
+        mask = np.isfinite(snapshot_signal) & np.isfinite(fwd_returns)
+        feat_clean = snapshot_signal[mask]
         fwd_clean = fwd_returns[mask]
 
         measurer = SpearmanICMeasurer(rolling_window=50, bootstrap_n=100)
@@ -718,28 +765,40 @@ class TestIntegration:
         self,
     ) -> None:
         """Build synthetic data where gex_signal predicts forward
-        returns. Verify measured IC > 0.1.
+        returns at snapshot level. Verify measured IC > 0.1.
+
+        Forward returns are computed per unique timestamp (D034),
+        not per option row.
         """
         calc = GEXCalculator(zscore_lookback=20)
         df = _make_option_chain(100, n_options_per_snapshot=20, seed=42)
         result_df = calc.compute(df)
 
-        signals = result_df["gex_signal"].to_numpy()
-        spot = result_df["spot_price"].to_numpy().astype(np.float64)
+        # Aggregate to snapshot level.
+        snapshot_df = (
+            result_df.group_by("timestamp", maintain_order=True)
+            .agg(
+                pl.col("spot_price").first(),
+                pl.col("gex_signal").first(),
+            )
+            .sort("timestamp")
+        )
+        snapshot_spot = snapshot_df["spot_price"].to_numpy().astype(np.float64)
+        snapshot_signal = snapshot_df["gex_signal"].to_numpy().astype(np.float64)
 
-        fwd_raw = np.full(len(spot), np.nan)
-        fwd_raw[:-1] = np.log(spot[1:] / spot[:-1])
+        fwd_raw = np.full(len(snapshot_spot), np.nan)
+        fwd_raw[:-1] = np.log(snapshot_spot[1:] / snapshot_spot[:-1])
 
         rng = np.random.default_rng(42)
-        mask = np.isfinite(signals) & np.isfinite(fwd_raw)
+        mask = np.isfinite(snapshot_signal) & np.isfinite(fwd_raw)
 
-        # Inject predictive relationship.
+        # Inject predictive relationship at snapshot level.
         fwd_synthetic = np.copy(fwd_raw)
         alpha = 0.3
         noise = rng.standard_normal(int(mask.sum())) * 0.01
-        fwd_synthetic[mask] = alpha * signals[mask] + noise
+        fwd_synthetic[mask] = alpha * snapshot_signal[mask] + noise
 
-        feat_clean = signals[mask]
+        feat_clean = snapshot_signal[mask]
         fwd_clean = fwd_synthetic[mask]
 
         from features.ic.measurer import SpearmanICMeasurer


### PR DESCRIPTION
## Summary

- Add `GEXCalculator` computing dealer-adjusted Gamma Exposure from option chain snapshots (Barbon & Buraschi 2020)
- Dealer sign convention: calls = -1 (dealers short), puts = +1 (dealers long) — characterized by 2 dedicated tests
- 5 output columns: `gex_raw`, `gex_normalized`, `gex_zscore`, `gex_regime`, `gex_signal`
- D033: implemented inline (S02 `update_gex()` uses opposite sign convention and simpler formula without S² — not wrappable)

## Files created (LOC)

| File | LOC | Purpose |
|------|-----|---------|
| `features/calculators/gex.py` | 310 | GEXCalculator implementation |
| `features/validation/gex_report.py` | 107 | GEX validation report (thin wrapper) |
| `tests/unit/features/calculators/test_gex.py` | 719 | 31 unit tests |
| `features/calculators/__init__.py` | +2 | Export GEXCalculator |

## Tests (31)

| Category | Count | Tests |
|----------|-------|-------|
| ABC conformity | 3 | name, required_columns, output_columns |
| Constructor validation (D030) | 3 | zscore_lookback, regime_thresholds, contract_multiplier |
| Input validation | 2 | invalid option_type, missing column |
| Correctness | 7 | outputs, warm-up, raw-from-first, signal bounded (Hypothesis), regime values, determinism, version |
| Sign convention (CRITICAL) | 2 | calls negative, puts positive |
| Magnitude sanity | 1 | SPY-like chain in [1e7, 1e12] |
| Look-ahead defense | 2 | zscore uses strict past, signal uses strict past |
| D028 compliance | 1 | docstring declares classification |
| D029 variance gates | 3 | gex_raw, gex_zscore, gex_signal |
| Edge cases | 3 | single option, unsorted raises, empty DataFrame |
| Integration | 2 | ICStage pipeline, IC > 0.1 on predictive data |
| Report | 2 | summary schema, None → "n/a" |

## Preflight gates

| Gate | Result |
|------|--------|
| `ruff check .` | ✅ All passed |
| `ruff format --check .` | ✅ All formatted |
| `mypy . --strict` | ✅ 0 errors (390 files) |
| `pytest tests/unit/features/` | ✅ 298 passed, 1 skipped |
| `features/` coverage | ✅ 92.32% (gate: 85%) |
| `gex.py` coverage | ✅ 98% (gate: 90%) |
| Full test suite | ✅ 1,582 passed, 0 regressions |

## D033 justification — inline implementation

S02 `CrowdBehaviorAnalyzer.update_gex()` (`crowd_behavior.py:43-79`) exists but:
- **Opposite sign convention**: S02 uses calls=+1, puts=-1; Barbon-Buraschi requires calls=-1, puts=+1
- **Simpler formula**: S02 uses `gamma * OI * 100` (no S² scaling for dollar GEX)
- **No strict-past protection**: no rolling z-score, no look-ahead safety
- **Uses float**: not suitable for feature validation pipeline

Wrapping S02 would require either modifying S02 (anti-scope-creep) or applying ad-hoc sign inversions and formula corrections that negate the wrapper benefit. Same pattern as D030 (OFI) and D032 (CVD/Kyle).

## Sign convention (dealer-adjusted)

| Option Type | Sign | Dealer Position | GEX Contribution |
|-------------|------|-----------------|------------------|
| Call | -1 | Short (sold to retail) | Negative |
| Put | +1 | Long (bought as hedge) | Positive |

Characterized by: `test_calls_contribute_negatively`, `test_puts_contribute_positively`

## Magnitude sanity

Synthetic SPY-like chain (S=400, 500 options, OI≈1000, gamma≈0.02, mult=100):
- Per-option contribution: `|sign * 1000 * 0.02 * 400² * 100| = $320M`
- Aggregate (mixed signs): `|gex_raw| ∈ [1e7, 1e12]` ✅
- Test: `test_gex_magnitude_realistic`

## Data availability caveat

Tests use **synthetic data only**. Real options data (Polygon, CBOE, IBKR) integration is scheduled for Phase 5 pending data source decision. The calculator is designed to accept real option chain DataFrames without modification.

## Phase 3 calculators complete

With this PR, all 5 calculators from Phase 3.4–3.8 are validated:

| Sub-phase | Calculator | PR |
|-----------|-----------|-----|
| 3.4 | HAR-RV | #111 ✅ |
| 3.5 | Rough Volatility | #112 ✅ |
| 3.6 | OFI | #113 ✅ |
| 3.7 | CVD + Kyle Lambda | #114 ✅ |
| **3.8** | **GEX** | **This PR** |

Route open for 3.9 Multicollinearity + Orthogonalization.

## Test plan

- [x] 31 tests passing under `CI=true --timeout=30`
- [x] Coverage `gex.py` ≥ 90% (actual: 98%)
- [x] Coverage `features/` ≥ 85% (actual: 92.32%)
- [x] 0 regressions on full test suite (1,582 passed)
- [x] mypy strict: 0 errors
- [x] ruff check + format: clean
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)