### PR TITLE
[phase-3.10] CPCV with purging + embargo (closes #96)

### DIFF
--- a/docs/claude_memory/CONTEXT.md
+++ b/docs/claude_memory/CONTEXT.md
@@ -1,7 +1,7 @@
 # APEX Project Context Snapshot
 
 **Last updated**: 2026-04-13
-**Updated by**: Session 022
+**Updated by**: Session 023
 
 ---
 
@@ -9,16 +9,16 @@
 
 | Metric | Value |
 |---|---|
-| Active Phase | Phase 3 — Feature Validation Harness (3.9 PR PENDING) |
+| Active Phase | Phase 3 — Feature Validation Harness (3.10 PR PENDING) |
 | Previous Phase | Phase 2 — Universal Data Infrastructure (DONE) |
-| Total tests | 1,634+ (1,571 unit + 55 integration + skips) |
+| Total tests | 1,686+ (1,623 unit + 55 integration + skips) |
 | Production LOC | ~35,770 |
 | Test LOC | ~22,700 |
 | mypy strict | 0 errors |
 | Services scaffolded | 10/10 (S01-S10) |
 | S01 fully implemented | Yes (78 files, 9,583 LOC) |
 | ADRs accepted | 10 (+ ADR-0004 Feature Validation Methodology) |
-| features/ coverage | ~92% (347 tests) |
+| features/ coverage | ~92% (399 tests) |
 
 ## Audit Status
 

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -1006,3 +1006,56 @@ Implement cross-calculator multicollinearity analysis for 8 signal columns from 
 
 - Push branch, open PR for Copilot review
 - Phase 3.10 (CPCV) after merge
+
+---
+
+## Session 023 -- 2026-04-13
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Mission | Phase 3.10 -- CPCV with Purging |
+| Agent Model | Claude Opus 4.6 |
+| Branch | `phase-3/cpcv-purging` |
+| PR | #119 |
+| Issue | #96 |
+
+### Objective
+
+Implement Combinatorial Purged Cross-Validation (CPCV) from Lopez de Prado (2018) Ch. 7. Scikit-learn-compatible splitter with temporal purging and embargo to eliminate label leakage in financial time series CV.
+
+### Files Created
+
+- `features/cv/cpcv.py` (~280 LOC) -- `CombinatoriallyPurgedKFold` class
+- `features/cv/purging.py` (~65 LOC) -- `purge_train_indices()` helper
+- `features/cv/embargo.py` (~65 LOC) -- `apply_embargo()` helper
+- `features/cv/__init__.py` (modified) -- exports added
+- `tests/unit/features/cv/test_cpcv.py` (~575 LOC, 35 tests)
+- `tests/unit/features/cv/test_purging.py` (~100 LOC, 10 tests)
+- `tests/unit/features/cv/test_embargo.py` (~65 LOC, 7 tests)
+- `reports/phase_3_10/cpcv_diagnostic_report.md` -- Leakage stress test report
+
+### Key Results
+
+- 52 new tests, all passing (57 total in features/cv/)
+- Leakage stress test: Random K-fold 82.7% vs CPCV 57.5% (25.2pp drop)
+- Zero regressions on full suite (1586 passed)
+- mypy strict: 0 errors, ruff: 0 errors
+
+### Decisions
+
+- No new ADR decisions needed -- followed existing PHASE_3_SPEC S3.10 contract exactly
+- Used `BacktestSplitter` ABC from `features/cv/base.py` as reference (did not subclass because API differs: CPCV needs `t1` parameter)
+- scikit-learn installed as dependency for leakage characterization tests (RandomForestClassifier)
+
+### Quality Gates
+
+- ruff check + format: clean
+- mypy --strict: 0 errors (5 files)
+- 52 new tests passed
+- Full suite: 1,586 passed, 53 deselected (pre-existing hypothesis timeouts), 0 regressions
+
+### Next Steps
+
+- Await Copilot review on PR #119
+- Phase 3.11 (DSR/PBO) depends on CPCV splits from this implementation

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -1057,5 +1057,41 @@ Implement Combinatorial Purged Cross-Validation (CPCV) from Lopez de Prado (2018
 
 ### Next Steps
 
-- Await Copilot review on PR #119
+- Await Copilot re-review on PR #119 (hotfix pushed)
 - Phase 3.11 (DSR/PBO) depends on CPCV splits from this implementation
+
+---
+
+## Session 024 -- 2026-04-13
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-13 |
+| Mission | Phase 3.10 -- PR #119 Copilot Review Hotfix |
+| Agent Model | Claude Opus 4.6 |
+| Branch | `phase-3/cpcv-purging` |
+| PR | #119 (updated) |
+
+### Objective
+
+Address 5 Copilot review comments + CI failure (sklearn missing) on PR #119.
+
+### Fixes Applied
+
+1. **Methodological bug (Lopez de Prado S7.4.1)**: Purging interval start used `t1[group_start]` instead of `t0[group_start]`. `split()` now accepts optional `t0` parameter. With t0, purging removes ~2x more samples (avg 26.7 vs 13.3). Test characterizing the bug added.
+2. **Performance #1**: train_candidates O(n) Python loop replaced with group-based `np.concatenate`.
+3. **Performance #2**: embargo Python `set` replaced with vectorized `np.arange` + `np.isin`.
+4. **CI red + sklearn dependency**: 3 leakage tests rewritten with deterministic 1-NN classifier in pure numpy. No sklearn dependency.
+5. **Brittle assertions**: RF-based accuracy bands replaced with deterministic 1-NN. Larger drop (33.8pp vs 25.2pp).
+
+### Key Results
+
+- 58 tests passing (53 before + 1 new t0 characterization + 4 parametrized already counted)
+- Leakage drop: K-fold 85.5% vs CPCV 51.7% (33.8pp, improved from 25.2pp before t0 fix)
+- mypy strict: 0 errors, ruff: 0 errors
+- Scope: 4 files only (cpcv.py, embargo.py, test_cpcv.py, report)
+
+### Next Steps
+
+- Await Copilot re-review on PR #119
+- Phase 3.11 (DSR/PBO) after merge

--- a/features/cv/__init__.py
+++ b/features/cv/__init__.py
@@ -1,4 +1,15 @@
-"""Cross-Validation sub-package — CPCV and feature validation.
+"""Cross-Validation sub-package -- CPCV and feature validation.
 
-Concrete implementations arrive in Phase 3.10 (CPCV) and 3.11 (DSR/PBO).
+Phase 3.10: CombinatoriallyPurgedKFold (CPCV splitter).
+Phase 3.11: DSR/PBO (planned).
 """
+
+from features.cv.cpcv import CombinatoriallyPurgedKFold
+from features.cv.embargo import apply_embargo
+from features.cv.purging import purge_train_indices
+
+__all__ = [
+    "CombinatoriallyPurgedKFold",
+    "apply_embargo",
+    "purge_train_indices",
+]

--- a/features/cv/cpcv.py
+++ b/features/cv/cpcv.py
@@ -1,0 +1,279 @@
+"""Combinatorial Purged Cross-Validation (CPCV) splitter.
+
+Implements the CPCV methodology from López de Prado (2018) Ch. 7:
+
+1. **Combinatorial splits**: partition *n* observations into *N* contiguous
+   groups, then iterate over every combination of *k* groups as the test
+   set — yielding C(N, k) train/test splits per run.
+2. **Purging**: for each split, remove training samples whose label end
+   time ``t1[i]`` falls within any test group's temporal range (§7.4.1).
+3. **Embargo**: remove training samples within ``embargo_pct × n`` bars
+   after each test group boundary (§7.4.2).
+
+This eliminates three types of information leakage that make standard
+K-fold invalid on financial time series:
+
+- **Index leakage**: train ∩ test = ∅ by construction.
+- **Label leakage**: purging removes samples whose outcome depends on
+  test-period data.
+- **Autocorrelation leakage**: embargo removes samples whose features
+  are correlated with the test set via serial dependence.
+
+API follows the scikit-learn cross-validator pattern:
+``split(X, t1) -> Iterator[(train_idx, test_idx)]``.
+
+References:
+    López de Prado, M. (2018). *Advances in Financial Machine Learning*.
+    Wiley, Ch. 7 S7.4-7.5.
+    Bailey, D. H., Borwein, J. M., Lopez de Prado, M. & Zhu, Q. J.
+    (2017). "The Probability of Backtest Overfitting." *Journal of
+    Computational Finance*, 20(4), 39-69.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Iterator
+from math import comb
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import polars as pl
+
+from features.cv.embargo import apply_embargo
+from features.cv.purging import purge_train_indices
+
+
+class CombinatoriallyPurgedKFold:
+    """Combinatorial Purged K-Fold cross-validator.
+
+    Splits time-ordered observations into *N* groups, then takes every
+    combination of *k* groups as test set (yielding ``C(N, k)`` splits
+    per run).  For each split:
+
+    1. Identify the *k* test groups (contiguous index ranges).
+    2. **Purge**: remove training samples whose label end time ``t1[i]``
+       falls inside any test group's time range.
+    3. **Embargo**: remove training samples whose index falls within
+       ``embargo_pct × n`` bars after each test group's last index.
+
+    Yields ``(train_idx, test_idx)`` tuples of ``np.intp`` arrays.
+
+    Parameters
+    ----------
+    n_splits : int
+        Total number of groups to partition observations into.
+        Default 6.
+    n_test_splits : int
+        Number of groups per test set.  Default 2 →
+        ``C(6, 2) = 15`` splits.
+    embargo_pct : float
+        Embargo size as fraction of total observations.  Default 0.01
+        (1%).  E.g. ``n=1000, embargo_pct=0.01`` → embargo of 10 bars
+        after each test group's end.
+
+    Raises
+    ------
+    ValueError
+        If ``n_splits < 2``, ``n_test_splits < 1``,
+        ``n_test_splits >= n_splits``, or ``embargo_pct`` not in
+        ``[0, 1)``.
+
+    Reference
+    ---------
+    López de Prado, M. (2018). *Advances in Financial Machine Learning*,
+    Ch. 7 S7.4-7.5, Wiley.
+    """
+
+    def __init__(
+        self,
+        n_splits: int = 6,
+        n_test_splits: int = 2,
+        embargo_pct: float = 0.01,
+    ) -> None:
+        if n_splits < 2:
+            msg = f"n_splits must be >= 2, got {n_splits}"
+            raise ValueError(msg)
+        if n_test_splits < 1:
+            msg = f"n_test_splits must be >= 1, got {n_test_splits}"
+            raise ValueError(msg)
+        if n_test_splits >= n_splits:
+            msg = f"n_test_splits ({n_test_splits}) must be < n_splits ({n_splits})"
+            raise ValueError(msg)
+        if not 0.0 <= embargo_pct < 1.0:
+            msg = f"embargo_pct must be in [0, 1), got {embargo_pct}"
+            raise ValueError(msg)
+
+        self._n_splits = n_splits
+        self._n_test_splits = n_test_splits
+        self._embargo_pct = embargo_pct
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_n_splits(self) -> int:
+        """Return total number of ``(train, test)`` splits this will yield.
+
+        Returns ``C(n_splits, n_test_splits)``.
+        """
+        return comb(self._n_splits, self._n_test_splits)
+
+    def split(
+        self,
+        X: pl.DataFrame | npt.NDArray[Any],  # noqa: N803
+        t1: pl.Series | npt.NDArray[np.datetime64],
+    ) -> Iterator[tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]]:
+        """Yield ``(train_idx, test_idx)`` for each combinatorial split.
+
+        Parameters
+        ----------
+        X:
+            Feature matrix or array — only ``len(X)`` matters; columns
+            are ignored.
+        t1:
+            Array/Series of datetime values.  ``t1[i]`` is the time when
+            the label for observation ``i`` is known (e.g. Triple
+            Barrier hit time, or ``t_i + horizon``).
+            Must be monotonically non-decreasing.
+
+        Yields
+        ------
+        tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]
+            ``(train_indices, test_indices)`` for each of the
+            ``C(n_splits, n_test_splits)`` combinatorial splits.
+
+        Raises
+        ------
+        ValueError
+            If ``len(X) < n_splits``, ``len(t1) != len(X)``, or
+            ``t1`` is not monotonically non-decreasing.
+        """
+        n = len(X)
+        t1_ns = self._validate_and_convert_t1(t1, n)
+
+        # Partition [0, n) into n_splits contiguous groups
+        groups = self._make_groups(n)
+
+        # Embargo size in number of bars
+        embargo_size = int(self._embargo_pct * n)
+
+        # Iterate over all C(n_splits, n_test_splits) combinations
+        for test_group_indices in itertools.combinations(
+            range(self._n_splits), self._n_test_splits
+        ):
+            # Collect test indices and compute intervals
+            test_idx_parts: list[npt.NDArray[np.intp]] = []
+            test_intervals: list[tuple[np.int64, np.int64]] = []
+            test_end_indices: list[int] = []
+
+            for gi in test_group_indices:
+                group_start, group_end = groups[gi]
+                group_indices = np.arange(group_start, group_end, dtype=np.intp)
+                test_idx_parts.append(group_indices)
+
+                # Temporal interval for purging: [t1 of first obs, t1 of last obs]
+                # We use the actual timestamps of group boundaries
+                test_intervals.append((t1_ns[group_start], t1_ns[group_end - 1]))
+                test_end_indices.append(group_end - 1)
+
+            test_idx = np.concatenate(test_idx_parts)
+
+            # Build initial train set: all indices not in test
+            test_set = set(test_idx.tolist())
+            train_candidates = np.array([i for i in range(n) if i not in test_set], dtype=np.intp)
+
+            # Apply purging
+            train_idx = purge_train_indices(train_candidates, t1_ns, test_intervals)
+
+            # Apply embargo
+            train_idx = apply_embargo(train_idx, test_end_indices, embargo_size, n)
+
+            yield train_idx, test_idx
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def n_splits(self) -> int:
+        """Number of groups observations are partitioned into."""
+        return self._n_splits
+
+    @property
+    def n_test_splits(self) -> int:
+        """Number of groups per test set."""
+        return self._n_test_splits
+
+    @property
+    def embargo_pct(self) -> float:
+        """Embargo size as fraction of total observations."""
+        return self._embargo_pct
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _validate_and_convert_t1(
+        self,
+        t1: pl.Series | npt.NDArray[np.datetime64],
+        n: int,
+    ) -> npt.NDArray[np.int64]:
+        """Validate t1 and convert to int64 nanosecond timestamps.
+
+        Raises
+        ------
+        ValueError
+            If length mismatch or not monotonically non-decreasing.
+        """
+        # Convert to numpy datetime64 if polars Series
+        if isinstance(t1, pl.Series):
+            t1_arr: npt.NDArray[np.datetime64] = t1.to_numpy().astype("datetime64[ns]")
+        else:
+            t1_arr = np.asarray(t1, dtype="datetime64[ns]")
+
+        if len(t1_arr) != n:
+            msg = f"len(t1)={len(t1_arr)} != len(X)={n}"
+            raise ValueError(msg)
+
+        # Convert to int64 nanoseconds for fast comparison
+        t1_ns: npt.NDArray[np.int64] = t1_arr.view(np.int64)
+
+        # Check monotonically non-decreasing
+        if len(t1_ns) > 1 and np.any(np.diff(t1_ns) < 0):
+            msg = (
+                "t1 must be monotonically non-decreasing. "
+                "Label end times must be sorted chronologically."
+            )
+            raise ValueError(msg)
+
+        return t1_ns
+
+    def _make_groups(self, n: int) -> list[tuple[int, int]]:
+        """Partition ``[0, n)`` into ``n_splits`` contiguous groups.
+
+        Returns list of ``(start, end)`` tuples (end exclusive).
+        Groups are as equal as possible; first groups may be 1 larger
+        if ``n`` is not evenly divisible.
+
+        Raises
+        ------
+        ValueError
+            If ``n < n_splits``.
+        """
+        if n < self._n_splits:
+            msg = (
+                f"n_samples={n} is less than n_splits={self._n_splits}. "
+                f"Cannot partition into that many groups."
+            )
+            raise ValueError(msg)
+
+        base_size, remainder = divmod(n, self._n_splits)
+        groups: list[tuple[int, int]] = []
+        start = 0
+        for i in range(self._n_splits):
+            size = base_size + (1 if i < remainder else 0)
+            groups.append((start, start + size))
+            start += size
+        return groups

--- a/features/cv/cpcv.py
+++ b/features/cv/cpcv.py
@@ -124,19 +124,30 @@ class CombinatoriallyPurgedKFold:
         self,
         X: pl.DataFrame | npt.NDArray[Any],  # noqa: N803
         t1: pl.Series | npt.NDArray[np.datetime64],
+        t0: pl.Series | npt.NDArray[np.datetime64] | None = None,
     ) -> Iterator[tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]]:
         """Yield ``(train_idx, test_idx)`` for each combinatorial split.
 
         Parameters
         ----------
         X:
-            Feature matrix or array — only ``len(X)`` matters; columns
+            Feature matrix or array -- only ``len(X)`` matters; columns
             are ignored.
         t1:
             Array/Series of datetime values.  ``t1[i]`` is the time when
             the label for observation ``i`` is known (e.g. Triple
             Barrier hit time, or ``t_i + horizon``).
             Must be monotonically non-decreasing.
+        t0:
+            Optional array/Series of label start times.  ``t0[i]`` is
+            the time when observation ``i`` enters the market (e.g. the
+            bar timestamp).  When provided, the purging interval for
+            each test group uses ``[t0[group_start], t1[group_end - 1]]``
+            per Lopez de Prado (2018) S7.4.1.
+
+            If omitted, ``t1`` is used as both start and end, which
+            assumes labels are point-in-time.  This may **under-purge**
+            with horizon-based labels where ``t1[i] > t0[i]``.
 
         Yields
         ------
@@ -147,11 +158,13 @@ class CombinatoriallyPurgedKFold:
         Raises
         ------
         ValueError
-            If ``len(X) < n_splits``, ``len(t1) != len(X)``, or
-            ``t1`` is not monotonically non-decreasing.
+            If ``len(X) < n_splits``, ``len(t1) != len(X)``,
+            ``t1`` is not monotonically non-decreasing, or
+            ``t0`` is provided with mismatched length or ``t0[i] > t1[i]``.
         """
         n = len(X)
         t1_ns = self._validate_and_convert_t1(t1, n)
+        t0_ns = self._validate_and_convert_t0(t0, t1_ns, n)
 
         # Partition [0, n) into n_splits contiguous groups
         groups = self._make_groups(n)
@@ -170,19 +183,25 @@ class CombinatoriallyPurgedKFold:
 
             for gi in test_group_indices:
                 group_start, group_end = groups[gi]
-                group_indices = np.arange(group_start, group_end, dtype=np.intp)
-                test_idx_parts.append(group_indices)
+                test_idx_parts.append(np.arange(group_start, group_end, dtype=np.intp))
 
-                # Temporal interval for purging: [t1 of first obs, t1 of last obs]
-                # We use the actual timestamps of group boundaries
-                test_intervals.append((t1_ns[group_start], t1_ns[group_end - 1]))
+                # Purge interval: [t0 of first test obs, t1 of last test obs]
+                # per Lopez de Prado (2018) S7.4.1
+                test_intervals.append((t0_ns[group_start], t1_ns[group_end - 1]))
                 test_end_indices.append(group_end - 1)
 
             test_idx = np.concatenate(test_idx_parts)
 
-            # Build initial train set: all indices not in test
-            test_set = set(test_idx.tolist())
-            train_candidates = np.array([i for i in range(n) if i not in test_set], dtype=np.intp)
+            # Build train set from non-test groups (vectorized)
+            test_group_set = set(test_group_indices)
+            train_parts = [
+                np.arange(gs, ge, dtype=np.intp)
+                for gid, (gs, ge) in enumerate(groups)
+                if gid not in test_group_set
+            ]
+            train_candidates = (
+                np.concatenate(train_parts) if train_parts else np.empty(0, dtype=np.intp)
+            )
 
             # Apply purging
             train_idx = purge_train_indices(train_candidates, t1_ns, test_intervals)
@@ -249,6 +268,42 @@ class CombinatoriallyPurgedKFold:
             raise ValueError(msg)
 
         return t1_ns
+
+    def _validate_and_convert_t0(
+        self,
+        t0: pl.Series | npt.NDArray[np.datetime64] | None,
+        t1_ns: npt.NDArray[np.int64],
+        n: int,
+    ) -> npt.NDArray[np.int64]:
+        """Validate optional t0 and convert to int64 nanosecond timestamps.
+
+        If ``t0`` is ``None``, returns ``t1_ns`` (legacy fallback:
+        point-in-time label assumption).
+
+        Raises
+        ------
+        ValueError
+            If length mismatch or any ``t0[i] > t1[i]``.
+        """
+        if t0 is None:
+            return t1_ns
+
+        if isinstance(t0, pl.Series):
+            t0_arr: npt.NDArray[np.datetime64] = t0.to_numpy().astype("datetime64[ns]")
+        else:
+            t0_arr = np.asarray(t0, dtype="datetime64[ns]")
+
+        if len(t0_arr) != n:
+            msg = f"len(t0)={len(t0_arr)} != len(X)={n}"
+            raise ValueError(msg)
+
+        t0_ns: npt.NDArray[np.int64] = t0_arr.view(np.int64)
+
+        if np.any(t0_ns > t1_ns):
+            msg = "t0[i] must be <= t1[i] for all i. Label start cannot exceed label end."
+            raise ValueError(msg)
+
+        return t0_ns
 
     def _make_groups(self, n: int) -> list[tuple[int, int]]:
         """Partition ``[0, n)`` into ``n_splits`` contiguous groups.

--- a/features/cv/embargo.py
+++ b/features/cv/embargo.py
@@ -1,0 +1,71 @@
+"""Embargo helper — adds temporal buffer after test groups.
+
+After purging removes samples with label overlap, an embargo buffer
+removes additional training samples that fall immediately after each
+test group boundary.  This guards against information leakage via
+autocorrelation of features (e.g. Kyle lambda, OFI multi-window).
+
+Reference:
+    López de Prado, M. (2018). *Advances in Financial Machine Learning*.
+    Wiley, §7.4.2 — "Embargo".
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+
+def apply_embargo(
+    train_candidates: npt.NDArray[np.intp],
+    test_end_indices: list[int],
+    embargo_size: int,
+    n_total: int,
+) -> npt.NDArray[np.intp]:
+    """Remove training indices within the embargo zone after each test group.
+
+    For each test group ending at index ``end_i``, indices in the range
+    ``[end_i + 1, end_i + embargo_size]`` (inclusive, clamped to
+    ``n_total - 1``) are excluded from the training set.
+
+    Parameters
+    ----------
+    train_candidates:
+        Array of candidate training indices (int).
+    test_end_indices:
+        List of the last index (inclusive) of each test group.
+    embargo_size:
+        Number of observations to exclude after each test group end.
+        If ``0``, no embargo is applied.
+    n_total:
+        Total number of observations (used for boundary clamping).
+
+    Returns
+    -------
+    npt.NDArray[np.intp]
+        Subset of ``train_candidates`` with embargoed indices removed.
+
+    Reference
+    ---------
+    López de Prado (2018) §7.4.2.
+    """
+    if embargo_size <= 0 or len(test_end_indices) == 0 or len(train_candidates) == 0:
+        return train_candidates
+
+    # Collect all embargoed indices into a set for O(1) lookup
+    embargoed: set[int] = set()
+    for end_i in test_end_indices:
+        embargo_start = end_i + 1
+        embargo_end = min(end_i + embargo_size, n_total - 1)
+        for idx in range(embargo_start, embargo_end + 1):
+            embargoed.add(idx)
+
+    if not embargoed:
+        return train_candidates
+
+    # Boolean mask: True = keep (not in embargo zone)
+    keep = np.array(
+        [int(idx) not in embargoed for idx in train_candidates],
+        dtype=np.bool_,
+    )
+    return train_candidates[keep]

--- a/features/cv/embargo.py
+++ b/features/cv/embargo.py
@@ -52,20 +52,26 @@ def apply_embargo(
     if embargo_size <= 0 or len(test_end_indices) == 0 or len(train_candidates) == 0:
         return train_candidates
 
-    # Collect all embargoed indices into a set for O(1) lookup
-    embargoed: set[int] = set()
-    for end_i in test_end_indices:
-        embargo_start = end_i + 1
-        embargo_end = min(end_i + embargo_size, n_total - 1)
-        for idx in range(embargo_start, embargo_end + 1):
-            embargoed.add(idx)
+    # Vectorized embargo zone construction
+    test_end_arr = np.asarray(test_end_indices, dtype=np.intp)
+    embargo_starts = test_end_arr + 1
+    embargo_ends = np.minimum(test_end_arr + embargo_size, n_total - 1)
+    valid_windows = embargo_starts <= embargo_ends
 
-    if not embargoed:
+    if not np.any(valid_windows):
         return train_candidates
 
-    # Boolean mask: True = keep (not in embargo zone)
-    keep = np.array(
-        [int(idx) not in embargoed for idx in train_candidates],
-        dtype=np.bool_,
+    embargoed_idx = np.unique(
+        np.concatenate(
+            [
+                np.arange(start, end + 1, dtype=np.intp)
+                for start, end in zip(
+                    embargo_starts[valid_windows],
+                    embargo_ends[valid_windows],
+                    strict=True,
+                )
+            ]
+        )
     )
+    keep = np.isin(train_candidates, embargoed_idx, invert=True)
     return train_candidates[keep]

--- a/features/cv/purging.py
+++ b/features/cv/purging.py
@@ -1,0 +1,66 @@
+"""Purging helper — removes training samples with label leakage.
+
+Purging eliminates training observations whose label end time ``t1[i]``
+falls within any test interval.  This prevents the model from learning
+on samples whose outcomes were determined using test-period data.
+
+Reference:
+    López de Prado, M. (2018). *Advances in Financial Machine Learning*.
+    Wiley, §7.4.1 — "Purging".
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+
+def purge_train_indices(
+    train_candidates: npt.NDArray[np.intp],
+    t1: npt.NDArray[np.int64],
+    test_intervals: list[tuple[np.int64, np.int64]],
+) -> npt.NDArray[np.intp]:
+    """Remove train indices whose label end time overlaps any test interval.
+
+    For each candidate training index ``i``, if ``t1[i]`` falls within
+    **any** ``[start, end]`` test interval (inclusive), index ``i`` is
+    purged from the training set.
+
+    Parameters
+    ----------
+    train_candidates:
+        Array of candidate training indices (int).
+    t1:
+        Array of shape ``(n_total,)`` with **int64 nanosecond timestamps**
+        representing the label end time for each observation.
+        ``t1[i]`` is the time at which the label for observation ``i``
+        becomes known (e.g. Triple Barrier hit time).
+    test_intervals:
+        List of ``(start_ns, end_ns)`` int64 timestamp pairs defining
+        the temporal extent of each test group.  Intervals may be
+        non-contiguous (combinatorial splits can select groups 0 and 4).
+
+    Returns
+    -------
+    npt.NDArray[np.intp]
+        Subset of ``train_candidates`` with leaked indices removed.
+
+    Reference
+    ---------
+    López de Prado (2018) §7.4.1.
+    """
+    if len(train_candidates) == 0 or len(test_intervals) == 0:
+        return train_candidates
+
+    # Gather t1 values for all train candidates
+    t1_train = t1[train_candidates]
+
+    # Build a boolean mask: True = keep (not purged)
+    keep = np.ones(len(train_candidates), dtype=np.bool_)
+
+    for start_ns, end_ns in test_intervals:
+        # Purge if t1[i] falls inside [start, end] inclusive
+        overlaps = (t1_train >= start_ns) & (t1_train <= end_ns)
+        keep &= ~overlaps
+
+    return train_candidates[keep]

--- a/reports/phase_3_10/cpcv_diagnostic_report.md
+++ b/reports/phase_3_10/cpcv_diagnostic_report.md
@@ -12,7 +12,8 @@ Generated from synthetic predictive input (seed=42, N=1000 bars, label horizon=1
 | embargo_pct | 0.01 (10 bars) |
 | Synthetic data | Random walk, 5 features, cumsum(N(0,1)) |
 | Label | y[i] = 1 if price[i+10] > price[i] else 0 |
-| Model | RandomForestClassifier(n_estimators=100) |
+| Classifier | 1-NN (deterministic, pure numpy, no external dependencies) |
+| Purging interval | [t0[group_start], t1[group_end-1]] per Lopez de Prado S7.4.1 |
 | Seed | 42 (fully reproducible) |
 
 ## Split summary
@@ -20,31 +21,34 @@ Generated from synthetic predictive input (seed=42, N=1000 bars, label horizon=1
 | Split # | Train size | Test size | Purged+Embargoed |
 |---------|-----------|-----------|------------------|
 | 0 | 656 | 334 | 10 |
-| 1 | 646 | 334 | 20 |
-| 2 | 646 | 334 | 20 |
-| 3 | 647 | 333 | 20 |
-| 4 | 657 | 333 | 10 |
-| 5 | 656 | 334 | 10 |
-| 6 | 646 | 334 | 20 |
-| 7 | 647 | 333 | 20 |
-| 8 | 657 | 333 | 10 |
-| 9 | 656 | 334 | 10 |
-| 10 | 647 | 333 | 20 |
-| 11 | 657 | 333 | 10 |
-| 12 | 657 | 333 | 10 |
-| 13 | 657 | 333 | 10 |
-| 14 | 668 | 332 | 0 |
+| 1 | 636 | 334 | 30 |
+| 2 | 636 | 334 | 30 |
+| 3 | 637 | 333 | 30 |
+| 4 | 647 | 333 | 20 |
+| 5 | 646 | 334 | 20 |
+| 6 | 626 | 334 | 40 |
+| 7 | 627 | 333 | 40 |
+| 8 | 637 | 333 | 30 |
+| 9 | 646 | 334 | 20 |
+| 10 | 627 | 333 | 40 |
+| 11 | 637 | 333 | 30 |
+| 12 | 647 | 333 | 20 |
+| 13 | 637 | 333 | 30 |
+| 14 | 658 | 332 | 10 |
 
 ## Distribution of sizes across 15 splits
 
 | Metric | Train | Test | Purged+Embargoed |
 |---|---|---|---|
-| Mean | 653.3 | 333.3 | 13.3 |
-| Min | 646 | 332 | 0 |
-| Max | 668 | 334 | 20 |
+| Mean | 640.0 | 333.3 | 26.7 |
+| Min | 626 | 332 | 10 |
+| Max | 658 | 334 | 40 |
 
-The last split (groups 4+5, contiguous at end of series) has 0 purged/embargoed
-because there are no training samples after the test set boundary.
+With the corrected purging interval (t0 as start), more samples are purged
+than with the initial implementation that used t1 as interval start
+(avg 26.7 vs 13.3 previously).  This is expected: the wider interval
+[t0, t1] catches training samples whose labels began before but ended
+during the test period.
 
 ## Leakage stress test
 
@@ -52,36 +56,49 @@ because there are no training samples after the test set boundary.
 
 | Metric | Value |
 |---|---|
-| OOS accuracy | 0.8270 |
-| Std across folds | 0.0225 |
+| OOS accuracy | 0.8550 |
 
-Shuffled K-fold on autocorrelated data allows the classifier to exploit
-temporal proximity between train and test samples.  The model memorizes
-local patterns and achieves **82.7% accuracy** -- far above the 50% chance
-baseline for a random walk.
+Shuffled K-fold on autocorrelated data allows the 1-NN classifier to
+exploit temporal proximity between train and test samples.  The nearest
+neighbor of a test sample is typically a temporally adjacent training
+sample, achieving **85.5% accuracy** -- far above the 50% chance baseline.
 
 ### With CPCV (purged + embargoed, C(6,2)=15 splits)
 
 | Metric | Value |
 |---|---|
-| OOS accuracy | 0.5746 |
-| Std across folds | 0.0371 |
+| OOS accuracy | 0.5166 |
 
 CPCV with purging and embargo eliminates the temporal leakage.  Accuracy
-drops to **57.5%**, close to the 50% theoretical chance level for a random
-walk.  The remaining 7.5% above chance is attributable to short-horizon
-mean reversion in the cumulative sum process.
+drops to **51.7%**, very close to the 50% theoretical chance level for a
+random walk.
 
 ### Accuracy drop
 
 | Metric | Value |
 |---|---|
-| K-fold accuracy | 0.8270 |
-| CPCV accuracy | 0.5746 |
-| Drop | 0.2524 (25.2 percentage points) |
+| K-fold accuracy | 0.8550 |
+| CPCV accuracy | 0.5166 |
+| Drop | 0.3384 (33.8 percentage points) |
 
-This 25.2pp drop demonstrates that CPCV eliminates the majority of the
-leakage that standard K-fold allows on autocorrelated financial data.
+This 33.8pp drop demonstrates that CPCV eliminates the vast majority of
+the leakage that standard K-fold allows on autocorrelated financial data.
+
+### Note on classifier choice
+
+The initial draft used sklearn RandomForestClassifier (n_estimators=100).
+After Copilot review, this was replaced with a deterministic 1-NN classifier
+in pure numpy.  Reasons:
+
+- **No external dependencies**: sklearn is not in CI requirements.
+- **Deterministic**: 1-NN produces identical results across platforms
+  regardless of BLAS implementation or RNG seeding differences.
+- **Sensitive to the same leakage**: 1-NN on autocorrelated features
+  exploits temporal proximity identically to RF -- a test sample's
+  nearest neighbor is typically its temporal neighbor.
+- **Larger accuracy drop**: 1-NN actually shows a larger leakage effect
+  (33.8pp vs 25.2pp with RF) because it is more directly sensitive to
+  neighbor proximity.
 
 ## Edge cases characterized
 
@@ -92,6 +109,8 @@ leakage that standard K-fold allows on autocorrelated financial data.
 | n_test_splits = 1 | Degenerates to C(N,1) = N sequential splits |
 | t1 not monotonic | ValueError raised with "monotonically non-decreasing" message |
 | t1 length != n | ValueError raised with "len(t1) != len(X)" message |
+| t0 omitted | Falls back to t1 as interval start (may under-purge) |
+| t0[i] > t1[i] | ValueError raised with "Label start cannot exceed label end" |
 | Non-contiguous test groups (e.g., groups 0 and 4) | Purging checks each group interval independently |
 | Last test group at series end | Embargo clamped to n-1, no overflow |
 
@@ -102,16 +121,21 @@ in financial time series cross-validation:
 
 1. **Index leakage**: train and test indices are always disjoint by construction.
 2. **Label leakage**: purging removes training samples whose label end time (t1)
-   falls within any test group's temporal range, preventing the model from
-   training on outcomes determined by test-period data.
+   falls within the test group's temporal range [t0_start, t1_end], preventing
+   the model from training on outcomes determined by test-period data.
 3. **Autocorrelation leakage**: embargo removes training samples immediately
    after each test group boundary, preventing exploitation of serial dependence
    in features.
 
 The leakage stress test provides empirical evidence: on a synthetic random walk
 dataset with horizon-10 forward labels, CPCV reduces out-of-sample accuracy from
-82.7% (inflated by leakage) to 57.5% (near the theoretical chance level of 50%).
-This 25.2pp drop characterizes the magnitude of leakage that CPCV prevents.
+85.5% (inflated by leakage) to 51.7% (at the theoretical chance level of 50%).
+This 33.8pp drop characterizes the magnitude of leakage that CPCV prevents.
+
+The corrected purging interval (using t0 as start per Lopez de Prado S7.4.1)
+purges approximately twice as many samples as the initial implementation that
+used t1 as the interval start, confirming that the wider interval is necessary
+to capture all label-leaking observations.
 
 The implementation is ready to serve as the cross-validation backbone for
 Phase 3.11 (DSR/PBO), where the C(N,k) split paths provide the combinatorial

--- a/reports/phase_3_10/cpcv_diagnostic_report.md
+++ b/reports/phase_3_10/cpcv_diagnostic_report.md
@@ -1,0 +1,124 @@
+# Phase 3.10 -- CPCV Diagnostic Report
+
+Generated from synthetic predictive input (seed=42, N=1000 bars, label horizon=10).
+
+## Configuration
+
+| Parameter | Value |
+|---|---|
+| n_splits | 6 |
+| n_test_splits | 2 |
+| Total splits | C(6, 2) = 15 |
+| embargo_pct | 0.01 (10 bars) |
+| Synthetic data | Random walk, 5 features, cumsum(N(0,1)) |
+| Label | y[i] = 1 if price[i+10] > price[i] else 0 |
+| Model | RandomForestClassifier(n_estimators=100) |
+| Seed | 42 (fully reproducible) |
+
+## Split summary
+
+| Split # | Train size | Test size | Purged+Embargoed |
+|---------|-----------|-----------|------------------|
+| 0 | 656 | 334 | 10 |
+| 1 | 646 | 334 | 20 |
+| 2 | 646 | 334 | 20 |
+| 3 | 647 | 333 | 20 |
+| 4 | 657 | 333 | 10 |
+| 5 | 656 | 334 | 10 |
+| 6 | 646 | 334 | 20 |
+| 7 | 647 | 333 | 20 |
+| 8 | 657 | 333 | 10 |
+| 9 | 656 | 334 | 10 |
+| 10 | 647 | 333 | 20 |
+| 11 | 657 | 333 | 10 |
+| 12 | 657 | 333 | 10 |
+| 13 | 657 | 333 | 10 |
+| 14 | 668 | 332 | 0 |
+
+## Distribution of sizes across 15 splits
+
+| Metric | Train | Test | Purged+Embargoed |
+|---|---|---|---|
+| Mean | 653.3 | 333.3 | 13.3 |
+| Min | 646 | 332 | 0 |
+| Max | 668 | 334 | 20 |
+
+The last split (groups 4+5, contiguous at end of series) has 0 purged/embargoed
+because there are no training samples after the test set boundary.
+
+## Leakage stress test
+
+### Without CPCV (random shuffled K-fold, 5-fold)
+
+| Metric | Value |
+|---|---|
+| OOS accuracy | 0.8270 |
+| Std across folds | 0.0225 |
+
+Shuffled K-fold on autocorrelated data allows the classifier to exploit
+temporal proximity between train and test samples.  The model memorizes
+local patterns and achieves **82.7% accuracy** -- far above the 50% chance
+baseline for a random walk.
+
+### With CPCV (purged + embargoed, C(6,2)=15 splits)
+
+| Metric | Value |
+|---|---|
+| OOS accuracy | 0.5746 |
+| Std across folds | 0.0371 |
+
+CPCV with purging and embargo eliminates the temporal leakage.  Accuracy
+drops to **57.5%**, close to the 50% theoretical chance level for a random
+walk.  The remaining 7.5% above chance is attributable to short-horizon
+mean reversion in the cumulative sum process.
+
+### Accuracy drop
+
+| Metric | Value |
+|---|---|
+| K-fold accuracy | 0.8270 |
+| CPCV accuracy | 0.5746 |
+| Drop | 0.2524 (25.2 percentage points) |
+
+This 25.2pp drop demonstrates that CPCV eliminates the majority of the
+leakage that standard K-fold allows on autocorrelated financial data.
+
+## Edge cases characterized
+
+| Edge case | Behavior |
+|---|---|
+| n_splits > n_samples | ValueError raised with informative message |
+| embargo_size = 0 (embargo_pct=0) | No embargo applied, train+test = n |
+| n_test_splits = 1 | Degenerates to C(N,1) = N sequential splits |
+| t1 not monotonic | ValueError raised with "monotonically non-decreasing" message |
+| t1 length != n | ValueError raised with "len(t1) != len(X)" message |
+| Non-contiguous test groups (e.g., groups 0 and 4) | Purging checks each group interval independently |
+| Last test group at series end | Embargo clamped to n-1, no overflow |
+
+## Conclusion
+
+The CPCV implementation correctly eliminates three types of information leakage
+in financial time series cross-validation:
+
+1. **Index leakage**: train and test indices are always disjoint by construction.
+2. **Label leakage**: purging removes training samples whose label end time (t1)
+   falls within any test group's temporal range, preventing the model from
+   training on outcomes determined by test-period data.
+3. **Autocorrelation leakage**: embargo removes training samples immediately
+   after each test group boundary, preventing exploitation of serial dependence
+   in features.
+
+The leakage stress test provides empirical evidence: on a synthetic random walk
+dataset with horizon-10 forward labels, CPCV reduces out-of-sample accuracy from
+82.7% (inflated by leakage) to 57.5% (near the theoretical chance level of 50%).
+This 25.2pp drop characterizes the magnitude of leakage that CPCV prevents.
+
+The implementation is ready to serve as the cross-validation backbone for
+Phase 3.11 (DSR/PBO), where the C(N,k) split paths provide the combinatorial
+distribution needed for Probability of Backtest Overfitting estimation.
+
+## References
+
+- Lopez de Prado, M. (2018). *Advances in Financial Machine Learning*, Ch. 7. Wiley.
+- Bailey, D. H., Borwein, J. M., Lopez de Prado, M. & Zhu, Q. J. (2017).
+  "The Probability of Backtest Overfitting." *Journal of Computational Finance*, 20(4), 39-69.

--- a/tests/unit/features/cv/test_cpcv.py
+++ b/tests/unit/features/cv/test_cpcv.py
@@ -261,6 +261,36 @@ class TestPurging:
                         f"Train index {i} has t1 inside test group [{g_min}, {g_max}]"
                     )
 
+    def test_purging_uses_t0_start_not_t1(self) -> None:
+        """Lopez de Prado S7.4.1: purge interval start = t0, not t1.
+
+        A train sample whose label STARTS before the test fold but ENDS
+        during the test fold must be purged.  With the old implementation
+        (t1 as interval start), it would survive because
+        ``t1[group_start]`` is strictly later than ``t0[group_start]``.
+        """
+        n = 60
+        # t0 = observation timestamps; t1 = t0 + 10 hours (label horizon)
+        t0 = _make_timestamps(n)
+        t1 = _make_t1_with_horizon(t0, horizon=10)
+        x = np.zeros(n)
+
+        cv = CombinatoriallyPurgedKFold(n_splits=6, n_test_splits=1, embargo_pct=0.0)
+
+        # With explicit t0: purge interval = [t0[group_start], t1[group_end-1]]
+        # This is wider than [t1[group_start], t1[group_end-1]], catching more leakage.
+        splits_with_t0 = list(cv.split(x, t1=t1, t0=t0))
+        splits_without_t0 = list(cv.split(x, t1=t1))
+
+        total_train_with_t0 = sum(len(tr) for tr, _ in splits_with_t0)
+        total_train_without_t0 = sum(len(tr) for tr, _ in splits_without_t0)
+
+        # With t0, more samples are purged (wider interval), so train set is smaller
+        assert total_train_with_t0 < total_train_without_t0, (
+            f"Passing t0 should purge more samples (wider interval). "
+            f"With t0: {total_train_with_t0}, without: {total_train_without_t0}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Embargo correctness
@@ -467,8 +497,9 @@ class TestLeakageCharacterization:
 
     Synthetic dataset with strongly autocorrelated features (random walk)
     and overlapping labels (y[i] depends on data at i + horizon).
-    Without CPCV, a classifier exploits temporal leakage from overlapping
-    train/test samples.  With CPCV + purging, this leakage is eliminated.
+    Uses a deterministic 1-NN classifier in pure numpy (no sklearn
+    dependency) that is sensitive to temporal-proximity leakage on
+    autocorrelated features.
     """
 
     @staticmethod
@@ -479,96 +510,112 @@ class TestLeakageCharacterization:
 
         Features are cumulative sums (random walk), making nearby
         observations highly correlated.  The label y[i] is the sign of
-        the price move from i to i + horizon.  The features at time i
-        contain information about prices at i + horizon through
-        autocorrelation, creating exploitable leakage.
+        the price move from i to i + horizon.
+
+        Returns (x, y, t0, t1) where t0 = observation timestamps and
+        t1 = label end times (t0 + horizon).
         """
         rng = np.random.default_rng(seed)
-        # Random walk features -- strongly autocorrelated
         increments = rng.standard_normal((n, 5))
         x = np.cumsum(increments, axis=0)
-        timestamps = _make_timestamps(n)
 
-        # Forward return label: 1 if price goes up over horizon, else 0
-        # This creates overlapping labels because y[i] uses data at i+horizon
         y = np.zeros(n, dtype=np.int64)
         for i in range(n - horizon):
             y[i] = 1 if x[i + horizon, 0] > x[i, 0] else 0
 
-        t1 = _make_t1_with_horizon(timestamps, horizon)
-        return x, y, timestamps, t1
+        t0 = _make_timestamps(n)
+        t1 = _make_t1_with_horizon(t0, horizon)
+        return x, y, t0, t1
+
+    @staticmethod
+    def _shuffled_kfold_indices(
+        n_samples: int, n_splits: int, seed: int
+    ) -> list[tuple[np.ndarray, np.ndarray]]:
+        """Deterministic shuffled K-fold (replaces sklearn KFold)."""
+        indices = np.arange(n_samples, dtype=np.intp)
+        rng = np.random.default_rng(seed)
+        rng.shuffle(indices)
+        fold_sizes = np.full(n_splits, n_samples // n_splits, dtype=np.int64)
+        fold_sizes[: n_samples % n_splits] += 1
+        folds: list[tuple[np.ndarray, np.ndarray]] = []
+        current = 0
+        for fold_size in fold_sizes:
+            start = current
+            stop = current + int(fold_size)
+            test_idx = indices[start:stop]
+            train_idx = np.concatenate((indices[:start], indices[stop:]))
+            folds.append((train_idx, test_idx))
+            current = stop
+        return folds
+
+    @staticmethod
+    def _predict_1nn(
+        x_train: np.ndarray,
+        y_train: np.ndarray,
+        x_test: np.ndarray,
+    ) -> np.ndarray:
+        """Deterministic 1-NN classifier (replaces sklearn RandomForest).
+
+        1-NN is sensitive to the same temporal-proximity leakage as RF
+        on autocorrelated features: a test sample whose temporal neighbor
+        is in the train set will be classified by that neighbor's label.
+        """
+        sq_dist = np.sum(
+            (x_test[:, np.newaxis, :] - x_train[np.newaxis, :, :]) ** 2,
+            axis=2,
+        )
+        nearest = np.argmin(sq_dist, axis=1)
+        return y_train[nearest]
+
+    def _mean_cv_accuracy(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        folds: list[tuple[np.ndarray, np.ndarray]],
+    ) -> float:
+        """Compute mean accuracy across CV folds using 1-NN."""
+        accs: list[float] = []
+        for train_idx, test_idx in folds:
+            if len(train_idx) < 2 or len(test_idx) < 1:
+                continue
+            preds = self._predict_1nn(x[train_idx], y[train_idx], x[test_idx])
+            accs.append(float(np.mean(preds == y[test_idx])))
+        return float(np.mean(accs)) if accs else float("nan")
 
     def test_random_kfold_shows_leakage(self) -> None:
-        """Without purging, random shuffled K-fold exploits autocorrelation."""
-        from sklearn.ensemble import RandomForestClassifier
-        from sklearn.model_selection import KFold
-
+        """Shuffled K-fold on autocorrelated data shows leakage via proximity."""
         n, horizon, seed = 1000, 20, 42
-        x, y, _, _ = self._build_leaky_dataset(n, horizon, seed)
-
-        kf = KFold(n_splits=5, shuffle=True, random_state=seed)
-        accuracies: list[float] = []
-        for train_idx, test_idx in kf.split(x):
-            clf = RandomForestClassifier(n_estimators=100, random_state=seed)
-            clf.fit(x[train_idx], y[train_idx])
-            acc = float(np.mean(clf.predict(x[test_idx]) == y[test_idx]))
-            accuracies.append(acc)
-
-        mean_acc = float(np.mean(accuracies))
-        # Shuffled K-fold on autocorrelated data should exploit leakage
-        assert mean_acc > 0.55, f"Expected leaky K-fold accuracy > 0.55, got {mean_acc:.3f}"
+        x, y, _t0, _t1 = self._build_leaky_dataset(n, horizon, seed)
+        folds = self._shuffled_kfold_indices(n_samples=len(x), n_splits=5, seed=seed)
+        mean_acc = self._mean_cv_accuracy(x, y, folds)
+        assert mean_acc > 0.55, (
+            f"Shuffled K-fold should expose leakage on autocorrelated data; "
+            f"expected > 0.55, got {mean_acc:.3f}"
+        )
 
     def test_cpcv_eliminates_leakage(self) -> None:
-        """With CPCV + purging + embargo, accuracy drops toward chance."""
-        from sklearn.ensemble import RandomForestClassifier
-
+        """CPCV with purging + embargo brings 1-NN accuracy toward chance."""
         n, horizon, seed = 1000, 20, 42
-        x, y, _timestamps, t1 = self._build_leaky_dataset(n, horizon, seed)
-
+        x, y, t0, t1 = self._build_leaky_dataset(n, horizon, seed)
         cv = CombinatoriallyPurgedKFold(n_splits=6, n_test_splits=2, embargo_pct=0.02)
-
-        accuracies: list[float] = []
-        for train_idx, test_idx in cv.split(x, t1):
-            if len(train_idx) < 10 or len(test_idx) < 5:
-                continue
-            clf = RandomForestClassifier(n_estimators=100, random_state=seed)
-            clf.fit(x[train_idx], y[train_idx])
-            acc = float(np.mean(clf.predict(x[test_idx]) == y[test_idx]))
-            accuracies.append(acc)
-
-        mean_acc = float(np.mean(accuracies))
-        # CPCV should bring accuracy close to chance (0.5)
+        folds = list(cv.split(x, t1=t1, t0=t0))
+        mean_acc = self._mean_cv_accuracy(x, y, folds)
         assert mean_acc < 0.62, (
-            f"CPCV accuracy should be near chance (<0.62), got {mean_acc:.3f}. "
-            f"Purging may not be working correctly."
+            f"CPCV should bring accuracy near chance (<0.62); got {mean_acc:.3f}. "
+            f"Purging may not be working."
         )
 
     def test_cpcv_accuracy_lower_than_kfold(self) -> None:
-        """CPCV accuracy must be strictly lower than random K-fold on leaky data."""
-        from sklearn.ensemble import RandomForestClassifier
-        from sklearn.model_selection import KFold
-
+        """Direct comparison: CPCV accuracy < shuffled K-fold by >= 10pp."""
         n, horizon, seed = 1000, 20, 42
-        x, y, _timestamps, t1 = self._build_leaky_dataset(n, horizon, seed)
+        x, y, t0, t1 = self._build_leaky_dataset(n, horizon, seed)
 
-        # Random K-fold accuracy
-        kf = KFold(n_splits=5, shuffle=True, random_state=seed)
-        kf_accs: list[float] = []
-        for train_idx, test_idx in kf.split(x):
-            clf = RandomForestClassifier(n_estimators=100, random_state=seed)
-            clf.fit(x[train_idx], y[train_idx])
-            kf_accs.append(float(np.mean(clf.predict(x[test_idx]) == y[test_idx])))
-
-        # CPCV accuracy
+        kfold_acc = self._mean_cv_accuracy(x, y, self._shuffled_kfold_indices(len(x), 5, seed))
         cv = CombinatoriallyPurgedKFold(n_splits=6, n_test_splits=2, embargo_pct=0.02)
-        cpcv_accs: list[float] = []
-        for train_idx, test_idx in cv.split(x, t1):
-            if len(train_idx) < 10 or len(test_idx) < 5:
-                continue
-            clf = RandomForestClassifier(n_estimators=100, random_state=seed)
-            clf.fit(x[train_idx], y[train_idx])
-            cpcv_accs.append(float(np.mean(clf.predict(x[test_idx]) == y[test_idx])))
+        cpcv_acc = self._mean_cv_accuracy(x, y, list(cv.split(x, t1=t1, t0=t0)))
 
-        assert float(np.mean(cpcv_accs)) < float(np.mean(kf_accs)), (
-            f"CPCV acc ({np.mean(cpcv_accs):.3f}) should be < K-fold acc ({np.mean(kf_accs):.3f})"
+        assert cpcv_acc < kfold_acc - 0.10, (
+            f"CPCV must reduce leakage by at least 10pp vs shuffled K-fold. "
+            f"K-fold={kfold_acc:.3f}, CPCV={cpcv_acc:.3f}, "
+            f"drop={kfold_acc - cpcv_acc:.3f}"
         )

--- a/tests/unit/features/cv/test_cpcv.py
+++ b/tests/unit/features/cv/test_cpcv.py
@@ -1,0 +1,574 @@
+"""Tests for features.cv.cpcv -- CombinatoriallyPurgedKFold.
+
+Covers constructor validation, split counts, partition invariants,
+purging correctness, embargo correctness, determinism, edge cases,
+and the critical leakage-elimination integration test.
+
+References:
+    Lopez de Prado (2018) Ch. 7.
+    Bailey et al. (2017) for downstream PBO usage.
+"""
+
+from __future__ import annotations
+
+from math import comb
+
+import numpy as np
+import polars as pl
+import pytest
+
+from features.cv.cpcv import CombinatoriallyPurgedKFold
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_timestamps(n: int, start: int = 0) -> np.ndarray:
+    """Create monotonically increasing datetime64[ns] timestamps."""
+    base = np.datetime64("2024-01-01T00:00:00", "ns")
+    offsets = np.arange(start, start + n, dtype="timedelta64[h]").astype("timedelta64[ns]")
+    return base + offsets
+
+
+def _make_t1_with_horizon(timestamps: np.ndarray, horizon: int) -> np.ndarray:
+    """Create t1 where t1[i] = timestamps[min(i + horizon, n - 1)].
+
+    Simulates a label that looks ``horizon`` bars into the future.
+    """
+    n = len(timestamps)
+    indices = np.minimum(np.arange(n) + horizon, n - 1)
+    return timestamps[indices]
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation (D030)
+# ---------------------------------------------------------------------------
+
+
+class TestCPCVConstructor:
+    """Constructor validation per D030."""
+
+    def test_defaults(self) -> None:
+        cv = CombinatoriallyPurgedKFold()
+        assert cv.n_splits == 6
+        assert cv.n_test_splits == 2
+        assert cv.embargo_pct == 0.01
+
+    def test_n_splits_below_2_raises(self) -> None:
+        with pytest.raises(ValueError, match="n_splits must be >= 2"):
+            CombinatoriallyPurgedKFold(n_splits=1)
+
+    def test_n_test_splits_below_1_raises(self) -> None:
+        with pytest.raises(ValueError, match="n_test_splits must be >= 1"):
+            CombinatoriallyPurgedKFold(n_test_splits=0)
+
+    def test_n_test_splits_ge_n_splits_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be < n_splits"):
+            CombinatoriallyPurgedKFold(n_splits=4, n_test_splits=4)
+
+    def test_embargo_pct_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="embargo_pct must be in"):
+            CombinatoriallyPurgedKFold(embargo_pct=-0.1)
+
+    def test_embargo_pct_ge_1_raises(self) -> None:
+        with pytest.raises(ValueError, match="embargo_pct must be in"):
+            CombinatoriallyPurgedKFold(embargo_pct=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Split count
+# ---------------------------------------------------------------------------
+
+
+class TestSplitCount:
+    """get_n_splits() and actual yield count match C(N, k)."""
+
+    @pytest.mark.parametrize(
+        ("n_splits", "n_test_splits", "expected"),
+        [
+            (6, 2, 15),
+            (10, 3, 120),
+            (5, 1, 5),
+            (4, 3, 4),
+        ],
+    )
+    def test_get_n_splits(self, n_splits: int, n_test_splits: int, expected: int) -> None:
+        cv = CombinatoriallyPurgedKFold(
+            n_splits=n_splits,
+            n_test_splits=n_test_splits,
+            embargo_pct=0.0,
+        )
+        assert cv.get_n_splits() == expected
+
+    def test_actual_yield_count_matches(self) -> None:
+        cv = CombinatoriallyPurgedKFold(n_splits=6, n_test_splits=2, embargo_pct=0.0)
+        n = 60
+        x = np.zeros(n)
+        t1 = _make_timestamps(n)
+        splits = list(cv.split(x, t1))
+        assert len(splits) == cv.get_n_splits()
+
+    def test_c10_3_yield_count(self) -> None:
+        cv = CombinatoriallyPurgedKFold(n_splits=10, n_test_splits=3, embargo_pct=0.0)
+        n = 100
+        x = np.zeros(n)
+        t1 = _make_timestamps(n)
+        splits = list(cv.split(x, t1))
+        assert len(splits) == comb(10, 3)
+
+    def test_degenerate_k_1_equals_n(self) -> None:
+        """C(N, 1) = N -- degenerates to walk-forward-like splits."""
+        cv = CombinatoriallyPurgedKFold(n_splits=5, n_test_splits=1, embargo_pct=0.0)
+        n = 50
+        x = np.zeros(n)
+        t1 = _make_timestamps(n)
+        splits = list(cv.split(x, t1))
+        assert len(splits) == 5
+
+
+# ---------------------------------------------------------------------------
+# Partition invariants
+# ---------------------------------------------------------------------------
+
+
+class TestPartitionInvariants:
+    """For every split: train and test are disjoint, valid, unique."""
+
+    @pytest.fixture
+    def cv_and_data(self) -> tuple[CombinatoriallyPurgedKFold, np.ndarray, np.ndarray]:
+        cv = CombinatoriallyPurgedKFold(n_splits=6, n_test_splits=2, embargo_pct=0.0)
+        n = 60
+        x = np.zeros(n)
+        t1 = _make_timestamps(n)
+        return cv, x, t1
+
+    def test_train_test_disjoint(
+        self, cv_and_data: tuple[CombinatoriallyPurgedKFold, np.ndarray, np.ndarray]
+    ) -> None:
+        cv, x, t1 = cv_and_data
+        for train_idx, test_idx in cv.split(x, t1):
+            assert len(np.intersect1d(train_idx, test_idx)) == 0
+
+    def test_all_indices_in_valid_range(
+        self, cv_and_data: tuple[CombinatoriallyPurgedKFold, np.ndarray, np.ndarray]
+    ) -> None:
+        cv, x, t1 = cv_and_data
+        n = len(x)
+        for train_idx, test_idx in cv.split(x, t1):
+            assert np.all(train_idx >= 0)
+            assert np.all(train_idx < n)
+            assert np.all(test_idx >= 0)
+            assert np.all(test_idx < n)
+
+    def test_no_duplicate_indices(
+        self, cv_and_data: tuple[CombinatoriallyPurgedKFold, np.ndarray, np.ndarray]
+    ) -> None:
+        cv, x, t1 = cv_and_data
+        for train_idx, test_idx in cv.split(x, t1):
+            assert len(train_idx) == len(set(train_idx.tolist()))
+            assert len(test_idx) == len(set(test_idx.tolist()))
+
+
+# ---------------------------------------------------------------------------
+# Purging correctness
+# ---------------------------------------------------------------------------
+
+
+class TestPurging:
+    """Purging removes training samples with label leakage."""
+
+    def test_sample_with_t1_inside_test_is_purged(self) -> None:
+        """If t1[i] falls inside a test group, i must not be in train."""
+        cv = CombinatoriallyPurgedKFold(n_splits=2, n_test_splits=1, embargo_pct=0.0)
+        n = 20
+        timestamps = _make_timestamps(n)
+        # Label horizon of 5: t1[i] = timestamps[i + 5]
+        t1 = _make_t1_with_horizon(timestamps, horizon=5)
+        x = np.zeros(n)
+
+        for train_idx, test_idx in cv.split(x, t1):
+            # Purging interval is based on t1 values at group boundaries
+            t1_test_start = t1[test_idx[0]]
+            t1_test_end = t1[test_idx[-1]]
+            for i in train_idx:
+                # t1[i] must NOT fall in the t1-based test interval
+                assert not (t1_test_start <= t1[i] <= t1_test_end), (
+                    f"Train index {i} has t1={t1[i]} inside test [{t1_test_start}, {t1_test_end}]"
+                )
+
+    def test_no_purging_when_labels_dont_overlap(self) -> None:
+        """With t1[i] = timestamps[i] (no look-ahead), no purging occurs."""
+        cv = CombinatoriallyPurgedKFold(n_splits=2, n_test_splits=1, embargo_pct=0.0)
+        n = 20
+        timestamps = _make_timestamps(n)
+        t1 = timestamps.copy()  # t1[i] = timestamps[i], no forward look
+        x = np.zeros(n)
+
+        for train_idx, test_idx in cv.split(x, t1):
+            # Without overlap, train + test = all indices
+            assert len(train_idx) + len(test_idx) == n
+
+    def test_purging_with_large_horizon(self) -> None:
+        """Larger label horizon should purge more training samples."""
+        n = 60
+        timestamps = _make_timestamps(n)
+        x = np.zeros(n)
+
+        purged_counts: list[int] = []
+        for horizon in [0, 5, 15]:
+            t1 = _make_t1_with_horizon(timestamps, horizon)
+            cv = CombinatoriallyPurgedKFold(n_splits=3, n_test_splits=1, embargo_pct=0.0)
+            total_purged = 0
+            for train_idx, test_idx in cv.split(x, t1):
+                expected_train_size = n - len(test_idx)
+                total_purged += expected_train_size - len(train_idx)
+            purged_counts.append(total_purged)
+
+        # Monotonically increasing purge count
+        assert purged_counts[0] <= purged_counts[1] <= purged_counts[2]
+        # With horizon=0, no purging
+        assert purged_counts[0] == 0
+
+    def test_non_contiguous_test_groups_purge_correctly(self) -> None:
+        """Combinatorial split with groups 0 and 2 (skipping 1).
+
+        For non-contiguous test groups, purging checks each group's
+        interval independently.  A train sample in the gap is only
+        purged if its t1 overlaps one of the individual group intervals.
+        """
+        cv = CombinatoriallyPurgedKFold(n_splits=3, n_test_splits=2, embargo_pct=0.0)
+        n = 30
+        timestamps = _make_timestamps(n)
+        t1 = _make_t1_with_horizon(timestamps, horizon=3)
+        x = np.zeros(n)
+
+        for train_idx, test_idx in cv.split(x, t1):
+            # Identify individual contiguous test groups
+            test_sorted = np.sort(test_idx)
+            group_intervals: list[tuple[np.datetime64, np.datetime64]] = []
+            g_start = test_sorted[0]
+            for k in range(1, len(test_sorted)):
+                if test_sorted[k] != test_sorted[k - 1] + 1:
+                    group_intervals.append((t1[g_start], t1[test_sorted[k - 1]]))
+                    g_start = test_sorted[k]
+            group_intervals.append((t1[g_start], t1[test_sorted[-1]]))
+
+            # Each train sample's t1 must not fall in any group interval
+            for i in train_idx:
+                for g_min, g_max in group_intervals:
+                    assert not (g_min <= t1[i] <= g_max), (
+                        f"Train index {i} has t1 inside test group [{g_min}, {g_max}]"
+                    )
+
+
+# ---------------------------------------------------------------------------
+# Embargo correctness
+# ---------------------------------------------------------------------------
+
+
+class TestEmbargo:
+    """Embargo removes samples after test group boundaries."""
+
+    def test_embargo_excludes_correct_bars(self) -> None:
+        """With embargo_pct=0.1 on n=100, embargo=10 bars after each test end."""
+        cv = CombinatoriallyPurgedKFold(n_splits=2, n_test_splits=1, embargo_pct=0.1)
+        n = 100
+        timestamps = _make_timestamps(n)
+        t1 = timestamps.copy()  # No label overlap
+        x = np.zeros(n)
+
+        splits = list(cv.split(x, t1))
+        # First split: test=group0=[0,50), train initially=[50,100)
+        # Embargo after test end (idx 49): exclude [50, 59]
+        train_0, _test_0 = splits[0]
+        assert 50 not in train_0
+        assert 59 not in train_0
+        assert 60 in train_0
+
+    def test_embargo_zero_no_exclusion(self) -> None:
+        cv = CombinatoriallyPurgedKFold(n_splits=2, n_test_splits=1, embargo_pct=0.0)
+        n = 20
+        timestamps = _make_timestamps(n)
+        t1 = timestamps.copy()
+        x = np.zeros(n)
+
+        for train_idx, test_idx in cv.split(x, t1):
+            # No purging, no embargo -> train + test = n
+            assert len(train_idx) + len(test_idx) == n
+
+    def test_embargo_at_series_end_no_overflow(self) -> None:
+        """When test group is the last group, embargo doesn't overflow."""
+        cv = CombinatoriallyPurgedKFold(n_splits=2, n_test_splits=1, embargo_pct=0.1)
+        n = 100
+        timestamps = _make_timestamps(n)
+        t1 = timestamps.copy()
+        x = np.zeros(n)
+
+        splits = list(cv.split(x, t1))
+        # Second split: test=group1=[50,100), no train after test
+        train_1, _test_1 = splits[1]
+        # All train indices should be valid
+        assert np.all(train_1 >= 0)
+        assert np.all(train_1 < n)
+
+    def test_embargo_with_multiple_test_groups(self) -> None:
+        """Embargo applied after each test group boundary."""
+        cv = CombinatoriallyPurgedKFold(n_splits=4, n_test_splits=2, embargo_pct=0.05)
+        n = 100
+        timestamps = _make_timestamps(n)
+        t1 = timestamps.copy()
+        x = np.zeros(n)
+
+        # embargo_size = 0.05 * 100 = 5 bars
+        for train_idx, test_idx in cv.split(x, t1):
+            train_set = set(train_idx.tolist())
+            test_sorted = np.sort(test_idx)
+
+            # Find test group boundaries (discontinuities)
+            diffs = np.diff(test_sorted)
+            group_ends = [int(test_sorted[0])]
+            for k, d in enumerate(diffs):
+                if d > 1:
+                    group_ends.append(int(test_sorted[k]))
+                    group_ends.append(int(test_sorted[k + 1]))
+            group_ends.append(int(test_sorted[-1]))
+
+            # Check embargo after each test group end
+            for end_idx in group_ends[1::2]:  # Every second is group end
+                for offset in range(1, 6):
+                    embargo_idx = end_idx + offset
+                    if embargo_idx < n and embargo_idx not in set(test_idx.tolist()):
+                        assert embargo_idx not in train_set, (
+                            f"Index {embargo_idx} should be embargoed "
+                            f"(test group ends at {end_idx})"
+                        )
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    """Same inputs produce identical splits in identical order."""
+
+    def test_two_calls_same_result(self) -> None:
+        cv = CombinatoriallyPurgedKFold(n_splits=4, n_test_splits=2, embargo_pct=0.01)
+        n = 40
+        x = np.zeros(n)
+        t1 = _make_timestamps(n)
+
+        splits_a = [(tr.copy(), te.copy()) for tr, te in cv.split(x, t1)]
+        splits_b = [(tr.copy(), te.copy()) for tr, te in cv.split(x, t1)]
+
+        assert len(splits_a) == len(splits_b)
+        for (tr_a, te_a), (tr_b, te_b) in zip(splits_a, splits_b, strict=True):
+            np.testing.assert_array_equal(tr_a, tr_b)
+            np.testing.assert_array_equal(te_a, te_b)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Boundary conditions and error handling."""
+
+    def test_n_splits_gt_n_raises(self) -> None:
+        cv = CombinatoriallyPurgedKFold(n_splits=10, n_test_splits=2, embargo_pct=0.0)
+        x = np.zeros(5)
+        t1 = _make_timestamps(5)
+        with pytest.raises(ValueError, match="n_samples=5 is less than n_splits=10"):
+            list(cv.split(x, t1))
+
+    def test_t1_length_mismatch_raises(self) -> None:
+        cv = CombinatoriallyPurgedKFold(n_splits=2, n_test_splits=1, embargo_pct=0.0)
+        x = np.zeros(10)
+        t1 = _make_timestamps(8)
+        with pytest.raises(ValueError, match="len\\(t1\\)=8 != len\\(X\\)=10"):
+            list(cv.split(x, t1))
+
+    def test_t1_not_monotonic_raises(self) -> None:
+        cv = CombinatoriallyPurgedKFold(n_splits=2, n_test_splits=1, embargo_pct=0.0)
+        x = np.zeros(4)
+        t1 = _make_timestamps(4)
+        # Swap two values to break monotonicity
+        t1_bad = t1.copy()
+        t1_bad[1], t1_bad[2] = t1_bad[2], t1_bad[1]
+        with pytest.raises(ValueError, match="monotonically non-decreasing"):
+            list(cv.split(x, t1_bad))
+
+    def test_minimum_viable_split(self) -> None:
+        """n=2, n_splits=2, n_test_splits=1 produces 2 valid splits."""
+        cv = CombinatoriallyPurgedKFold(n_splits=2, n_test_splits=1, embargo_pct=0.0)
+        x = np.zeros(2)
+        t1 = _make_timestamps(2)
+        splits = list(cv.split(x, t1))
+        assert len(splits) == 2
+        for train_idx, test_idx in splits:
+            assert len(test_idx) == 1
+            assert len(train_idx) >= 1
+
+    def test_polars_dataframe_input(self) -> None:
+        """x can be a polars DataFrame."""
+        cv = CombinatoriallyPurgedKFold(n_splits=3, n_test_splits=1, embargo_pct=0.0)
+        n = 30
+        x = pl.DataFrame({"a": range(n), "b": range(n)})
+        t1 = _make_timestamps(n)
+        splits = list(cv.split(x, t1))
+        assert len(splits) == 3
+
+    def test_polars_series_t1_input(self) -> None:
+        """t1 can be a polars Series of datetimes."""
+        cv = CombinatoriallyPurgedKFold(n_splits=3, n_test_splits=1, embargo_pct=0.0)
+        n = 30
+        x = np.zeros(n)
+        ts = _make_timestamps(n)
+        t1 = pl.Series("t1", ts)
+        splits = list(cv.split(x, t1))
+        assert len(splits) == 3
+
+
+# ---------------------------------------------------------------------------
+# Conditioned on D028 (forecast-like classification)
+# ---------------------------------------------------------------------------
+
+
+class TestConditionedOnD028:
+    """For forecast-like labels where t1[i] = i + horizon."""
+
+    def test_purging_removes_horizon_leaking_samples(self) -> None:
+        """Samples whose label end time crosses into the test set are purged."""
+        n = 60
+        timestamps = _make_timestamps(n)
+        horizon = 10
+        t1 = _make_t1_with_horizon(timestamps, horizon)
+
+        cv = CombinatoriallyPurgedKFold(n_splits=3, n_test_splits=1, embargo_pct=0.0)
+        x = np.zeros(n)
+
+        for train_idx, test_idx in cv.split(x, t1):
+            # Purge interval uses t1 values at group boundaries
+            t1_test_min = t1[test_idx[0]]
+            t1_test_max = t1[test_idx[-1]]
+            for i in train_idx:
+                assert not (t1_test_min <= t1[i] <= t1_test_max)
+
+
+# ---------------------------------------------------------------------------
+# Integration: leakage characterization test
+# ---------------------------------------------------------------------------
+
+
+class TestLeakageCharacterization:
+    """THE critical test proving CPCV eliminates label leakage.
+
+    Synthetic dataset with strongly autocorrelated features (random walk)
+    and overlapping labels (y[i] depends on data at i + horizon).
+    Without CPCV, a classifier exploits temporal leakage from overlapping
+    train/test samples.  With CPCV + purging, this leakage is eliminated.
+    """
+
+    @staticmethod
+    def _build_leaky_dataset(
+        n: int, horizon: int, seed: int
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Build autocorrelated dataset with overlapping label leakage.
+
+        Features are cumulative sums (random walk), making nearby
+        observations highly correlated.  The label y[i] is the sign of
+        the price move from i to i + horizon.  The features at time i
+        contain information about prices at i + horizon through
+        autocorrelation, creating exploitable leakage.
+        """
+        rng = np.random.default_rng(seed)
+        # Random walk features -- strongly autocorrelated
+        increments = rng.standard_normal((n, 5))
+        x = np.cumsum(increments, axis=0)
+        timestamps = _make_timestamps(n)
+
+        # Forward return label: 1 if price goes up over horizon, else 0
+        # This creates overlapping labels because y[i] uses data at i+horizon
+        y = np.zeros(n, dtype=np.int64)
+        for i in range(n - horizon):
+            y[i] = 1 if x[i + horizon, 0] > x[i, 0] else 0
+
+        t1 = _make_t1_with_horizon(timestamps, horizon)
+        return x, y, timestamps, t1
+
+    def test_random_kfold_shows_leakage(self) -> None:
+        """Without purging, random shuffled K-fold exploits autocorrelation."""
+        from sklearn.ensemble import RandomForestClassifier
+        from sklearn.model_selection import KFold
+
+        n, horizon, seed = 1000, 20, 42
+        x, y, _, _ = self._build_leaky_dataset(n, horizon, seed)
+
+        kf = KFold(n_splits=5, shuffle=True, random_state=seed)
+        accuracies: list[float] = []
+        for train_idx, test_idx in kf.split(x):
+            clf = RandomForestClassifier(n_estimators=100, random_state=seed)
+            clf.fit(x[train_idx], y[train_idx])
+            acc = float(np.mean(clf.predict(x[test_idx]) == y[test_idx]))
+            accuracies.append(acc)
+
+        mean_acc = float(np.mean(accuracies))
+        # Shuffled K-fold on autocorrelated data should exploit leakage
+        assert mean_acc > 0.55, f"Expected leaky K-fold accuracy > 0.55, got {mean_acc:.3f}"
+
+    def test_cpcv_eliminates_leakage(self) -> None:
+        """With CPCV + purging + embargo, accuracy drops toward chance."""
+        from sklearn.ensemble import RandomForestClassifier
+
+        n, horizon, seed = 1000, 20, 42
+        x, y, _timestamps, t1 = self._build_leaky_dataset(n, horizon, seed)
+
+        cv = CombinatoriallyPurgedKFold(n_splits=6, n_test_splits=2, embargo_pct=0.02)
+
+        accuracies: list[float] = []
+        for train_idx, test_idx in cv.split(x, t1):
+            if len(train_idx) < 10 or len(test_idx) < 5:
+                continue
+            clf = RandomForestClassifier(n_estimators=100, random_state=seed)
+            clf.fit(x[train_idx], y[train_idx])
+            acc = float(np.mean(clf.predict(x[test_idx]) == y[test_idx]))
+            accuracies.append(acc)
+
+        mean_acc = float(np.mean(accuracies))
+        # CPCV should bring accuracy close to chance (0.5)
+        assert mean_acc < 0.62, (
+            f"CPCV accuracy should be near chance (<0.62), got {mean_acc:.3f}. "
+            f"Purging may not be working correctly."
+        )
+
+    def test_cpcv_accuracy_lower_than_kfold(self) -> None:
+        """CPCV accuracy must be strictly lower than random K-fold on leaky data."""
+        from sklearn.ensemble import RandomForestClassifier
+        from sklearn.model_selection import KFold
+
+        n, horizon, seed = 1000, 20, 42
+        x, y, _timestamps, t1 = self._build_leaky_dataset(n, horizon, seed)
+
+        # Random K-fold accuracy
+        kf = KFold(n_splits=5, shuffle=True, random_state=seed)
+        kf_accs: list[float] = []
+        for train_idx, test_idx in kf.split(x):
+            clf = RandomForestClassifier(n_estimators=100, random_state=seed)
+            clf.fit(x[train_idx], y[train_idx])
+            kf_accs.append(float(np.mean(clf.predict(x[test_idx]) == y[test_idx])))
+
+        # CPCV accuracy
+        cv = CombinatoriallyPurgedKFold(n_splits=6, n_test_splits=2, embargo_pct=0.02)
+        cpcv_accs: list[float] = []
+        for train_idx, test_idx in cv.split(x, t1):
+            if len(train_idx) < 10 or len(test_idx) < 5:
+                continue
+            clf = RandomForestClassifier(n_estimators=100, random_state=seed)
+            clf.fit(x[train_idx], y[train_idx])
+            cpcv_accs.append(float(np.mean(clf.predict(x[test_idx]) == y[test_idx])))
+
+        assert float(np.mean(cpcv_accs)) < float(np.mean(kf_accs)), (
+            f"CPCV acc ({np.mean(cpcv_accs):.3f}) should be < K-fold acc ({np.mean(kf_accs):.3f})"
+        )

--- a/tests/unit/features/cv/test_embargo.py
+++ b/tests/unit/features/cv/test_embargo.py
@@ -1,0 +1,59 @@
+"""Tests for features.cv.embargo -- apply_embargo().
+
+Reference: Lopez de Prado (2018) S7.4.2.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from features.cv.embargo import apply_embargo
+
+
+class TestApplyEmbargo:
+    """Core embargo logic."""
+
+    def test_embargo_removes_indices_after_test_end(self) -> None:
+        """Indices immediately after test_end are excluded."""
+        # n=10, test ends at index 4, embargo_size=2
+        train = np.array([5, 6, 7, 8, 9], dtype=np.intp)
+        result = apply_embargo(train, [4], embargo_size=2, n_total=10)
+        # indices 5, 6 are in embargo zone [5, 6]
+        np.testing.assert_array_equal(result, [7, 8, 9])
+
+    def test_embargo_size_zero_keeps_all(self) -> None:
+        train = np.array([5, 6, 7], dtype=np.intp)
+        result = apply_embargo(train, [4], embargo_size=0, n_total=10)
+        np.testing.assert_array_equal(result, [5, 6, 7])
+
+    def test_embargo_clamps_to_n_total(self) -> None:
+        """Embargo zone doesn't overflow past the last index."""
+        # n=10, test ends at index 8, embargo_size=5
+        train = np.array([9], dtype=np.intp)
+        result = apply_embargo(train, [8], embargo_size=5, n_total=10)
+        # embargo zone: [9, min(13, 9)] = [9, 9] -> index 9 removed
+        np.testing.assert_array_equal(result, np.array([], dtype=np.intp))
+
+    def test_multiple_test_groups_embargo(self) -> None:
+        """Embargo applied after each test group independently."""
+        # n=20, test ends at 4 and 14, embargo_size=2
+        train = np.array([5, 6, 7, 15, 16, 17], dtype=np.intp)
+        result = apply_embargo(train, [4, 14], embargo_size=2, n_total=20)
+        # embargo after 4: [5, 6]; after 14: [15, 16]
+        np.testing.assert_array_equal(result, [7, 17])
+
+    def test_empty_train(self) -> None:
+        train = np.array([], dtype=np.intp)
+        result = apply_embargo(train, [4], embargo_size=2, n_total=10)
+        assert len(result) == 0
+
+    def test_empty_test_end_indices(self) -> None:
+        train = np.array([0, 1, 2], dtype=np.intp)
+        result = apply_embargo(train, [], embargo_size=2, n_total=10)
+        np.testing.assert_array_equal(result, [0, 1, 2])
+
+    def test_embargo_of_one(self) -> None:
+        """embargo_size=1 excludes exactly one bar."""
+        train = np.array([5, 6, 7], dtype=np.intp)
+        result = apply_embargo(train, [4], embargo_size=1, n_total=10)
+        np.testing.assert_array_equal(result, [6, 7])

--- a/tests/unit/features/cv/test_purging.py
+++ b/tests/unit/features/cv/test_purging.py
@@ -1,0 +1,96 @@
+"""Tests for features.cv.purging -- purge_train_indices().
+
+Reference: Lopez de Prado (2018) S7.4.1.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from features.cv.purging import purge_train_indices
+
+
+def _make_t1_ns(values: list[int]) -> np.ndarray:
+    """Create int64 nanosecond timestamps from simple ints."""
+    return np.array(values, dtype=np.int64)
+
+
+class TestPurgeTrainIndices:
+    """Core purging logic."""
+
+    def test_no_overlap_keeps_all(self) -> None:
+        """Train samples with t1 strictly before test start are kept."""
+        train = np.array([0, 1, 2], dtype=np.intp)
+        t1 = _make_t1_ns([10, 20, 30, 100, 110, 120])
+        # Test interval is [100, 120]
+        result = purge_train_indices(train, t1, [(np.int64(100), np.int64(120))])
+        np.testing.assert_array_equal(result, [0, 1, 2])
+
+    def test_overlap_purges_sample(self) -> None:
+        """Train sample whose t1 falls inside test interval is purged."""
+        train = np.array([0, 1, 2], dtype=np.intp)
+        # t1[1] = 105 falls inside test interval [100, 110]
+        t1 = _make_t1_ns([10, 105, 200, 100, 110])
+        result = purge_train_indices(train, t1, [(np.int64(100), np.int64(110))])
+        np.testing.assert_array_equal(result, [0, 2])
+
+    def test_t1_exactly_at_test_start_is_purged(self) -> None:
+        """t1[i] == test_start is inside [start, end] inclusive."""
+        train = np.array([0], dtype=np.intp)
+        t1 = _make_t1_ns([100, 200])
+        result = purge_train_indices(train, t1, [(np.int64(100), np.int64(200))])
+        np.testing.assert_array_equal(result, np.array([], dtype=np.intp))
+
+    def test_t1_exactly_at_test_end_is_purged(self) -> None:
+        """t1[i] == test_end is inside [start, end] inclusive."""
+        train = np.array([0], dtype=np.intp)
+        t1 = _make_t1_ns([200, 300])
+        result = purge_train_indices(train, t1, [(np.int64(100), np.int64(200))])
+        np.testing.assert_array_equal(result, np.array([], dtype=np.intp))
+
+    def test_t1_strictly_after_test_end_kept(self) -> None:
+        """t1[i] > test_end is not in interval -- kept (subject to embargo)."""
+        train = np.array([0], dtype=np.intp)
+        t1 = _make_t1_ns([201, 300])
+        result = purge_train_indices(train, t1, [(np.int64(100), np.int64(200))])
+        np.testing.assert_array_equal(result, [0])
+
+    def test_multiple_disjoint_test_intervals(self) -> None:
+        """Non-contiguous test intervals each purge independently."""
+        train = np.array([1, 3, 5], dtype=np.intp)
+        #                   idx: 0   1    2   3    4   5    6
+        t1 = _make_t1_ns([10, 105, 200, 305, 400, 500, 600])
+        # Two disjoint test intervals: [100, 110] and [300, 310]
+        intervals = [(np.int64(100), np.int64(110)), (np.int64(300), np.int64(310))]
+        result = purge_train_indices(train, t1, intervals)
+        # idx 1: t1=105 in [100,110] -> purged
+        # idx 3: t1=305 in [300,310] -> purged
+        # idx 5: t1=500 -> kept
+        np.testing.assert_array_equal(result, [5])
+
+    def test_empty_train_returns_empty(self) -> None:
+        train = np.array([], dtype=np.intp)
+        t1 = _make_t1_ns([100, 200])
+        result = purge_train_indices(train, t1, [(np.int64(100), np.int64(200))])
+        assert len(result) == 0
+
+    def test_empty_intervals_keeps_all(self) -> None:
+        train = np.array([0, 1], dtype=np.intp)
+        t1 = _make_t1_ns([100, 200])
+        result = purge_train_indices(train, t1, [])
+        np.testing.assert_array_equal(result, [0, 1])
+
+    def test_all_purged(self) -> None:
+        """All train samples have t1 inside test interval."""
+        train = np.array([0, 1, 2], dtype=np.intp)
+        t1 = _make_t1_ns([100, 105, 110])
+        result = purge_train_indices(train, t1, [(np.int64(99), np.int64(111))])
+        assert len(result) == 0
+
+    def test_purge_is_read_only_on_t1(self) -> None:
+        """t1 array must not be mutated."""
+        train = np.array([0, 1], dtype=np.intp)
+        t1 = _make_t1_ns([100, 200])
+        t1_copy = t1.copy()
+        purge_train_indices(train, t1, [(np.int64(100), np.int64(150))])
+        np.testing.assert_array_equal(t1, t1_copy)


### PR DESCRIPTION
## Summary

- **CombinatoriallyPurgedKFold** cross-validator implementing Lopez de Prado (2018) Ch. 7 CPCV methodology
- Three leakage elimination mechanisms: combinatorial splits, temporal purging (S7.4.1), and embargo (S7.4.2)
- Helpers factored into `purging.py` and `embargo.py` for independent testability
- scikit-learn-compatible API: `split(X, t1) -> Iterator[(train_idx, test_idx)]`
- Default: `n_splits=6, n_test_splits=2` producing `C(6,2) = 15` splits per run

## Files changed

| File | Purpose |
|---|---|
| `features/cv/cpcv.py` | `CombinatoriallyPurgedKFold` class |
| `features/cv/purging.py` | `purge_train_indices()` helper |
| `features/cv/embargo.py` | `apply_embargo()` helper |
| `features/cv/__init__.py` | Updated exports |
| `tests/unit/features/cv/test_cpcv.py` | 35 tests (constructor, splits, invariants, purging, embargo, determinism, edge cases, D028, leakage characterization) |
| `tests/unit/features/cv/test_purging.py` | 10 tests |
| `tests/unit/features/cv/test_embargo.py` | 7 tests |
| `reports/phase_3_10/cpcv_diagnostic_report.md` | Diagnostic report with leakage stress test |

## Leakage stress test results

On synthetic random walk data (n=1000, horizon=10, seed=42):

| Method | OOS Accuracy |
|---|---|
| Random K-fold (shuffled) | **82.7%** (leakage inflated) |
| CPCV (purged + embargoed) | **57.5%** (near 50% chance) |
| **Accuracy drop** | **25.2 percentage points** |

## Test plan

- [x] 52 new unit tests all passing (57 total in `tests/unit/features/cv/`)
- [x] `ruff check` -- 0 errors
- [x] `ruff format` -- all formatted
- [x] `mypy --strict features/cv/` -- 0 errors
- [x] Full test suite regression -- 1586 passed, 0 failed (53 deselected: pre-existing hypothesis timeouts)
- [ ] Copilot review

Refs: PHASE_3_SPEC S3.10, ADR-0004, D024-D028
References: Lopez de Prado (2018) Ch. 7, Bailey et al. (2017)

🤖 Generated with [Claude Code](https://claude.com/claude-code)