### PR TITLE
phase(4.2): sample weights per ADR-0005 D2

### DIFF
--- a/docs/claude_memory/CONTEXT.md
+++ b/docs/claude_memory/CONTEXT.md
@@ -1,7 +1,7 @@
 # APEX Project Context Snapshot
 
 **Last updated**: 2026-04-14
-**Updated by**: Session 030 (Phase 4 design gate)
+**Updated by**: Session 031 (Phase 4.2 Sample Weights)
 
 ---
 
@@ -13,18 +13,32 @@ the full inventory. 3 features activated for downstream use:
 `gex_signal`, `har_rv_signal`, `ofi_signal`. S02 adapter scaffolded,
 not wired (issue #123 for streaming).
 
-Phase 4 design-gate in progress on branch `design-gate/phase-4`.
-Artifacts: [`docs/adr/ADR-0005-meta-labeling-fusion-methodology.md`](../adr/ADR-0005-meta-labeling-fusion-methodology.md)
-and [`docs/phases/PHASE_4_SPEC.md`](../phases/PHASE_4_SPEC.md). Issues
-`#125`–`#135` (9 sub-phase + 2 transverse: leakage audit `#134`,
-closure tracking `#135`). Phase 4.1 Triple Barrier Labeling (`#125`)
-is next, to be started after the design-gate PR is merged. Technical
-debt tracked: `#115` (CVD-Kyle perf, Phase 5), `#123` (streaming
-calculators, Phase 5).
+Phase 4 design-gate merged. Phase 4.1 Triple Barrier Labeling (`#125`)
+merged via PR #138 on `main`.
+
+Phase 4.2 Sample Weights (`#126`) in progress on branch
+`phase/4.2-sample-weights`. Canonical bar-indexed uniqueness ×
+return-attribution weights per ADR-0005 D2 / LdP §§4.4-4.5:
+`features/labeling/sample_weights.py` with 4 public helpers
+(`compute_concurrency`, `uniqueness_weights`,
+`return_attribution_weights`, `combined_weights`). 52 new unit tests,
+94% coverage. Coexists with the Phase 3.1 prototype
+`features/weights.py::SampleWeighter` (untouched, 21 tests still
+green); migration of `features/pipeline.py` deferred to the Phase 4
+closure report (#133) as technical debt.
+
+Remaining Phase 4 work: #127 (Baseline Meta-Labeler), #128 (Nested
+Tuning), #129 (Statistical Validation), #130 (Persistence + Model
+Card), #131 (Fusion Engine IC-weighted), #132 (E2E Pipeline Test),
+#133 (Closure Report), plus #134 (mid-phase leakage audit) and #135
+(closure tracking).
+
+Technical debt tracked: `#115` (CVD-Kyle perf, Phase 5), `#123`
+(streaming calculators, Phase 5).
 
 | Metric | Value |
 |---|---|
-| Active Phase | Phase 4 (Fusion Engine + Meta-Labeler) — design-gate PR pending |
+| Active Phase | Phase 4.2 (Sample Weights — #126 PR pending); 4.1 merged (PR #138) |
 | Previous Phase | Phase 3 — Feature Validation Harness (DONE, 13/13 sub-phases) |
 | Total tests | 1,833 unit (1 xfailed latency) + 1 new Phase 3 integration test + existing integration tests |
 | Production LOC | ~35,770 (+ ~8,271 `features/`) |
@@ -37,9 +51,10 @@ calculators, Phase 5).
 
 ## On the horizon
 
-Phase 4 design-gate PR (Fusion Engine + Meta-Labeler). Prerequisites
-confirmed in the Phase 3 closure report. Expected to start with a
-dedicated design-gate PR before implementation begins.
+Phase 4.3 Baseline Meta-Labeler (issue #127) once PR for #126 merges.
+Builds on the `t0/t1` schema from Phase 4.1 + the sample weights from
+Phase 4.2 to train a `RandomForestClassifier` (ADR-0005 D3) with
+CPCV-based validation.
 
 ## Audit Status
 

--- a/docs/claude_memory/DECISIONS.md
+++ b/docs/claude_memory/DECISIONS.md
@@ -916,3 +916,69 @@ Row-level IC on such features produces artificial zero returns on same-snapshot 
 
 - PR #116 Copilot review comment #4
 - PHASE_3_SPEC §2.8
+
+## D035 — Coexistence of `features/weights.py` Prototype and Canonical Phase 4.2 Sample Weights (2026-04-14)
+
+### Context
+
+Phase 4.2 (issue #126) requires the canonical bar-indexed uniqueness ×
+return-attribution sample weights from López de Prado (2018) §§4.4-4.5,
+consumed by sub-phases 4.3 / 4.4 / 4.5 of the Meta-Labeler training
+pipeline. The repository already contains `features/weights.py` with a
+Phase 3.1 prototype `SampleWeighter` class that:
+
+- operates on `list[datetime]` entry/exit times (not Polars Series),
+- implements a *duration-weighted* uniqueness formula (not the
+  bar-indexed LdP §4.4 canonical form),
+- raises `NotImplementedError` for `return_attribution_weights`,
+- is wired into `features/pipeline.py` and covered by 21 passing tests
+  in `tests/unit/features/test_weights.py`,
+- is also exercised by `test_pipeline.py` and
+  `test_pipeline_with_store.py`.
+
+### Decision
+
+Create the canonical module at `features/labeling/sample_weights.py`
+as a **sibling**, not a refactor. The Phase 3.1 prototype remains
+untouched. Phase 4.2 introduces the ADR-0005 D2 implementation with
+Polars-native `pl.Series` I/O, vectorized O(n_samples + n_bars)
+algorithms, and full `return_attribution_weights` + `combined_weights`
+coverage.
+
+Both modules will coexist for the remainder of Phase 4. Migration of
+`features/pipeline.py` onto the canonical API is logged as technical
+debt to be addressed in the Phase 4 closure report (issue #133),
+alongside deletion of the now-redundant prototype.
+
+### Rationale
+
+1. **Non-negotiable: 21 existing tests stay green.** Refactoring
+   `features/weights.py` in-place would force touching `pipeline.py`
+   and those 21 tests in the same PR, dramatically expanding the
+   Phase 4.2 scope and risking regressions in paths unrelated to the
+   meta-labeler.
+2. **Clean SRP boundary.** The canonical module lives inside
+   `features/labeling/` next to its direct consumer schema from
+   Phase 4.1 (`triple_barrier.py`). This matches PHASE_4_SPEC §3.2.
+3. **Explicit documentation.** Both the module docstring and
+   `reports/phase_4_2/audit.md` call out the coexistence and the
+   migration contract, so no future reader mistakes the old prototype
+   for canonical behavior.
+
+### Consequences
+
+- Short term: two modules named `weights` in the repo. Mitigated by
+  distinct paths (`features/weights.py` vs
+  `features/labeling/sample_weights.py`) and explicit docstring notes.
+- Long term: must retire the prototype before Phase 5, or at the Phase
+  4 closure report. Tracked under issue #133.
+- Test double-maintenance: `test_weights.py` (21 tests, Phase 3.1)
+  remains; Phase 4.2 adds `test_sample_weights_{uniqueness,attribution,combined}.py`
+  (52 tests).
+
+### References
+
+- [`reports/phase_4_2/audit.md`](../../reports/phase_4_2/audit.md) §0 / §1
+- [`docs/adr/ADR-0005-meta-labeling-fusion-methodology.md`](../adr/ADR-0005-meta-labeling-fusion-methodology.md) D2
+- [`docs/phases/PHASE_4_SPEC.md`](../phases/PHASE_4_SPEC.md) §3.2
+- LdP (2018) §§4.4-4.5 and Table 4.1

--- a/docs/claude_memory/SESSIONS.md
+++ b/docs/claude_memory/SESSIONS.md
@@ -1452,3 +1452,77 @@ services/ features/ backtesting/ core/ tests/` is empty.
   risk).
 - After merge: start Phase 4.1 Triple Barrier Labeling (#125) in a
   fresh Claude Code session.
+
+## Session 031 — 2026-04-14
+
+### Focus
+
+Phase 4.2 — Sample Weights (issue #126). Canonical bar-indexed
+uniqueness × return-attribution weights per ADR-0005 D2 and López de
+Prado (2018) §§4.4-4.5.
+
+### Branch
+
+`phase/4.2-sample-weights` (off `main` after PR #138 for Phase 4.1
+merged).
+
+### Deliverables
+
+| Artifact | LOC | Notes |
+|---|---|---|
+| `reports/phase_4_2/audit.md` | 327 | Pre-impl audit, verdict CRÉER (new sibling, not refactor). Documents coexistence with `features/weights.py::SampleWeighter`. |
+| `features/labeling/sample_weights.py` | 478 | Public API: `compute_concurrency`, `uniqueness_weights`, `return_attribution_weights`, `combined_weights`. O(n_samples + n_bars). |
+| `features/labeling/__init__.py` | +14 | Phase 4.2 re-exports section. |
+| `tests/unit/features/labeling/test_sample_weights_uniqueness.py` | 262 | 21 tests (concurrency, disjoint→1.0, LdP §4.4 Table 4.1 reference, fail-loud validation, helpers). |
+| `tests/unit/features/labeling/test_sample_weights_attribution.py` | 206 | 15 tests incl. Hypothesis anti-leakage property (200 cases): shuffle post-`max(t1)` preserves weights to 1e-12. |
+| `tests/unit/features/labeling/test_sample_weights_combined.py` | 152 | 16 tests: normalization invariant `sum(w) == n_samples`, identity `w ∝ u × r`, all-zero returns preserved. |
+| `reports/phase_4_2/weights_distribution.md` | 176 | Diagnostic: 100 events × 1,000 bars seed 42, histograms + P05/P50/P95 for `c_t`, `u`, `r`, `w`; normalization drift 1.42e-14. |
+
+### Quality Gates
+
+- ruff check: clean on the 5 new/modified files (all rules: E,W,F,I,N,UP,ANN,S,B,A,C4,PT,RUF).
+- ruff format: clean.
+- mypy --strict on `features/labeling/sample_weights.py`: 0 errors.
+- pytest: 52/52 pass locally.
+- Coverage on `features/labeling/sample_weights.py`: **94%** (137 stmts,
+  7 missed), above DoD threshold of 92%. Remaining 6% are unreachable
+  defensive branches: dtype mismatch inside `_locate_span_indices` (pre-filtered
+  by `_validate_datetime_series`), `c_t == 0` inside a consistent span,
+  and the `sum(w) drift > 1e-9` defensive raise.
+- Anti-leakage property test: 200 Hypothesis cases, all pass.
+
+### Architectural Decisions
+
+- Coexistence of `features/weights.py::SampleWeighter` (Phase 3.1
+  prototype, duration-weighted, 21 existing tests) with
+  `features/labeling/sample_weights.py` (new canonical LdP §4.4 bar-
+  indexed implementation). Zero modification to the old module.
+  Migration of `features/pipeline.py` to the canonical API is deferred
+  to the Phase 4 closure report (issue #133) as technical debt.
+- Closed interval `[t0, t1]` (both bars inclusive) — matches LdP §4.4
+  convention; internally mapped to half-open `[i0, i1+1)` via
+  `np.searchsorted` for cumsum-based O(n) scans.
+- Fail-loud on every edge case (tz-naive, non-UTC, orphan timestamps,
+  non-monotonic bars, NaN/Inf returns). ADR-0005 D2 explicitly forbids
+  silent ffill or zero-weight remap.
+
+### Scope
+
+Phase 4.2 deliverables only. `features/weights.py` untouched — 21
+existing tests must remain green. No changes to
+`features/labeling/triple_barrier.py` (Phase 4.1, consumer of `t0/t1`
+schema).
+
+### Issues Addressed
+
+- Refs #126 (Phase 4.2 Sample Weights)
+- Refs ADR-0005 D2
+
+### Next Steps
+
+- Push branch `phase/4.2-sample-weights` to `origin` and open PR
+  against `main` with the quant PR template.
+- Wait for Copilot review + full CI (quality / rust / unit-tests /
+  integration / backtest-gate).
+- On merge: pull `main`, branch `phase/4.3-baseline-meta-labeler`,
+  open issue #127 (Baseline Meta-Labeler).

--- a/features/labeling/__init__.py
+++ b/features/labeling/__init__.py
@@ -14,11 +14,19 @@ Public API:
 - :func:`build_events_from_signals` - event-time construction helper.
 - :func:`compute_label_diagnostics` - distribution + sanity stats.
 
+Phase 4.2 additions (ADR-0005 D2 - sample weights):
+
+- :func:`compute_concurrency` - bar-indexed concurrency count ``c_t``.
+- :func:`uniqueness_weights` - uniqueness weight ``u_i``.
+- :func:`return_attribution_weights` - return-attribution weight ``r_i``.
+- :func:`combined_weights` - final training weight ``w_i = u_i * r_i``.
+
 References:
     Lopez de Prado (2018), Advances in Financial Machine Learning,
-    Chapter 3.4 - 3.6.
+    Chapter 3.4 - 3.6 and Chapter 4.4 - 4.5.
     ADR-0005 D1 - Triple Barrier Method contract.
-    PHASE_4_SPEC section 3.1 - module structure and public API.
+    ADR-0005 D2 - Sample weights contract.
+    PHASE_4_SPEC section 3.1 and 3.2 - module structure and public API.
 """
 
 from __future__ import annotations
@@ -32,6 +40,12 @@ from core.math.labeling import (
 )
 from features.labeling.diagnostics import LabelDiagnostics, compute_label_diagnostics
 from features.labeling.events import build_events_from_signals
+from features.labeling.sample_weights import (
+    combined_weights,
+    compute_concurrency,
+    return_attribution_weights,
+    uniqueness_weights,
+)
 from features.labeling.triple_barrier import label_events_binary
 
 __all__ = [
@@ -41,7 +55,11 @@ __all__ = [
     "TripleBarrierConfig",
     "TripleBarrierLabeler",
     "build_events_from_signals",
+    "combined_weights",
+    "compute_concurrency",
     "compute_label_diagnostics",
     "label_events_binary",
+    "return_attribution_weights",
     "to_binary_target",
+    "uniqueness_weights",
 ]

--- a/features/labeling/sample_weights.py
+++ b/features/labeling/sample_weights.py
@@ -40,8 +40,12 @@ Algorithmic contract:
 Performance contract:
 
 - Target: 10,000 samples x 100,000 bars in <= 30 s on a single CPU core
-  (issue #126 DoD section 5). The algorithm is O(n_samples + n_bars)
-  which comfortably fits the budget.
+  (issue #126 DoD section 5). The core concurrency / weight
+  accumulation scan is O(n_samples + n_bars), but the end-to-end
+  implementation also locates ``t0`` / ``t1`` in ``bars`` via
+  :func:`numpy.searchsorted`, so the overall complexity is
+  O(n_samples log n_bars + n_bars) unless the inputs are already
+  bar-index aligned. This still comfortably fits the budget.
 
 References:
     Lopez de Prado, M. (2018). *Advances in Financial Machine Learning*.
@@ -96,9 +100,13 @@ def _validate_datetime_series(series: pl.Series, name: str) -> None:
         )
     # Defense in depth: verify first element is UTC-aware. For a fully
     # typed UTC series this is redundant, but it catches the case where a
-    # caller hand-builds the series with ``strict=False`` coercion.
+    # caller hand-builds the series with ``strict=False`` coercion. We
+    # use constant-time scalar indexing instead of materializing the
+    # whole series via ``to_list()`` - the latter is an O(n) allocation
+    # that would hurt performance on large ``bars`` inputs (see Copilot
+    # review on PR #139).
     if len(series) > 0:
-        head = series.to_list()[0]
+        head = series[0]
         if head is not None:
             _ensure_utc_scalar(head, f"{name}[0]")
 
@@ -191,6 +199,18 @@ def _empty_float_series() -> pl.Series:
     return pl.Series(values=[], dtype=pl.Float64)
 
 
+def _check_same_length(t0: pl.Series, t1: pl.Series) -> None:
+    """Fail-loud length-parity check for the ``t0`` / ``t1`` span pair.
+
+    Called at the top of every public entry point so mismatched inputs
+    (e.g. ``t0=[]``, ``t1=[...]``) surface before any early-return path
+    can mask the bug. ``_locate_span_indices`` performs the same check,
+    but that is only reached when both series are non-empty.
+    """
+    if len(t0) != len(t1):
+        raise ValueError(f"t0 ({len(t0)}) and t1 ({len(t1)}) have different lengths")
+
+
 def compute_concurrency(
     t0: pl.Series,
     t1: pl.Series,
@@ -226,6 +246,7 @@ def compute_concurrency(
     _validate_datetime_series(t0, "t0")
     _validate_datetime_series(t1, "t1")
     _validate_datetime_series(bars, "bars")
+    _check_same_length(t0, t1)
 
     n_bars = len(bars)
     if len(t0) == 0:
@@ -280,6 +301,7 @@ def uniqueness_weights(
     _validate_datetime_series(t0, "t0")
     _validate_datetime_series(t1, "t1")
     _validate_datetime_series(bars, "bars")
+    _check_same_length(t0, t1)
 
     n_samples = len(t0)
     if n_samples == 0:
@@ -363,6 +385,7 @@ def return_attribution_weights(
     _validate_datetime_series(t1, "t1")
     _validate_datetime_series(bars, "bars")
     _validate_numeric_series(log_returns, "log_returns", expected_length=len(bars))
+    _check_same_length(t0, t1)
 
     n_samples = len(t0)
     if n_samples == 0:

--- a/features/labeling/sample_weights.py
+++ b/features/labeling/sample_weights.py
@@ -1,0 +1,460 @@
+"""Phase 4.2 - Sample weights for Meta-Labeler training.
+
+Canonical Polars-native implementation of the uniqueness x return
+attribution sample weights defined in ADR-0005 D2 and Lopez de Prado
+(2018) chapter 4 sections 4.4 - 4.5. Consumed by sub-phases 4.3, 4.4,
+and 4.5 of the Phase 4 Meta-Labeler training pipeline.
+
+Public API:
+
+- :func:`compute_concurrency` - bar-indexed concurrency count ``c_t``.
+- :func:`uniqueness_weights` - ``u_i = mean(1 / c_t for t in [t0_i, t1_i])``.
+- :func:`return_attribution_weights` - ``r_i = |sum(ret_t / c_t for t in [t0_i, t1_i])|``.
+- :func:`combined_weights` - ``w_i = u_i * r_i`` normalized so ``sum(w) == n_samples``.
+
+Coexistence with :mod:`features.weights`:
+
+    The pre-existing :class:`features.weights.SampleWeighter` (Phase 3.1
+    prototype) exposes a *duration-weighted* uniqueness formula on
+    ``list[datetime]`` inputs, with ``return_attribution_weights`` still
+    ``NotImplementedError``. It remains wired into
+    :mod:`features.pipeline` and covered by 21 tests; this Phase 4.2
+    module is the canonical bar-indexed implementation and lives as a
+    sibling. Migration of the Phase 3 pipeline to the canonical module is
+    tracked as technical debt for the Phase 4 closure report (issue #133)
+    or Phase 5.
+
+Algorithmic contract:
+
+- Both label bars ``t0`` and ``t1`` are included in the span (closed
+  interval). Every ``t0_i`` and ``t1_i`` must exist in ``bars``; orphan
+  timestamps raise ``ValueError`` (fail-loud, no silent drop).
+- Concurrency ``c_t`` is computed in O(n_samples + n_bars) via a
+  delta-plus-cumsum scan over bar indices, never a double Python loop.
+- Weights depend only on ``t0``, ``t1``, and bars/log_returns **within**
+  the label span ``[t0, t1]``. Shuffling log returns strictly after
+  ``max(t1)`` cannot change any weight - this is enforced by a property
+  test in :mod:`tests.unit.features.labeling.test_sample_weights_attribution`.
+- UTC-only timestamps. Naive or non-UTC datetimes raise ``ValueError``.
+
+Performance contract:
+
+- Target: 10,000 samples x 100,000 bars in <= 30 s on a single CPU core
+  (issue #126 DoD section 5). The algorithm is O(n_samples + n_bars)
+  which comfortably fits the budget.
+
+References:
+    Lopez de Prado, M. (2018). *Advances in Financial Machine Learning*.
+    Wiley, Chapter 4 sections 4.4 (Average Uniqueness) and 4.5 (Sample
+    Weights by Return Attribution), including Table 4.1.
+    ADR-0005 D2 - Sample weights contract.
+    PHASE_4_SPEC section 3.2 - module structure and public API.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import numpy as np
+import numpy.typing as npt
+import polars as pl
+
+__all__ = [
+    "combined_weights",
+    "compute_concurrency",
+    "return_attribution_weights",
+    "uniqueness_weights",
+]
+
+# Tolerance for the normalization invariant ``sum(w) == n_samples``.
+_NORMALIZATION_TOL: float = 1e-9
+
+
+def _ensure_utc_scalar(ts: datetime, field: str) -> None:
+    """Fail-loud UTC check for a single datetime scalar."""
+    if ts.tzinfo is None:
+        raise ValueError(f"{field}={ts!r} is tz-naive; ADR-0005 D2 requires UTC-aware datetimes")
+    if ts.utcoffset() != UTC.utcoffset(None):
+        raise ValueError(
+            f"{field}={ts!r} is not UTC (offset={ts.utcoffset()}); "
+            "ADR-0005 D2 requires UTC-aware datetimes"
+        )
+
+
+def _validate_datetime_series(series: pl.Series, name: str) -> None:
+    """Reject empty-less checks and enforce Datetime[us, UTC] dtype.
+
+    Empty series are accepted (return path is handled by the callers).
+    """
+    if series.dtype != pl.Datetime("us", "UTC"):
+        # Polars is strict: a pl.Datetime without tz, or with a different
+        # tz, has a different dtype. This check fires on both naive and
+        # non-UTC inputs.
+        raise ValueError(
+            f"{name} must be pl.Datetime('us', 'UTC'); got dtype={series.dtype}. "
+            "ADR-0005 D2 requires UTC-aware timestamps."
+        )
+    # Defense in depth: verify first element is UTC-aware. For a fully
+    # typed UTC series this is redundant, but it catches the case where a
+    # caller hand-builds the series with ``strict=False`` coercion.
+    if len(series) > 0:
+        head = series.to_list()[0]
+        if head is not None:
+            _ensure_utc_scalar(head, f"{name}[0]")
+
+
+def _validate_numeric_series(
+    series: pl.Series, name: str, *, expected_length: int | None = None
+) -> None:
+    """Reject non-finite values and length mismatches on a numeric series."""
+    if expected_length is not None and len(series) != expected_length:
+        raise ValueError(
+            f"{name} length ({len(series)}) does not match expected length ({expected_length})"
+        )
+    if series.null_count() > 0:
+        raise ValueError(f"{name} contains null values; ADR-0005 D2 forbids silent ffill")
+    if len(series) == 0:
+        return
+    arr = series.to_numpy()
+    if not np.isfinite(arr).all():
+        raise ValueError(
+            f"{name} contains non-finite values (NaN/Inf); ADR-0005 D2 forbids silent ffill"
+        )
+
+
+def _locate_span_indices(
+    t0: pl.Series,
+    t1: pl.Series,
+    bars: pl.Series,
+) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+    """Resolve each sample's ``[t0, t1]`` closed-interval to bar indices.
+
+    Returns ``(i0, i1_plus_one)`` where ``bars[i0] == t0`` and
+    ``bars[i1_plus_one - 1] == t1`` for every sample (fail-loud on miss).
+
+    The half-open ``[i0, i1_plus_one)`` convention is what the cumulative
+    sum and concurrency delta scan consume downstream.
+    """
+    if t0.dtype != bars.dtype:
+        raise ValueError(f"t0 dtype ({t0.dtype}) does not match bars dtype ({bars.dtype})")
+    if t1.dtype != bars.dtype:
+        raise ValueError(f"t1 dtype ({t1.dtype}) does not match bars dtype ({bars.dtype})")
+
+    bars_np = bars.to_numpy()
+    # Strict monotonicity of bars is required; ``searchsorted`` relies on
+    # it and upstream 4.1 output already satisfies it.
+    if len(bars_np) > 1 and not np.all(bars_np[1:] > bars_np[:-1]):
+        raise ValueError("bars must be strictly monotonic increasing")
+
+    t0_np = t0.to_numpy()
+    t1_np = t1.to_numpy()
+
+    if len(t0_np) != len(t1_np):
+        raise ValueError(f"t0 ({len(t0_np)}) and t1 ({len(t1_np)}) have different lengths")
+
+    if np.any(t1_np < t0_np):
+        bad = int(np.argmax(t1_np < t0_np))
+        raise ValueError(f"t1 < t0 at sample index {bad}: t0={t0_np[bad]}, t1={t1_np[bad]}")
+
+    # side='left' finds the insertion index for an exact match; verify
+    # equality to detect orphan timestamps.
+    i0 = np.searchsorted(bars_np, t0_np, side="left").astype(np.int64)
+    i1 = np.searchsorted(bars_np, t1_np, side="left").astype(np.int64)
+
+    if np.any(i0 >= len(bars_np)) or np.any(i1 >= len(bars_np)):
+        oob_mask = (i0 >= len(bars_np)) | (i1 >= len(bars_np))
+        bad = int(np.argmax(oob_mask))
+        raise ValueError(
+            f"t0/t1 at sample index {bad} is past the last bar: "
+            f"t0={t0_np[bad]}, t1={t1_np[bad]}, last_bar={bars_np[-1]}"
+        )
+
+    if not np.array_equal(bars_np[i0], t0_np):
+        bad = int(np.argmax(bars_np[i0] != t0_np))
+        raise ValueError(
+            f"t0={t0_np[bad]} (sample {bad}) is not present in bars; "
+            "every event timestamp must exist in the bar series"
+        )
+    if not np.array_equal(bars_np[i1], t1_np):
+        bad = int(np.argmax(bars_np[i1] != t1_np))
+        raise ValueError(
+            f"t1={t1_np[bad]} (sample {bad}) is not present in bars; "
+            "every event timestamp must exist in the bar series"
+        )
+
+    # Closed interval [t0, t1] -> half-open [i0, i1 + 1).
+    return i0, (i1 + 1).astype(np.int64)
+
+
+def _empty_float_series() -> pl.Series:
+    """Return an empty ``pl.Series`` of dtype ``Float64``."""
+    return pl.Series(values=[], dtype=pl.Float64)
+
+
+def compute_concurrency(
+    t0: pl.Series,
+    t1: pl.Series,
+    bars: pl.Series,
+) -> pl.Series:
+    """Return ``c_t`` - the number of active labels at each bar ``t``.
+
+    For every bar in ``bars``, counts how many samples satisfy
+    ``t0_i <= bar <= t1_i``. Implemented as a delta-plus-cumsum scan in
+    O(n_samples + n_bars) time and O(n_bars) memory.
+
+    Args:
+        t0: UTC-aware bar timestamps marking the start of each label span.
+        t1: UTC-aware bar timestamps marking the end of each label span.
+        bars: UTC-aware strictly-monotonic bar timestamps covering the
+            union of all label spans.
+
+    Returns:
+        ``pl.Series[Int64]`` of length ``len(bars)`` with the concurrency
+        count at each bar. Zeroes at bars outside every span are allowed
+        and expected; those bars are simply never accessed by downstream
+        weight computations.
+
+    Raises:
+        ValueError: If timestamps are non-UTC, bars are non-monotonic,
+            any ``t0_i`` / ``t1_i`` is absent from ``bars``, or
+            ``t1_i < t0_i`` at any sample.
+
+    Reference:
+        Lopez de Prado (2018), chapter 4 section 4.4, equation for
+        ``c_t = sum_i 1_{t0_i <= t <= t1_i}``.
+    """
+    _validate_datetime_series(t0, "t0")
+    _validate_datetime_series(t1, "t1")
+    _validate_datetime_series(bars, "bars")
+
+    n_bars = len(bars)
+    if len(t0) == 0:
+        return pl.Series(values=np.zeros(n_bars, dtype=np.int64), dtype=pl.Int64)
+    if n_bars == 0:
+        raise ValueError("bars is empty but t0/t1 are not; cannot compute concurrency")
+
+    i0, i1_plus_one = _locate_span_indices(t0, t1, bars)
+
+    # Delta array: +1 at span start, -1 just after span end. Cumulative
+    # sum gives concurrency at each bar.
+    delta = np.zeros(n_bars + 1, dtype=np.int64)
+    np.add.at(delta, i0, 1)
+    np.add.at(delta, i1_plus_one, -1)
+    concurrency = np.cumsum(delta[:-1])
+    return pl.Series(values=concurrency, dtype=pl.Int64)
+
+
+def uniqueness_weights(
+    t0: pl.Series,
+    t1: pl.Series,
+    bars: pl.Series,
+) -> pl.Series:
+    """Compute uniqueness weight ``u_i`` per sample.
+
+    ``u_i = mean(1 / c_t for t in [t0_i, t1_i])``
+
+    where ``c_t`` is the concurrency count at bar ``t``. Lower when the
+    span overlaps many other spans (information is shared); higher when
+    the span is disjoint (information is unique to this sample).
+
+    Args:
+        t0: UTC bar timestamps - span starts.
+        t1: UTC bar timestamps - span ends.
+        bars: UTC strictly-monotonic bar timestamps covering the label
+            range.
+
+    Returns:
+        ``pl.Series[Float64]`` of length ``n_samples`` with the per-sample
+        uniqueness weight. For disjoint events the value is exactly 1.0.
+
+    Raises:
+        ValueError: If inputs fail validation (see
+            :func:`compute_concurrency`) or if ``c_t == 0`` at any bar
+            inside ``[t0_i, t1_i]`` (should not happen when inputs are
+            consistent, but we fail loudly rather than emit NaN).
+
+    Reference:
+        Lopez de Prado (2018), chapter 4 section 4.4, equation (4.2):
+        ``u_bar_i = (1 / |T_i|) * sum_{t in T_i} (1 / c_t)``.
+    """
+    _validate_datetime_series(t0, "t0")
+    _validate_datetime_series(t1, "t1")
+    _validate_datetime_series(bars, "bars")
+
+    n_samples = len(t0)
+    if n_samples == 0:
+        return _empty_float_series()
+    if len(bars) == 0:
+        raise ValueError("bars is empty but t0/t1 are not")
+
+    i0, i1_plus_one = _locate_span_indices(t0, t1, bars)
+
+    concurrency = compute_concurrency(t0, t1, bars).to_numpy()
+
+    # Every bar covered by at least one span must have c_t >= 1. Check
+    # the slice actually consumed by any sample rather than the whole
+    # bars array (some bars may be outside every span and legitimately
+    # have c_t == 0; we never access those).
+    inv_concurrency = np.zeros(len(concurrency), dtype=np.float64)
+    covered_mask = concurrency > 0
+    inv_concurrency[covered_mask] = 1.0 / concurrency[covered_mask]
+
+    # Verify fail-loud: every bar inside every sample span must be
+    # covered. A single cheap check per sample: min(c_t) over the span.
+    # Using the prefix sum trick again: min requires a different
+    # structure. Instead we check that `covered_mask[i0:i1+1]` is fully
+    # True via a per-sample prefix-cumsum of the covered mask. If the
+    # number of covered bars in [i0, i1+1) equals (i1+1 - i0), all bars
+    # in the span are covered.
+    cumsum_covered = np.concatenate(([0], np.cumsum(covered_mask.astype(np.int64))))
+    covered_in_span = cumsum_covered[i1_plus_one] - cumsum_covered[i0]
+    span_len = i1_plus_one - i0
+    if not np.array_equal(covered_in_span, span_len):
+        bad = int(np.argmax(covered_in_span != span_len))
+        raise ValueError(
+            f"c_t == 0 at a bar inside sample {bad}'s span "
+            f"[{t0[bad]}, {t1[bad]}]; this should not happen if inputs "
+            "are consistent. ADR-0005 D2 forbids silent zero-weight."
+        )
+
+    # Prefix sums of 1/c_t; u_i = (cumsum[i1+1] - cumsum[i0]) / span_len.
+    cumsum_inv = np.concatenate(([0.0], np.cumsum(inv_concurrency)))
+    weights = (cumsum_inv[i1_plus_one] - cumsum_inv[i0]) / span_len.astype(np.float64)
+
+    return pl.Series(values=weights, dtype=pl.Float64)
+
+
+def return_attribution_weights(
+    t0: pl.Series,
+    t1: pl.Series,
+    bars: pl.Series,
+    log_returns: pl.Series,
+) -> pl.Series:
+    """Compute return-attribution weight ``r_i`` per sample.
+
+    ``r_i = |sum(ret_t / c_t for t in [t0_i, t1_i])|``
+
+    Attributes the P&L magnitude of the span to the sample, discounted by
+    the concurrency at each bar so that overlapping labels do not
+    double-count returns.
+
+    Args:
+        t0: UTC bar timestamps - span starts.
+        t1: UTC bar timestamps - span ends.
+        bars: UTC strictly-monotonic bar timestamps.
+        log_returns: ``pl.Series[Float64]`` of per-bar log returns,
+            aligned with ``bars``. No NaN / Inf allowed.
+
+    Returns:
+        ``pl.Series[Float64]`` of length ``n_samples`` with the
+        per-sample absolute-value weight. Zero when the span's
+        concurrency-adjusted log-return sum is exactly zero.
+
+    Raises:
+        ValueError: If inputs fail validation, if ``log_returns`` and
+            ``bars`` have different lengths, or if ``c_t == 0`` inside
+            any span.
+
+    Reference:
+        Lopez de Prado (2018), chapter 4 section 4.5, equation (4.10):
+        ``w_i = |sum_{t in T_i} ret_t / c_t|``.
+    """
+    _validate_datetime_series(t0, "t0")
+    _validate_datetime_series(t1, "t1")
+    _validate_datetime_series(bars, "bars")
+    _validate_numeric_series(log_returns, "log_returns", expected_length=len(bars))
+
+    n_samples = len(t0)
+    if n_samples == 0:
+        return _empty_float_series()
+    if len(bars) == 0:
+        raise ValueError("bars is empty but t0/t1 are not")
+
+    i0, i1_plus_one = _locate_span_indices(t0, t1, bars)
+
+    concurrency = compute_concurrency(t0, t1, bars).to_numpy()
+    covered_mask = concurrency > 0
+    ret = log_returns.to_numpy().astype(np.float64)
+
+    # Same fail-loud check as uniqueness_weights: every bar in every
+    # span must be covered.
+    cumsum_covered = np.concatenate(([0], np.cumsum(covered_mask.astype(np.int64))))
+    covered_in_span = cumsum_covered[i1_plus_one] - cumsum_covered[i0]
+    span_len = i1_plus_one - i0
+    if not np.array_equal(covered_in_span, span_len):
+        bad = int(np.argmax(covered_in_span != span_len))
+        raise ValueError(
+            f"c_t == 0 at a bar inside sample {bad}'s span "
+            f"[{t0[bad]}, {t1[bad]}]; ADR-0005 D2 forbids silent zero-weight."
+        )
+
+    # ret_over_c defined only on covered bars; zero elsewhere (we never
+    # access the uncovered entries).
+    ret_over_c = np.zeros_like(ret)
+    ret_over_c[covered_mask] = ret[covered_mask] / concurrency[covered_mask]
+
+    cumsum_rc = np.concatenate(([0.0], np.cumsum(ret_over_c)))
+    per_sample_sum = cumsum_rc[i1_plus_one] - cumsum_rc[i0]
+    return pl.Series(values=np.abs(per_sample_sum), dtype=pl.Float64)
+
+
+def combined_weights(
+    t0: pl.Series,
+    t1: pl.Series,
+    bars: pl.Series,
+    log_returns: pl.Series,
+) -> pl.Series:
+    """Compute the final Meta-Labeler training weight ``w_i``.
+
+    ``w_i = u_i * r_i``, then normalized so that
+    ``sum(w_i) == n_samples`` (within ``1e-9`` tolerance).
+
+    When every sample's ``r_i`` is zero (pathological zero-return
+    scenario), the raw product is all-zero; we return the all-zero
+    series unchanged because normalization would divide by zero. The
+    caller should treat an all-zero weight vector as a degenerate
+    training batch and handle it explicitly upstream.
+
+    Args:
+        t0: UTC bar timestamps - span starts.
+        t1: UTC bar timestamps - span ends.
+        bars: UTC strictly-monotonic bar timestamps.
+        log_returns: Per-bar log returns aligned with ``bars``.
+
+    Returns:
+        ``pl.Series[Float64]`` of length ``n_samples`` with the final
+        normalized training weights. Empty input -> empty output.
+
+    Raises:
+        ValueError: If the underlying weight computations fail validation.
+
+    Reference:
+        Lopez de Prado (2018), chapter 4 section 4.5, combined weighting.
+        ADR-0005 D2 - final training weight contract.
+    """
+    n_samples = len(t0)
+    u = uniqueness_weights(t0, t1, bars)
+    r = return_attribution_weights(t0, t1, bars, log_returns)
+
+    if n_samples == 0:
+        return _empty_float_series()
+
+    w_raw = u.to_numpy() * r.to_numpy()
+    total = float(np.sum(w_raw))
+    if total <= 0.0:
+        # All-zero or degenerate: return the raw product (all zeros) and
+        # let the caller surface the issue. We do NOT silently remap to
+        # uniform weights - that would mask a pathological training set.
+        return pl.Series(values=w_raw, dtype=pl.Float64)
+
+    w = w_raw * (float(n_samples) / total)
+
+    # Invariant: sum(w) == n_samples within tolerance.
+    achieved = float(np.sum(w))
+    if abs(achieved - float(n_samples)) > _NORMALIZATION_TOL:
+        raise ValueError(
+            f"normalization drift: sum(w)={achieved} vs n_samples={n_samples} "
+            f"(tolerance={_NORMALIZATION_TOL}); investigate float precision"
+        )
+
+    return pl.Series(values=w, dtype=pl.Float64)

--- a/reports/phase_4_2/audit.md
+++ b/reports/phase_4_2/audit.md
@@ -1,0 +1,327 @@
+# Phase 4.2 — Sample Weights (uniqueness × return attribution) — Audit pré-implémentation
+
+| Field | Value |
+|---|---|
+| Branch | `phase/4.2-sample-weights` |
+| Date | 2026-04-14 |
+| Issue | #126 |
+| Predecessor | Phase 4.1 (PR #138 merged) |
+| Authors | Claude (Opus 4.6) + Clément Barbier (architect review pending) |
+| Status | **READY — verdict CRÉER (new sibling module) ; plan §4 prêt à exécuter** |
+
+---
+
+## 0. TL;DR
+
+Contrairement à la Phase 4.1 (qui ÉTENDAIT un labeler existant),
+Phase 4.2 **crée un module canonique neuf** `features/labeling/sample_weights.py`
+conformément à **PHASE_4_SPEC §2.3** qui liste explicitement ce module
+dans la colonne « To create (no pre-existing equivalent) » avec la
+justification : *« Uniqueness + return-attribution weights do not exist
+anywhere in the repo »*.
+
+Cela **ne contredit pas** l'existence de `features/weights.py::SampleWeighter`
+(143 LOC, Phase 3.1), qui est une **API duration-weighted datetime-based**
+consommée par `features/pipeline.py` et 21 tests. Les deux modules coexistent
+de façon explicite :
+
+| Aspect | `features/weights.py::SampleWeighter` (existant, Phase 3.1) | `features/labeling/sample_weights.py` (neuf, Phase 4.2) |
+|---|---|---|
+| Canonicalité | Prototype duration-weighted — pas la formule López de Prado §4.4 stricte | **Canonique** — formule LdP §4.4 `u_i = mean(1/c_t)` bar-indexée |
+| API | `(entry_times: list[datetime], exit_times: list[datetime]) -> np.ndarray` | `(t0: pl.Series, t1: pl.Series, bars: pl.Series, log_returns: pl.Series) -> pl.Series` |
+| Return attribution | `raise NotImplementedError` ([features/weights.py:140](../../features/weights.py)) | **Implémenté** per ADR-0005 D2 |
+| Consommateurs actuels | `features/pipeline.py:31`, `tests/unit/features/test_weights.py` (21 tests), `test_pipeline{,_with_store}.py` | Sub-phases 4.3 (training), 4.4 (tuning), 4.5 (validation) |
+| Phase 4.2 touche ? | **Non** — zéro modification, tests existants doivent rester verts | **Crée** intégralement |
+
+La coexistence est **documentée dans le docstring** du nouveau module et
+dans le rapport `weights_distribution.md`. Une dette technique est ouverte
+implicitement : à la fin de Phase 4 (ou début Phase 5), `features/weights.py`
+deviendra redondant et pourra être supprimé après migration de
+`features/pipeline.py`. **Hors scope Phase 4.2.**
+
+Aucune divergence entre le prompt de mission (issue #126), ADR-0005 D2
+(reproduit §2 ci-dessous), et PHASE_4_SPEC §3.2 : la triade converge.
+Verdict **CRÉER** unanime.
+
+---
+
+## 1. Inventaire de l'existant
+
+### 1.1 Code pré-existant identifié
+
+Recherche `rg -n "sample_weight|SampleWeight|uniqueness" --type py` :
+
+| Fichier | Rôle | Phase 4.2 touche ? |
+|---|---|---|
+| [features/weights.py](../../features/weights.py) | `SampleWeighter` — duration-weighted average uniqueness sur `list[datetime]`. 143 LOC. Prototype Phase 3.1. | **Non** — laissé intact. Le nouveau module est un sibling canonique. |
+| [features/pipeline.py](../../features/pipeline.py) | Ligne 31 : `from features.weights import SampleWeighter`. Ligne 57 : `weighter: SampleWeighter` dans la signature. | **Non** — pipeline Phase 3 préservé. |
+| [tests/unit/features/test_weights.py](../../tests/unit/features/test_weights.py) | 21 tests sur `SampleWeighter.uniqueness_weights()`. | **Non** — doit rester vert. |
+| [tests/unit/features/test_pipeline.py](../../tests/unit/features/test_pipeline.py), [test_pipeline_with_store.py](../../tests/unit/features/test_pipeline_with_store.py) | Injection `SampleWeighter()` dans le pipeline Phase 3. | **Non** — intact. |
+| [core/math/labeling.py](../../core/math/labeling.py) | `BarrierLabel.entry_time`, `BarrierLabel.exit_time` — source des `t0` / `t1` consommés par 4.2. | **Non** — lecture seule. API stable. |
+| [features/labeling/triple_barrier.py](../../features/labeling/triple_barrier.py) | `label_events_binary()` retourne schema `{symbol, t0, t1, entry_price, exit_price, ternary_label, binary_target, barrier_hit, holding_periods}` avec `t0` / `t1` en `pl.Datetime("us", "UTC")`. | **Non** — consommateur aval. |
+| [features/cv/cpcv.py](../../features/cv/cpcv.py) | `CombinatoriallyPurgedKFold.split(X, t1)` — accepte déjà `t1` pour le purging. Pas de `sample_weight` en paramètre (ADR-0005 D2 : « weights live inside `.fit()`, pas dans CPCV »). | **Non** — contrat D2 respecté. |
+
+### 1.2 Schéma d'entrée canonique (source de vérité)
+
+Le livrable 4.1 (`features/labeling/triple_barrier.py::label_events_binary`)
+produit un `pl.DataFrame` dont Phase 4.2 consomme les colonnes `t0`, `t1` :
+
+```python
+schema = {
+    "symbol": pl.Utf8,
+    "t0": pl.Datetime("us", "UTC"),       # <--- consommé par 4.2
+    "t1": pl.Datetime("us", "UTC"),       # <--- consommé par 4.2
+    "entry_price": pl.Float64,
+    "exit_price": pl.Float64,
+    "ternary_label": pl.Int8,
+    "binary_target": pl.Int8,
+    "barrier_hit": pl.Utf8,
+    "holding_periods": pl.Int32,
+}
+```
+
+Les `bars` et `log_returns` sont alignés sur le même pl.DataFrame de
+barres OHLC utilisé par 4.1. 4.2 ne recalcule pas les log-returns : ils
+sont fournis en entrée (colonne `log_return` pré-calculée par l'appelant
+ou via `polars.col("close").log().diff()`).
+
+### 1.3 Emplacement canonique pour le nouveau code
+
+Per **PHASE_4_SPEC §3.2 (Module structure)** et **Issue #126 Deliverables** :
+
+```
+features/labeling/
+├── sample_weights.py          (NEW)
+
+tests/unit/features/labeling/
+├── test_sample_weights_uniqueness.py    (NEW, ~10 tests)
+├── test_sample_weights_attribution.py   (NEW, ~8 tests)
+└── test_sample_weights_combined.py      (NEW, ~6 tests)
+```
+
+**Aucune modification** de :
+- `features/weights.py` (prototype Phase 3.1 intact — coexistence documentée).
+- `features/labeling/__init__.py` (sauf ajout des re-exports des 4 nouvelles fonctions, additif).
+- `core/math/labeling.py` (lecture seule).
+- `features/cv/cpcv.py` (D2 : weights dans `.fit()`, pas dans CPCV).
+- `services/*` (spec §2.4 frozen — inchangé).
+
+---
+
+## 2. Conformité vs D2 de ADR-0005
+
+D2 (reproduit intégralement pour référence) :
+
+> **D2 — Sample weights: uniqueness × return attribution**
+>
+> Every sample carries two weights (López de Prado §4.4–4.5) computed
+> in sub-phase 4.2:
+>
+> - **Uniqueness weight** `u_i`: inverse of the average concurrency
+>   count of label-span `[t0_i, t1_i]` with other label spans.
+>   Formally, `u_i = mean(1 / c_t for t in [t0_i, t1_i])` where `c_t`
+>   is the number of labels whose span covers bar `t`. This prevents
+>   oversampling periods with many overlapping labels.
+> - **Return attribution weight** `r_i`:
+>   `r_i = |sum(ret_t / c_t for t in [t0_i, t1_i])|` where `ret_t` is
+>   the log return of bar `t`. Weights samples by the P&L magnitude
+>   attributable to the label span, not just the hit/miss outcome.
+>
+> **Final training weight**: `w_i = u_i × r_i`, then normalized so that
+> `sum(w_i) = n_samples`. Weights are passed through
+> `sklearn.fit(X, y, sample_weight=w)`. CPCV fold construction itself
+> is NOT weighted; weights live inside `.fit()`.
+
+### 2.1 Scorecard de conformité (cible — pas encore écrit)
+
+| Paramètre D2 | Plan Phase 4.2 | Conforme ? |
+|---|---|---|
+| Formule `u_i = mean(1 / c_t for t in [t0_i, t1_i])` | Implémentée dans `uniqueness_weights()` en Polars vectorisé | ✅ cible |
+| Formule `r_i = |sum(ret_t / c_t for t in [t0_i, t1_i])|` | Implémentée dans `return_attribution_weights()` (valeur absolue obligatoire) | ✅ cible |
+| `w_i = u_i × r_i`, normalisé `sum(w_i) = n_samples` | Implémentée dans `combined_weights()` avec renormalisation explicite | ✅ cible |
+| Consommé via `sklearn.fit(X, y, sample_weight=w)` | Contrat aval 4.3 ; 4.2 livre `pl.Series[Float64]` convertible `.to_numpy()` | ✅ cible |
+| CPCV fold construction **pas** weighted | 4.2 ne modifie pas `features/cv/cpcv.py` | ✅ cible |
+| Anti-leakage : weights ne dépendent que de `[t0_i, t1_i]`, bars, log_returns intra-span | Property test dédié (shuffle post-t1 returns → weights inchangés) | ✅ cible |
+| Fail-loud : `c_t == 0` → `ValueError` | Guard explicite, message avec timestamp | ✅ cible |
+
+**Aucune dérogation prévue.** Conformité cible : 100%.
+
+### 2.2 Contraintes additionnelles issues d'Issue #126 et PHASE_4_SPEC §3.2
+
+- **Coverage ≥ 92%** sur `features/labeling/sample_weights.py` (issue #126
+  DoD §1 — plus strict que les 85% globaux de la CI).
+- **mypy --strict clean** (issue #126 DoD §2 — annotations complètes,
+  `pl.Series[datetime]`, `pl.Series[float]` via `pl.Series` + runtime
+  dtype check).
+- **ruff clean** (DoD §3).
+- **Perf : 10,000 samples × 100,000 bars ≤ 30 s sur 1 CPU** (DoD §5).
+  Cela **interdit** les doubles boucles Python ; plan vectorisé Polars/
+  NumPy obligatoire. Le `SampleWeighter` existant (O(n² × endpoints) via
+  triple boucle Python) **ne tient pas** ce budget au-delà de quelques
+  milliers d'events — raison supplémentaire pour un module neuf plutôt
+  qu'une extension.
+- **Test de référence contre López de Prado §4.4 Table 4.1** (DoD §6).
+  La Table 4.1 LdP est un scénario à 5 observations, je l'encode
+  littéralement dans `test_uniqueness_matches_reference_table_LdP_4_4`
+  avec les valeurs numériques attendues (computées à la main + commentées).
+
+---
+
+## 3. Verdict
+
+### 3.1 Verdict retenu : **CRÉER** (module neuf sibling, conservation de l'existant)
+
+**Justification (≥ 5 lignes exigées) :**
+
+1. La triade contractuelle (ADR-0005 D2, PHASE_4_SPEC §2.3 ligne
+   `features/labeling/sample_weights.py | 4.2 | Uniqueness + return-attribution
+   weights do not exist anywhere in the repo`, Issue #126 Deliverables)
+   converge explicitement vers **CRÉER** dans `features/labeling/`.
+2. Le prototype existant `features/weights.py::SampleWeighter` a trois
+   incompatibilités techniques avec D2 : (a) API `list[datetime]` vs Polars
+   série bar-indexée requise par la pipeline Phase 4 ; (b) formule
+   duration-weighted vs formule bar-indexée `mean(1/c_t)` de LdP §4.4 ;
+   (c) `return_attribution_weights` est `NotImplementedError`.
+3. Un refactor destructeur de `features/weights.py` casserait
+   `features/pipeline.py` (Phase 3) et 21 tests stables. Inacceptable
+   (CLAUDE.md §6 : « never suggest merging if CI is red »). Un refactor
+   additif rallongerait l'API existante avec une seconde signature — plus
+   confus que la coexistence explicite.
+4. La coexistence de deux modules est temporaire : le prototype Phase 3.1
+   deviendra redondant une fois les Phase 4.3/4.4 wired sur le module
+   canonique. Nettoyage prévu en Phase 4.9 closure report comme dette
+   technique identifiée.
+5. La perf 10 000 × 100 000 ≤ 30 s (Issue #126 DoD §5) impose un
+   algorithme fondamentalement différent du prototype (vectorisation
+   Polars, bitmap concurrency via `group_by_dynamic` ou numpy broadcast).
+   Réutiliser l'ossature du prototype handicaperait le budget perf.
+
+### 3.2 Verdict implicite du prompt de mission : identique
+
+Issue #126 et PHASE_4_SPEC §3.2 spécifient toutes deux
+`features/labeling/sample_weights.py` comme module **NEW**. Pas de
+contradiction avec ma recommandation. **Aucune demande de confirmation
+requise** — j'enchaîne sur le plan §4.
+
+### 3.3 Décisions micro-design à consigner
+
+| Point | Décision | Justification |
+|---|---|---|
+| Inclusion du bar `t0` dans le span | `[t0, t1]` inclusif des deux bornes | Cohérent avec `label_event` qui considère `entry_time` comme le premier bar de l'event window, et avec LdP §4.4 qui indexe sur `T_i = {t : t0_i ≤ t ≤ t1_i}` |
+| Inclusion du bar `t1` dans le span | `[t0, t1]` inclusif des deux bornes | Idem LdP §4.4 |
+| Convention égalité `c_t == 0` hors span | `c_t` n'est calculé que sur les bars couverts par ≥ 1 sample ; un bar sans couverture n'apparaît jamais dans `T_i` donc `c_t == 0` n'arrive que si un sample référence un bar hors de la plage des autres samples → `ValueError` fail-loud |
+| Ordre de normalisation | Après calcul de `u × r` : `w *= n_samples / sum(w)`, tolérance `1e-9` | Spec §3.2 Algorithm notes |
+| Type d'output | `pl.Series[Float64]` (pas `np.ndarray`) | Cohérent avec la pipeline Polars Phase 4.1 ; conversion `.to_numpy()` triviale pour sklearn |
+| `log_returns` calculés ou fournis ? | **Fournis** en paramètre ; API accepte `pl.Series[Float64]` pré-calculée | Séparation de responsabilité ; 4.1 ne calcule pas les log-returns non plus ; permet au caller de choisir entre log-diff de close vs fracdiff vs autre |
+| Intra-bar alignment `bars` vs `t0`/`t1` | Tous les `t0`/`t1` doivent exister dans `bars.timestamp` ; sinon `ValueError` avec timestamp orphelin | Fail-loud (pattern Phase 4.1) |
+| Dtype `t0` / `t1` | `pl.Datetime("us", "UTC")` strict — naïf raise | Cohérent avec 4.1 output |
+| Support multi-symbole | MVP Phase 4.2 : mono-symbole ; multi-symbole = regrouper par `symbol` côté caller | PHASE_4_SPEC §3.2 silence sur le multi-symbole ; 4.1 normalise aussi mono-symbole |
+
+---
+
+## 4. Plan d'implémentation
+
+### 4.1 Fichiers à créer / modifier
+
+| Fichier | Action | LOC est. | # tests |
+|---|---|---|---|
+| `features/labeling/sample_weights.py` | **Create** : `compute_concurrency`, `uniqueness_weights`, `return_attribution_weights`, `combined_weights` + internes vectorisés. | ~270 | - |
+| `features/labeling/__init__.py` | **Extend** (additif) : re-exporte les 4 fonctions publiques. | +8 | - |
+| `tests/unit/features/labeling/test_sample_weights_uniqueness.py` | **Create**. | ~260 | 10 |
+| `tests/unit/features/labeling/test_sample_weights_attribution.py` | **Create**. | ~200 | 8 |
+| `tests/unit/features/labeling/test_sample_weights_combined.py` | **Create**. | ~170 | 6 |
+| `reports/phase_4_2/audit.md` | **Create** (ce document). | ~400 | - |
+| `reports/phase_4_2/weights_distribution.md` | **Create** (généré post-tests via fixture). | ~100 | - |
+| `docs/claude_memory/SESSIONS.md` | **Append** : entrée Session 031. | +40 | - |
+| `docs/claude_memory/CONTEXT.md` | **Update** : statut Phase 4.2. | diff | - |
+| `docs/claude_memory/DECISIONS.md` | **Append** : décision coexistence `features/weights.py` vs `features/labeling/sample_weights.py`. | +20 | - |
+
+**Total estimé** : ~700 LOC implementation (module + diagnostics) + ~630 LOC
+tests. 24 tests nouveaux (cible ≥ 24 per issue §Tests). Zéro modification
+sous `services/`, `core/`, `features/pipeline.py`, `features/weights.py`.
+Une seule addition additive dans `features/labeling/__init__.py` (4
+re-exports).
+
+### 4.2 Ordre d'implémentation recommandé
+
+1. `features/labeling/sample_weights.py` — skeleton + `compute_concurrency`
+   (le primitif) + tests concurrency (3-4 cas).
+2. `uniqueness_weights` + tests LdP §4.4 Table 4.1 + edge cases.
+3. `return_attribution_weights` + tests anti-leakage (shuffle post-t1 returns).
+4. `combined_weights` + test normalisation `sum == n_samples`.
+5. Fail-loud path : UTC check, alignment check, `c_t == 0` raise, misaligned
+   bars raise, naive datetime raise.
+6. Re-exports dans `features/labeling/__init__.py`.
+7. Génération `reports/phase_4_2/weights_distribution.md` via fixture
+   synthétique (seed 42, 100 events × 1000 bars, distribution overlap moyenne).
+8. `make lint` (ruff + mypy strict + bandit) puis `pytest tests/unit/features/labeling/`.
+9. Budget perf : test dédié avec `n_samples=10_000`, `n_bars=100_000`, assert
+   `duration < 30.0` (seuil issue #126 DoD §5) — `@pytest.mark.slow` pour ne
+   pas bloquer le CI default.
+
+### 4.3 Edge cases critiques
+
+Les trois edge cases à prioriser dans les tests :
+
+1. **Anti-leakage (ADR-0005 D2 + Issue §Anti-leakage)** — shuffler les log
+   returns après `t1_max` ne doit **pas** altérer les weights. Property
+   test Hypothesis avec 100 exemples suffisent (perf budget).
+2. **Normalisation `sum(w) == n_samples`** — tolérance `1e-9`. Cas
+   dégénéré : tous les events disjoints → chaque `u_i = 1`, `r_i = |ret_total_i|` ;
+   après normalisation `w_i = n * |r_i| / sum(|r_j|)`. Formule vérifiable
+   à la main.
+3. **`c_t == 0` fail-loud** — un sample avec `t0` ou `t1` hors de la plage
+   couverte par les autres samples (et donc hors de `bars`) doit raise avec
+   timestamp explicite, pas silencieusement skip.
+
+Edge cases secondaires :
+
+4. Empty events / bars → retourne `pl.Series` vide, pas d'erreur.
+5. Single event disjoint → `u_1 = 1`, `r_1 = |sum ret_t|`, après normalisation
+   `w_1 = 1.0` exactement.
+6. Tous events parfaitement identiques (mêmes `t0`/`t1`) → `c_t` constant,
+   `u_i = 1/n` pour tous, weights tous égaux après normalisation.
+7. Naive datetime dans `t0`/`t1`/`bars` → `ValueError` immédiat.
+8. `log_returns` non alignés sur `bars` (tailles différentes) → `ValueError`.
+9. `log_returns` contient NaN / Inf → `ValueError` fail-loud (pas de ffill
+   silencieux — pattern Phase 4.1).
+10. Concurrency géante (1 bar couvert par 1000 samples) → weight très
+    faible mais strictement > 0, pas de division par zéro.
+11. Zero-length span `t0 == t1` : par convention inclusive `[t0, t0]` =
+    1 bar → `u_i = 1/c_{t0}`. Cas documenté.
+12. Events ordonnés vs non-ordonnés : l'API ne requiert pas d'ordre
+    particulier sur les events ; tests parametrisés avec random shuffle.
+13. `ret_t = 0` exactement sur toute la span → `r_i = 0` → contribution
+    nulle au combined weight → après normalisation sum(w) peut devenir 0 si
+    **tous** les events ont ret nul → cas limite documenté, potentiel
+    `ValueError` ou retour all-zero series (décision : retourner all-zero
+    et laisser le caller décider — plus utile pour debugging qu'un raise).
+
+### 4.4 Risques résiduels et mitigations
+
+| Risque | Probabilité | Impact | Mitigation |
+|---|---|---|---|
+| Budget perf 10k × 100k ≤ 30s non tenu | Moyenne | Bloquant (DoD §5) | Algorithme cible : concurrency via `pl.int_range` + `group_by_dynamic`, ou numpy bitmap `(n_samples, n_bars)` si memory OK (1e9 bytes = 8 GB pour bool → pas OK, partitionner en chunks de 10k bars). Fallback : algorithme O(n_samples * avg_span) en numpy vectorisé. |
+| Mémoire peak > 4 GB lors du test perf | Faible | Faible | Chunker par 10k bars si bitmap ; alternative O(n log n) via tri + balayage d'événements (scanline) |
+| Drift numérique entre float32/float64 sur `sum(1/c_t)` | Faible | Faible | Forcer `pl.Float64` partout ; `@pytest.mark.parametrize` tolérance adaptée |
+| Test LdP §4.4 Table 4.1 — divergence de ±1 sur les counts selon la convention inclusive/exclusive | Moyenne | Moyen | Documenter la convention `[t0, t1]` inclusive dans le docstring + commenter chaque ligne du test avec son counting manuel |
+| `features/weights.py::SampleWeighter.uniqueness_weights` diverge du nouveau module sur le même scénario | Haute (par design) | Nul | Documenté : les deux formules sont différentes (duration-weighted vs bar-indexed). Aucun test de parité. |
+| Ajout additif dans `features/labeling/__init__.py` casse l'import order | Faible | Faible | Tests existants Phase 4.1 doivent rester verts après ajout des re-exports |
+| Hypothesis property test trop lent (>5s) | Faible | Faible | Budget `@settings(max_examples=50, deadline=None)` |
+
+---
+
+## 5. Décision
+
+**Aucune confirmation architecte requise** (triade ADR/Spec/Issue
+convergente). Le plan §4 est exécuté immédiatement dans un commit
+`phase(4.2): sample weights module per ADR-0005 D2` sur cette même
+branche `phase/4.2-sample-weights`, suivi des commits tests + diagnostics
++ mise à jour mémoire puis push + PR.
+
+Dette technique ouverte à porter dans `docs/claude_memory/DECISIONS.md` :
+*« `features/weights.py::SampleWeighter` (prototype Phase 3.1) coexiste
+avec `features/labeling/sample_weights.py` (canonique Phase 4.2). La
+migration de `features/pipeline.py` vers le module canonique est reportée
+à la closure Phase 4 (issue #133) ou à Phase 5 ; cette coexistence est
+temporaire et explicitement documentée pour éviter la confusion DRY. »*

--- a/reports/phase_4_2/weights_distribution.md
+++ b/reports/phase_4_2/weights_distribution.md
@@ -1,0 +1,216 @@
+# Phase 4.2 — Sample Weights Distribution Diagnostic
+
+| Field | Value |
+|---|---|
+| Branch | `phase/4.2-sample-weights` |
+| Issue | #126 |
+| Date | 2026-04-14 |
+| Fixture seed | `42` (numpy `default_rng`) |
+| Bars | 1,000 (1-minute UTC, synthetic) |
+| Events | 100 (holding periods ∈ [5, 50] bars, uniform starts across first 90% of bars) |
+| Module under test | `features/labeling/sample_weights.py` |
+| Coverage | 94% (52 passing tests) |
+
+---
+
+## 1. Purpose
+
+This report exercises the canonical ADR-0005 D2 implementation on a
+synthetic but realistic fixture (100 overlapping labels over 1,000 bars,
+mild positive drift + Gaussian noise). It verifies:
+
+1. The normalization invariant `sum(w) == n_samples` holds to float
+   precision (tolerance `1e-9`).
+2. The uniqueness distribution reacts correctly to overlap
+   (`u ∈ (0, 1]`, left-skewed when many labels overlap).
+3. The combined weight `w = u × r` has positive skew (a few high-signal
+   samples carry most of the loss, as expected for a meta-labeler
+   training set).
+
+No production data was used; everything below is reproducible from the
+committed test fixtures (seed `42`).
+
+---
+
+## 2. Concurrency `c_t`
+
+Computed by `features.labeling.sample_weights.compute_concurrency`
+over all 1,000 bars.
+
+| Metric | Value |
+|---|---|
+| `min` | 0 |
+| `p05` | 0 |
+| `p50` | 3 |
+| `p95` | 6 |
+| `max` | 8 |
+| `mean` | 2.810 |
+| `std` | 1.861 |
+| Bars with `c ≥ 1` | 845 / 1,000 |
+
+Up to 8 labels are active simultaneously at the busiest bars; 15.5% of
+bars have no active label (expected — holding periods stop ≤ 50 bars and
+the last 10% of bars receive no new starts, so the tail empties out).
+
+---
+
+## 3. Uniqueness `u_i`
+
+Per-sample `u_i = mean(1 / c_t for t in [t0_i, t1_i])`.
+
+| Metric | Value |
+|---|---|
+| `min` | 0.1429 |
+| `p05` | 0.1671 |
+| `p50` | 0.2584 |
+| `p95` | 0.6710 |
+| `max` | 0.8889 |
+| `mean` | 0.2974 |
+| `std` | 0.1395 |
+
+### Histogram (10 equal-width bins)
+
+| Range | Count | Bar |
+|---|---:|---|
+| [0.1429, 0.2175) | 26 | `##########################` |
+| [0.2175, 0.2921) | 39 | `########################################` |
+| [0.2921, 0.3667) | 15 | `###############` |
+| [0.3667, 0.4413) | 10 | `##########` |
+| [0.4413, 0.5159) | 4 | `####` |
+| [0.5159, 0.5905) | 0 |  |
+| [0.5905, 0.6651) | 0 |  |
+| [0.6651, 0.7397) | 3 | `###` |
+| [0.7397, 0.8143) | 2 | `##` |
+| [0.8143, 0.8889) | 1 | `#` |
+
+Right-skewed toward zero: most labels land in the densely-overlapped
+region (c ≈ 3–4) and therefore share information with peers. The small
+high-uniqueness tail corresponds to events starting in the last 10% of
+the window where future overlap is sparse — exactly the behavior López
+de Prado §4.4 Figure 4.1 illustrates.
+
+All `u_i ∈ (0, 1]` as required by ADR-0005 D2.
+
+---
+
+## 4. Return attribution `r_i`
+
+Per-sample `r_i = |sum(ret_t / c_t for t in [t0_i, t1_i])|` with
+per-bar log-returns drawn i.i.d. from `N(μ=1e-4, σ=1e-3)`.
+
+| Metric | Value |
+|---|---|
+| `min` | 5.996e-05 |
+| `p05` | 1.806e-04 |
+| `p50` | 8.598e-04 |
+| `p95` | 4.109e-03 |
+| `max` | 6.828e-03 |
+| `mean` | 1.337e-03 |
+| `std` | 1.286e-03 |
+
+All values are strictly non-negative (absolute-value contract), and
+positively skewed — a minority of samples pick up disproportionately
+larger run-length moves, which is what the combined weight will then
+amplify.
+
+---
+
+## 5. Combined weights `w_i` (normalized)
+
+`w_i = u_i × r_i`, then scaled so `sum(w) == n_samples == 100`.
+
+| Metric | Value |
+|---|---|
+| `min` | 0.0331 |
+| `p05` | 0.0803 |
+| `p50` | 0.5040 |
+| `p95` | 3.5623 |
+| `max` | 10.1959 |
+| `mean` | 1.0000 (normalization invariant) |
+| `std` | 1.5477 |
+| `sum(w)` | 100.0 (vs 100 target) |
+| `|sum(w) − n_samples|` | 1.42e-14 (tolerance 1e-9) |
+
+### Histogram (10 equal-width bins)
+
+| Range | Count | Bar |
+|---|---:|---|
+| [0.0331, 1.0494) | 78 | `########################################` |
+| [1.0494, 2.0656) | 11 | `#####` |
+| [2.0656, 3.0819) | 3 | `#` |
+| [3.0819, 4.0982) | 3 | `#` |
+| [4.0982, 5.1145) | 1 |  |
+| [5.1145, 6.1308) | 1 |  |
+| [6.1308, 7.1470) | 2 | `#` |
+| [7.1470, 8.1633) | 0 |  |
+| [8.1633, 9.1796) | 0 |  |
+| [9.1796, 10.1959) | 1 |  |
+
+The long right tail is the expected signature of the meta-labeler
+weighting scheme: a few signal-rich samples (high uniqueness × strong
+attribution) carry the gradient, while the mass concentrates below
+mean. This is the behavior PHASE_4_SPEC §3.2 assumes for the Random
+Forest training loss in sub-phase 4.3.
+
+---
+
+## 6. Invariants checked
+
+| Invariant | Expected | Observed | Status |
+|---|---|---|---|
+| `sum(w) == n_samples` | 100 ± 1e-9 | 100.0 (drift 1.42e-14) | PASS |
+| `u_i ∈ (0, 1]` | All in (0, 1] | min 0.1429, max 0.8889 | PASS |
+| `r_i ≥ 0` | Non-negative | min 5.996e-05 | PASS |
+| `w_i ≥ 0` | Non-negative | min 0.0331 | PASS |
+| Anti-leakage (`shuffle post-t1 ret` invariance) | Unchanged | Hypothesis 200 cases | PASS |
+| Disjoint events → `u_i == 1.0` | All ones | `test_disjoint_spans_all_ones` | PASS |
+| LdP §4.4 Table 4.1 triangle | 11/18, 4/9, 11/18 | Exact to 1e-12 | PASS |
+
+---
+
+## 7. Reproduction
+
+```bash
+python3 -c "
+from datetime import UTC, datetime, timedelta
+import numpy as np
+import polars as pl
+from features.labeling.sample_weights import (
+    combined_weights, compute_concurrency,
+    return_attribution_weights, uniqueness_weights,
+)
+
+rng = np.random.default_rng(42)
+N_BARS, N_EVENTS = 1000, 100
+start = datetime(2024, 6, 1, 9, 30, tzinfo=UTC)
+bars = pl.Series(
+    [start + timedelta(minutes=i) for i in range(N_BARS)],
+    dtype=pl.Datetime('us', 'UTC'),
+)
+t0_idx = rng.integers(0, int(N_BARS * 0.9), size=N_EVENTS)
+hold   = rng.integers(5, 51, size=N_EVENTS)
+t1_idx = np.minimum(t0_idx + hold, N_BARS - 1)
+t0 = pl.Series([bars[int(i)] for i in t0_idx], dtype=pl.Datetime('us','UTC'))
+t1 = pl.Series([bars[int(i)] for i in t1_idx], dtype=pl.Datetime('us','UTC'))
+log_returns = pl.Series(
+    rng.normal(1e-4, 1e-3, size=N_BARS).tolist(), dtype=pl.Float64,
+)
+w = combined_weights(t0, t1, bars, log_returns).to_numpy()
+assert abs(w.sum() - N_EVENTS) < 1e-9
+"
+```
+
+Seed `42`, `numpy` 2.2.x, `polars` 1.39.x. Any deviation in these
+percentiles larger than ~1% between runs indicates a regression in the
+numerics.
+
+---
+
+## 8. References
+
+- López de Prado, M. (2018). *Advances in Financial Machine Learning*.
+  Wiley, Chapter 4.4 (Average Uniqueness) and 4.5 (Sample Weights by
+  Return Attribution), Table 4.1.
+- [`docs/adr/ADR-0005-meta-labeling-fusion-methodology.md`](../../docs/adr/ADR-0005-meta-labeling-fusion-methodology.md) — section D2.
+- [`docs/phases/PHASE_4_SPEC.md`](../../docs/phases/PHASE_4_SPEC.md) — section 3.2.
+- [`reports/phase_4_2/audit.md`](audit.md) — pre-implementation audit.

--- a/tests/unit/features/labeling/test_sample_weights_attribution.py
+++ b/tests/unit/features/labeling/test_sample_weights_attribution.py
@@ -1,0 +1,256 @@
+"""Tests for features.labeling.sample_weights - return attribution r_i.
+
+Groups:
+
+A. Core semantics (|sum(ret/c)| under overlap vs disjoint)
+B. Zero-return corner cases
+C. Fail-loud validation (NaN / Inf returns, length mismatch, c_t == 0)
+D. Anti-leakage property (shuffling log returns strictly after max(t1) does
+   not change any r_i). This is the critical invariant of ADR-0005 D2.
+E. Dtype / empty input contract
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from features.labeling.sample_weights import return_attribution_weights
+
+# --------------------------- Helpers ---------------------------------
+
+
+def _ts(minute: int) -> datetime:
+    return datetime(2024, 6, 1, 9, 30, tzinfo=UTC) + timedelta(minutes=minute)
+
+
+def _bars(n: int) -> pl.Series:
+    return pl.Series(
+        values=[_ts(i) for i in range(n)],
+        dtype=pl.Datetime("us", "UTC"),
+    )
+
+
+def _times(minutes: list[int]) -> pl.Series:
+    return pl.Series(
+        values=[_ts(m) for m in minutes],
+        dtype=pl.Datetime("us", "UTC"),
+    )
+
+
+def _returns(values: list[float]) -> pl.Series:
+    return pl.Series(values=values, dtype=pl.Float64)
+
+
+# --------------------------- A. Core semantics ------------------------
+
+
+class TestReturnAttributionCore:
+    def test_single_span_equals_sum_of_returns(self) -> None:
+        """With c_t == 1 everywhere in the span, r_i == |sum(ret_t)|."""
+        bars = _bars(5)
+        t0 = _times([1])
+        t1 = _times([3])
+        ret = _returns([0.0, 0.01, 0.02, 0.03, 0.0])
+        r = return_attribution_weights(t0, t1, bars, ret).to_list()
+        # Sum over bars 1,2,3 = 0.06
+        assert r == pytest.approx([0.06])
+
+    def test_is_absolute_value_of_sum(self) -> None:
+        bars = _bars(4)
+        t0 = _times([0])
+        t1 = _times([3])
+        ret = _returns([-0.02, -0.03, -0.01, -0.01])  # all negative
+        r = return_attribution_weights(t0, t1, bars, ret).to_list()
+        assert r == pytest.approx([0.07])
+
+    def test_concurrency_scales_attribution(self) -> None:
+        """Two identical spans cover c == 2; each gets half the return."""
+        bars = _bars(4)
+        t0 = _times([1, 1])
+        t1 = _times([2, 2])
+        ret = _returns([0.0, 0.04, 0.06, 0.0])
+        # ret/c on [1,2] = [0.02, 0.03]; per-sample sum = 0.05.
+        r = return_attribution_weights(t0, t1, bars, ret).to_list()
+        assert r == pytest.approx([0.05, 0.05])
+
+
+# --------------------------- B. Zero-return corner cases --------------
+
+
+class TestReturnAttributionZero:
+    def test_all_zero_returns(self) -> None:
+        bars = _bars(4)
+        t0 = _times([0, 1])
+        t1 = _times([2, 3])
+        ret = _returns([0.0, 0.0, 0.0, 0.0])
+        r = return_attribution_weights(t0, t1, bars, ret).to_list()
+        assert r == pytest.approx([0.0, 0.0])
+
+    def test_positive_and_negative_returns_cancel(self) -> None:
+        bars = _bars(3)
+        t0 = _times([0])
+        t1 = _times([2])
+        ret = _returns([0.05, -0.03, -0.02])  # sums to 0
+        r = return_attribution_weights(t0, t1, bars, ret).to_list()
+        assert r == pytest.approx([0.0], abs=1e-12)
+
+
+# --------------------------- C. Fail-loud validation ------------------
+
+
+class TestReturnAttributionValidation:
+    def test_nan_return_raises(self) -> None:
+        bars = _bars(3)
+        t0 = _times([0])
+        t1 = _times([2])
+        ret = _returns([0.01, float("nan"), 0.02])
+        with pytest.raises(ValueError, match="non-finite"):
+            return_attribution_weights(t0, t1, bars, ret)
+
+    def test_inf_return_raises(self) -> None:
+        bars = _bars(3)
+        t0 = _times([0])
+        t1 = _times([2])
+        ret = _returns([0.01, float("inf"), 0.02])
+        with pytest.raises(ValueError, match="non-finite"):
+            return_attribution_weights(t0, t1, bars, ret)
+
+    def test_length_mismatch_raises(self) -> None:
+        bars = _bars(4)
+        t0 = _times([0])
+        t1 = _times([1])
+        ret = _returns([0.01, 0.02])  # wrong length
+        with pytest.raises(ValueError, match="length"):
+            return_attribution_weights(t0, t1, bars, ret)
+
+    def test_null_returns_raise(self) -> None:
+        bars = _bars(3)
+        t0 = _times([0])
+        t1 = _times([2])
+        ret = pl.Series(values=[0.01, None, 0.02], dtype=pl.Float64)
+        with pytest.raises(ValueError, match="null"):
+            return_attribution_weights(t0, t1, bars, ret)
+
+    def test_empty_bars_nonempty_events_raises(self) -> None:
+        """Fail-loud when we have events but no bar series to anchor them."""
+        bars = pl.Series(values=[], dtype=pl.Datetime("us", "UTC"))
+        t0 = _times([0])
+        t1 = _times([0])
+        ret = pl.Series(values=[], dtype=pl.Float64)
+        with pytest.raises(ValueError, match="bars is empty"):
+            return_attribution_weights(t0, t1, bars, ret)
+
+    def test_fully_empty_inputs_return_empty(self) -> None:
+        """Empty bars + empty events + empty returns must return an empty series."""
+        bars = pl.Series(values=[], dtype=pl.Datetime("us", "UTC"))
+        t0 = _times([])
+        t1 = _times([])
+        ret = pl.Series(values=[], dtype=pl.Float64)
+        r = return_attribution_weights(t0, t1, bars, ret)
+        assert len(r) == 0
+        assert r.dtype == pl.Float64
+
+
+# --------------------------- D. Anti-leakage property -----------------
+
+
+@st.composite
+def _event_and_bars(draw: st.DrawFn) -> tuple[pl.Series, pl.Series, pl.Series, pl.Series, int]:
+    """Generate (t0, t1, bars, log_returns, tail_start_index) for anti-leakage.
+
+    tail_start_index marks the first bar strictly after max(t1); bars at or
+    past this index must have no influence on any r_i.
+    """
+    n_bars = draw(st.integers(min_value=5, max_value=40))
+    n_samples = draw(st.integers(min_value=1, max_value=8))
+    starts = draw(
+        st.lists(
+            st.integers(min_value=0, max_value=n_bars - 2),
+            min_size=n_samples,
+            max_size=n_samples,
+        )
+    )
+    # Ensure t1_i >= t0_i and t1_i fits inside bars.
+    lengths = draw(
+        st.lists(
+            st.integers(min_value=0, max_value=max(1, n_bars // 3)),
+            min_size=n_samples,
+            max_size=n_samples,
+        )
+    )
+    t0_idx = sorted(starts)  # sort just for readability; not required
+    t1_idx = [min(s + ln, n_bars - 1) for s, ln in zip(t0_idx, lengths, strict=True)]
+
+    bars = _bars(n_bars)
+    t0 = _times(t0_idx)
+    t1 = _times(t1_idx)
+
+    rets = draw(
+        st.lists(
+            st.floats(min_value=-0.1, max_value=0.1, allow_nan=False, allow_infinity=False),
+            min_size=n_bars,
+            max_size=n_bars,
+        )
+    )
+    log_returns = _returns(rets)
+    tail_start = max(t1_idx) + 1
+    return t0, t1, bars, log_returns, tail_start
+
+
+class TestAntiLeakage:
+    @settings(max_examples=200, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @given(payload=_event_and_bars())
+    def test_shuffling_returns_after_max_t1_preserves_weights(
+        self,
+        payload: tuple[pl.Series, pl.Series, pl.Series, pl.Series, int],
+    ) -> None:
+        """Weights must depend only on returns inside [min(t0), max(t1)].
+
+        ADR-0005 D2 forbids future information leakage. We enforce it by
+        permuting the slice of log_returns strictly AFTER max(t1) and
+        verifying every r_i is unchanged.
+        """
+        t0, t1, bars, log_returns, tail_start = payload
+        before = return_attribution_weights(t0, t1, bars, log_returns).to_numpy()
+
+        if tail_start >= len(bars):
+            # Tail is empty; nothing to shuffle. Any permutation equals identity.
+            return
+
+        rng = np.random.default_rng(0)
+        arr = log_returns.to_numpy().copy()
+        tail = arr[tail_start:].copy()
+        rng.shuffle(tail)
+        arr[tail_start:] = tail
+        shuffled = pl.Series(values=arr, dtype=pl.Float64)
+
+        after = return_attribution_weights(t0, t1, bars, shuffled).to_numpy()
+        np.testing.assert_allclose(before, after, atol=1e-12)
+
+
+# --------------------------- E. Empty / dtype -------------------------
+
+
+class TestReturnAttributionEdgeCases:
+    def test_empty_events_returns_empty_series(self) -> None:
+        bars = _bars(3)
+        ret = _returns([0.0, 0.0, 0.0])
+        t0 = _times([])
+        t1 = _times([])
+        r = return_attribution_weights(t0, t1, bars, ret)
+        assert len(r) == 0
+        assert r.dtype == pl.Float64
+
+    def test_result_is_non_negative(self) -> None:
+        bars = _bars(5)
+        t0 = _times([0, 2])
+        t1 = _times([3, 4])
+        ret = _returns([-0.02, -0.01, -0.03, -0.04, -0.01])
+        r = return_attribution_weights(t0, t1, bars, ret).to_numpy()
+        assert np.all(r >= 0.0)

--- a/tests/unit/features/labeling/test_sample_weights_attribution.py
+++ b/tests/unit/features/labeling/test_sample_weights_attribution.py
@@ -254,3 +254,24 @@ class TestReturnAttributionEdgeCases:
         ret = _returns([-0.02, -0.01, -0.03, -0.04, -0.01])
         r = return_attribution_weights(t0, t1, bars, ret).to_numpy()
         assert np.all(r >= 0.0)
+
+    def test_empty_t0_nonempty_t1_raises(self) -> None:
+        """Regression guard for Copilot review on PR #139.
+
+        Mismatched ``t0`` / ``t1`` lengths must fail-loud even when the
+        empty-input fast path is otherwise active.
+        """
+        bars = _bars(3)
+        ret = _returns([0.0, 0.0, 0.0])
+        t0 = _times([])
+        t1 = _times([1])
+        with pytest.raises(ValueError, match="different lengths"):
+            return_attribution_weights(t0, t1, bars, ret)
+
+    def test_nonempty_t0_empty_t1_raises(self) -> None:
+        bars = _bars(3)
+        ret = _returns([0.0, 0.0, 0.0])
+        t0 = _times([1])
+        t1 = _times([])
+        with pytest.raises(ValueError, match="different lengths"):
+            return_attribution_weights(t0, t1, bars, ret)

--- a/tests/unit/features/labeling/test_sample_weights_combined.py
+++ b/tests/unit/features/labeling/test_sample_weights_combined.py
@@ -1,0 +1,169 @@
+"""Tests for features.labeling.sample_weights.combined_weights.
+
+Groups:
+
+A. Normalization invariant sum(w) == n_samples
+B. Componentwise identity w == u * r (up to normalization factor)
+C. All-zero pathological case (no silent remap to uniform)
+D. Reproducibility across calls
+E. Empty input / dtype
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+
+from features.labeling.sample_weights import (
+    combined_weights,
+    return_attribution_weights,
+    uniqueness_weights,
+)
+
+# --------------------------- Helpers ---------------------------------
+
+
+def _ts(minute: int) -> datetime:
+    return datetime(2024, 6, 1, 9, 30, tzinfo=UTC) + timedelta(minutes=minute)
+
+
+def _bars(n: int) -> pl.Series:
+    return pl.Series(
+        values=[_ts(i) for i in range(n)],
+        dtype=pl.Datetime("us", "UTC"),
+    )
+
+
+def _times(minutes: list[int]) -> pl.Series:
+    return pl.Series(
+        values=[_ts(m) for m in minutes],
+        dtype=pl.Datetime("us", "UTC"),
+    )
+
+
+def _returns(values: list[float]) -> pl.Series:
+    return pl.Series(values=values, dtype=pl.Float64)
+
+
+# --------------------------- A. Normalization -------------------------
+
+
+class TestCombinedNormalization:
+    def test_sum_equals_n_samples_disjoint(self) -> None:
+        bars = _bars(6)
+        t0 = _times([0, 2, 4])
+        t1 = _times([1, 3, 5])
+        ret = _returns([0.01, 0.02, -0.01, 0.03, -0.02, 0.01])
+        w = combined_weights(t0, t1, bars, ret).to_numpy()
+        assert float(np.sum(w)) == pytest.approx(3.0, abs=1e-9)
+
+    def test_sum_equals_n_samples_overlapping(self) -> None:
+        bars = _bars(5)
+        t0 = _times([0, 1, 2])
+        t1 = _times([2, 3, 4])
+        ret = _returns([0.01, 0.02, 0.03, 0.04, 0.05])
+        w = combined_weights(t0, t1, bars, ret).to_numpy()
+        assert float(np.sum(w)) == pytest.approx(3.0, abs=1e-9)
+
+    def test_sum_equals_n_samples_single_sample(self) -> None:
+        bars = _bars(4)
+        t0 = _times([0])
+        t1 = _times([3])
+        ret = _returns([0.02, 0.03, -0.01, 0.04])
+        w = combined_weights(t0, t1, bars, ret).to_numpy()
+        assert float(np.sum(w)) == pytest.approx(1.0, abs=1e-9)
+        # Single sample normalized => exactly 1.0 regardless of magnitude
+        assert w.tolist() == pytest.approx([1.0])
+
+
+# --------------------------- B. Componentwise identity ----------------
+
+
+class TestCombinedIdentity:
+    def test_raw_product_matches_u_times_r_up_to_scale(self) -> None:
+        """Combined must be proportional to u*r with a single global factor."""
+        bars = _bars(6)
+        t0 = _times([0, 1, 3])
+        t1 = _times([2, 4, 5])
+        ret = _returns([0.01, 0.02, 0.03, 0.04, 0.05, 0.06])
+
+        u = uniqueness_weights(t0, t1, bars).to_numpy()
+        r = return_attribution_weights(t0, t1, bars, ret).to_numpy()
+        raw = u * r
+
+        w = combined_weights(t0, t1, bars, ret).to_numpy()
+
+        scale = float(np.sum(raw))
+        expected = raw * (len(t0) / scale)
+        np.testing.assert_allclose(w, expected, atol=1e-12)
+
+
+# --------------------------- C. All-zero pathological -----------------
+
+
+class TestCombinedZero:
+    def test_all_zero_returns_returns_zero_vector(self) -> None:
+        """ADR-0005 D2: no silent remap to uniform when r == 0 everywhere."""
+        bars = _bars(4)
+        t0 = _times([0, 2])
+        t1 = _times([1, 3])
+        ret = _returns([0.0, 0.0, 0.0, 0.0])
+        w = combined_weights(t0, t1, bars, ret).to_numpy()
+        assert w.tolist() == [0.0, 0.0]
+
+    def test_all_uniqueness_zero_would_return_zero(self) -> None:
+        # uniqueness can never be 0 in a well-formed input, but u*r being
+        # all zero (via returns) should yield all-zero combined.
+        bars = _bars(3)
+        t0 = _times([0])
+        t1 = _times([2])
+        ret = _returns([0.02, -0.01, -0.01])  # sum == 0
+        w = combined_weights(t0, t1, bars, ret).to_numpy()
+        assert w.tolist() == pytest.approx([0.0], abs=1e-12)
+
+
+# --------------------------- D. Reproducibility -----------------------
+
+
+class TestCombinedReproducibility:
+    def test_two_calls_return_identical_values(self) -> None:
+        bars = _bars(6)
+        t0 = _times([0, 2, 3])
+        t1 = _times([2, 4, 5])
+        ret = _returns([0.01, -0.02, 0.03, 0.01, -0.01, 0.02])
+        w1 = combined_weights(t0, t1, bars, ret).to_numpy()
+        w2 = combined_weights(t0, t1, bars, ret).to_numpy()
+        np.testing.assert_array_equal(w1, w2)
+
+
+# --------------------------- E. Empty / dtype -------------------------
+
+
+class TestCombinedEdgeCases:
+    def test_empty_events_returns_empty(self) -> None:
+        bars = _bars(3)
+        ret = _returns([0.0, 0.0, 0.0])
+        t0 = _times([])
+        t1 = _times([])
+        w = combined_weights(t0, t1, bars, ret)
+        assert len(w) == 0
+        assert w.dtype == pl.Float64
+
+    def test_result_dtype_is_float64(self) -> None:
+        bars = _bars(4)
+        t0 = _times([0])
+        t1 = _times([2])
+        ret = _returns([0.01, 0.02, 0.03, 0.04])
+        w = combined_weights(t0, t1, bars, ret)
+        assert w.dtype == pl.Float64
+
+    def test_all_weights_non_negative(self) -> None:
+        bars = _bars(5)
+        t0 = _times([0, 1])
+        t1 = _times([2, 4])
+        ret = _returns([-0.01, 0.02, -0.03, 0.01, -0.02])
+        w = combined_weights(t0, t1, bars, ret).to_numpy()
+        assert np.all(w >= 0.0)

--- a/tests/unit/features/labeling/test_sample_weights_uniqueness.py
+++ b/tests/unit/features/labeling/test_sample_weights_uniqueness.py
@@ -256,6 +256,33 @@ class TestUniquenessEdgeCases:
         assert len(u) == 0
         assert u.dtype == pl.Float64
 
+    def test_empty_t0_nonempty_t1_raises(self) -> None:
+        """Mismatched lengths must fail-loud even on the empty fast path.
+
+        Regression guard for Copilot review on PR #139: the previous
+        empty fast-return masked this caller bug by silently producing
+        an empty result.
+        """
+        bars = _bars(5)
+        t0 = _times([])
+        t1 = _times([1])
+        with pytest.raises(ValueError, match="different lengths"):
+            uniqueness_weights(t0, t1, bars)
+
+    def test_nonempty_t0_empty_t1_raises(self) -> None:
+        bars = _bars(5)
+        t0 = _times([1])
+        t1 = _times([])
+        with pytest.raises(ValueError, match="different lengths"):
+            uniqueness_weights(t0, t1, bars)
+
+    def test_compute_concurrency_empty_t0_nonempty_t1_raises(self) -> None:
+        bars = _bars(5)
+        t0 = _times([])
+        t1 = _times([1])
+        with pytest.raises(ValueError, match="different lengths"):
+            compute_concurrency(t0, t1, bars)
+
     def test_empty_bars_but_nonempty_events_raises(self) -> None:
         bars = pl.Series(values=[], dtype=pl.Datetime("us", "UTC"))
         t0 = _times([0])

--- a/tests/unit/features/labeling/test_sample_weights_uniqueness.py
+++ b/tests/unit/features/labeling/test_sample_weights_uniqueness.py
@@ -1,0 +1,324 @@
+"""Tests for features.labeling.sample_weights - uniqueness & concurrency.
+
+Groups:
+
+A. compute_concurrency primitives
+B. uniqueness_weights core semantics (disjoint -> 1.0, overlap -> < 1.0)
+C. Lopez de Prado (2018) section 4.4 Table 4.1 reference scenario
+D. Fail-loud validation (naive / non-UTC, orphan timestamps, non-monotonic bars)
+E. Edge cases (empty input, single sample, t0 == t1)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+
+import numpy as np
+import polars as pl
+import pytest
+
+from features.labeling.sample_weights import (
+    _ensure_utc_scalar,
+    _validate_datetime_series,
+    compute_concurrency,
+    uniqueness_weights,
+)
+
+# --------------------------- Helpers ---------------------------------
+
+
+def _ts(minute: int) -> datetime:
+    return datetime(2024, 6, 1, 9, 30, tzinfo=UTC) + timedelta(minutes=minute)
+
+
+def _bars(n: int) -> pl.Series:
+    return pl.Series(
+        values=[_ts(i) for i in range(n)],
+        dtype=pl.Datetime("us", "UTC"),
+    )
+
+
+def _times(minutes: list[int]) -> pl.Series:
+    return pl.Series(
+        values=[_ts(m) for m in minutes],
+        dtype=pl.Datetime("us", "UTC"),
+    )
+
+
+# --------------------------- A. Concurrency primitives ----------------
+
+
+class TestComputeConcurrency:
+    def test_single_span_covers_three_bars(self) -> None:
+        bars = _bars(5)
+        t0 = _times([1])
+        t1 = _times([3])
+        c = compute_concurrency(t0, t1, bars).to_list()
+        assert c == [0, 1, 1, 1, 0]
+
+    def test_three_overlapping_spans(self) -> None:
+        """Classic overlapping triangle from LdP Figure 4.1-like scenario."""
+        bars = _bars(5)
+        t0 = _times([0, 1, 2])
+        t1 = _times([2, 3, 4])
+        c = compute_concurrency(t0, t1, bars).to_list()
+        assert c == [1, 2, 3, 2, 1]
+
+    def test_disjoint_spans_each_bar_one(self) -> None:
+        bars = _bars(4)
+        t0 = _times([0, 2])
+        t1 = _times([1, 3])
+        c = compute_concurrency(t0, t1, bars).to_list()
+        assert c == [1, 1, 1, 1]
+
+    def test_empty_samples_returns_zero_vector(self) -> None:
+        bars = _bars(5)
+        t0 = _times([])
+        t1 = _times([])
+        c = compute_concurrency(t0, t1, bars).to_list()
+        assert c == [0, 0, 0, 0, 0]
+
+    def test_single_bar_span_t0_equals_t1(self) -> None:
+        bars = _bars(3)
+        t0 = _times([1])
+        t1 = _times([1])
+        c = compute_concurrency(t0, t1, bars).to_list()
+        assert c == [0, 1, 0]
+
+
+# --------------------------- B. Uniqueness core -----------------------
+
+
+class TestUniquenessCore:
+    def test_disjoint_spans_all_ones(self) -> None:
+        """LdP §4.4 canonical: non-overlapping labels each have u_i == 1.0."""
+        bars = _bars(6)
+        t0 = _times([0, 2, 4])
+        t1 = _times([1, 3, 5])
+        u = uniqueness_weights(t0, t1, bars).to_list()
+        assert u == pytest.approx([1.0, 1.0, 1.0])
+
+    def test_overlapping_spans_strictly_below_one(self) -> None:
+        bars = _bars(5)
+        t0 = _times([0, 1, 2])
+        t1 = _times([2, 3, 4])
+        u = uniqueness_weights(t0, t1, bars).to_list()
+        assert all(v < 1.0 for v in u)
+        # Middle sample has the heaviest overlap, so it must be the smallest.
+        assert u[1] < u[0]
+        assert u[1] < u[2]
+
+    def test_single_sample_is_one(self) -> None:
+        bars = _bars(5)
+        t0 = _times([1])
+        t1 = _times([3])
+        u = uniqueness_weights(t0, t1, bars).to_list()
+        assert u == pytest.approx([1.0])
+
+    def test_identical_spans_each_get_half(self) -> None:
+        """Two identical spans share concurrency == 2 at every bar -> u = 0.5."""
+        bars = _bars(5)
+        t0 = _times([1, 1])
+        t1 = _times([3, 3])
+        u = uniqueness_weights(t0, t1, bars).to_list()
+        assert u == pytest.approx([0.5, 0.5])
+
+    def test_span_length_one_equals_inverse_concurrency(self) -> None:
+        """When |T_i| == 1, u_i == 1/c_{t0}."""
+        bars = _bars(4)
+        t0 = _times([1, 1, 2])
+        t1 = _times([1, 1, 2])
+        u = uniqueness_weights(t0, t1, bars).to_list()
+        # bar 1 has c = 2 (samples 0 and 1); bar 2 has c = 1 (sample 2).
+        assert u == pytest.approx([0.5, 0.5, 1.0])
+
+
+# --------------------------- C. LdP Table 4.1 reference --------------
+
+
+class TestUniquenessReferenceTable:
+    def test_uniqueness_matches_reference_table_lopezdeprado_4_4(self) -> None:
+        """Reproduce LdP (2018) §4.4 textbook illustration.
+
+        Setup (see ADR-0005 D2 and audit.md §2.2):
+            - 3 samples with spans:
+                #0: bars [0, 2]  -> c = [1, 2, 3]         (concurrency at t0, t0+1, t0+2)
+                #1: bars [1, 3]  -> c = [2, 3, 2]
+                #2: bars [2, 4]  -> c = [3, 2, 1]
+            - Overall concurrency across [0..4] = [1, 2, 3, 2, 1]
+            - u_0 = mean(1/1, 1/2, 1/3) = 11/18   = 0.6111...
+            - u_1 = mean(1/2, 1/3, 1/2) =  4/9    = 0.4444...
+            - u_2 = mean(1/3, 1/2, 1/1) = 11/18   = 0.6111...
+        """
+        bars = _bars(5)
+        t0 = _times([0, 1, 2])
+        t1 = _times([2, 3, 4])
+        u = uniqueness_weights(t0, t1, bars).to_list()
+        expected = [11.0 / 18.0, 4.0 / 9.0, 11.0 / 18.0]
+        assert u == pytest.approx(expected, abs=1e-12)
+
+
+# --------------------------- D. Fail-loud validation ------------------
+
+
+class TestUniquenessValidation:
+    def test_naive_t0_raises(self) -> None:
+        bars = _bars(3)
+        naive = pl.Series(
+            values=[datetime(2024, 6, 1, 9, 30)],  # no tzinfo
+            dtype=pl.Datetime("us"),  # naive dtype
+        )
+        with pytest.raises(ValueError, match="UTC"):
+            uniqueness_weights(naive, naive, bars)
+
+    def test_non_utc_timezone_raises(self) -> None:
+        bars = _bars(3)
+        plus_two = timezone(timedelta(hours=2))
+        ts = datetime(2024, 6, 1, 11, 30, tzinfo=plus_two)
+        series = pl.Series(values=[ts], dtype=pl.Datetime("us", "+02:00"))
+        with pytest.raises(ValueError, match="UTC"):
+            uniqueness_weights(series, series, bars)
+
+    def test_orphan_t0_not_in_bars_raises(self) -> None:
+        bars = _bars(5)
+        orphan = datetime(2024, 6, 1, 9, 30, 30, tzinfo=UTC)  # between bars
+        t0 = pl.Series(values=[orphan], dtype=pl.Datetime("us", "UTC"))
+        t1 = _times([3])
+        with pytest.raises(ValueError, match="not present in bars"):
+            uniqueness_weights(t0, t1, bars)
+
+    def test_t1_before_t0_raises(self) -> None:
+        bars = _bars(5)
+        t0 = _times([3])
+        t1 = _times([1])
+        with pytest.raises(ValueError, match="t1 < t0"):
+            uniqueness_weights(t0, t1, bars)
+
+    def test_non_monotonic_bars_raises(self) -> None:
+        reordered = pl.Series(
+            values=[_ts(2), _ts(0), _ts(1)],
+            dtype=pl.Datetime("us", "UTC"),
+        )
+        t0 = _times([0])
+        t1 = _times([1])
+        with pytest.raises(ValueError, match="strictly monotonic"):
+            uniqueness_weights(t0, t1, reordered)
+
+    def test_t1_past_last_bar_raises(self) -> None:
+        bars = _bars(3)
+        t0 = _times([0])
+        t1 = _times([5])  # past last bar
+        with pytest.raises(ValueError, match="past the last bar"):
+            uniqueness_weights(t0, t1, bars)
+
+    def test_orphan_t1_not_in_bars_raises(self) -> None:
+        """t0 aligned on a bar, t1 off-grid -> fail-loud on the t1 branch."""
+        bars = _bars(5)
+        orphan_t1 = datetime(2024, 6, 1, 9, 30, tzinfo=UTC) + timedelta(minutes=2, seconds=30)
+        t0 = _times([0])
+        t1 = pl.Series(values=[orphan_t1], dtype=pl.Datetime("us", "UTC"))
+        with pytest.raises(ValueError, match=r"t1=.* is not present in bars"):
+            uniqueness_weights(t0, t1, bars)
+
+    def test_t0_t1_length_mismatch_raises(self) -> None:
+        bars = _bars(5)
+        t0 = _times([0, 1])
+        t1 = _times([2])
+        with pytest.raises(ValueError, match="different lengths"):
+            uniqueness_weights(t0, t1, bars)
+
+    def test_bars_dtype_mismatch_raises(self) -> None:
+        """t0 carries a different Datetime unit from bars -> fail-loud."""
+        # bars in us, t0/t1 in ns -> dtype mismatch in _locate_span_indices.
+        bars = _bars(5)
+        ns_t0 = pl.Series(
+            values=[_ts(0)],
+            dtype=pl.Datetime("ns", "UTC"),
+        )
+        ns_t1 = pl.Series(
+            values=[_ts(1)],
+            dtype=pl.Datetime("ns", "UTC"),
+        )
+        # _validate_datetime_series rejects the different dtype first.
+        with pytest.raises(ValueError, match=r"pl\.Datetime\('us', 'UTC'\)"):
+            uniqueness_weights(ns_t0, ns_t1, bars)
+
+
+# --------------------------- E. Edge cases ----------------------------
+
+
+class TestUniquenessEdgeCases:
+    def test_empty_events_returns_empty_series(self) -> None:
+        bars = _bars(5)
+        t0 = _times([])
+        t1 = _times([])
+        u = uniqueness_weights(t0, t1, bars)
+        assert len(u) == 0
+        assert u.dtype == pl.Float64
+
+    def test_empty_bars_but_nonempty_events_raises(self) -> None:
+        bars = pl.Series(values=[], dtype=pl.Datetime("us", "UTC"))
+        t0 = _times([0])
+        t1 = _times([0])
+        with pytest.raises(ValueError, match="bars is empty"):
+            uniqueness_weights(t0, t1, bars)
+
+    def test_compute_concurrency_empty_bars_nonempty_events_raises(self) -> None:
+        """Same fail-loud path as uniqueness, surfaced by compute_concurrency."""
+        bars = pl.Series(values=[], dtype=pl.Datetime("us", "UTC"))
+        t0 = _times([0])
+        t1 = _times([0])
+        with pytest.raises(ValueError, match="bars is empty"):
+            compute_concurrency(t0, t1, bars)
+
+    def test_uniqueness_values_in_unit_interval(self) -> None:
+        """u_i in (0, 1] for every well-formed sample."""
+        rng = np.random.default_rng(42)
+        n_bars = 50
+        bars = _bars(n_bars)
+        starts = sorted(int(x) for x in rng.integers(0, n_bars - 5, size=10))
+        lengths = rng.integers(1, 5, size=10).tolist()
+        t0 = _times(list(starts))
+        t1 = _times([s + int(ln) for s, ln in zip(starts, lengths, strict=True)])
+        u = uniqueness_weights(t0, t1, bars).to_numpy()
+        assert np.all(u > 0.0)
+        assert np.all(u <= 1.0)
+
+    def test_result_dtype_is_float64(self) -> None:
+        bars = _bars(4)
+        t0 = _times([0])
+        t1 = _times([1])
+        u = uniqueness_weights(t0, t1, bars)
+        assert u.dtype == pl.Float64
+
+
+# --------------------------- F. Private helpers (defensive paths) ------
+
+
+class TestPrivateValidators:
+    """Direct coverage of defensive branches inside private helpers.
+
+    These paths cannot be reached via the public API on well-typed Polars
+    inputs, but they remain important belt-and-braces checks for callers
+    that hand-build a series bypassing dtype coercion.
+    """
+
+    def test_ensure_utc_scalar_naive_raises(self) -> None:
+        naive = datetime(2024, 6, 1, 9, 30)
+        with pytest.raises(ValueError, match="tz-naive"):
+            _ensure_utc_scalar(naive, "probe")
+
+    def test_ensure_utc_scalar_non_utc_raises(self) -> None:
+        plus_two = timezone(timedelta(hours=2))
+        ts = datetime(2024, 6, 1, 11, 30, tzinfo=plus_two)
+        with pytest.raises(ValueError, match="not UTC"):
+            _ensure_utc_scalar(ts, "probe")
+
+    def test_validate_datetime_series_with_null_head_ok(self) -> None:
+        """Null first element should skip the per-scalar UTC check gracefully."""
+        series = pl.Series(
+            values=[None, _ts(0)],
+            dtype=pl.Datetime("us", "UTC"),
+        )
+        # Must not raise: the `head is None` branch exits cleanly.
+        _validate_datetime_series(series, "probe")


### PR DESCRIPTION
Closes #126.

## Scope

Phase 4.2 — Sample Weights, canonical ADR-0005 D2 implementation (López de Prado 2018 §§4.4–4.5). Builds on the `t0/t1` schema merged in PR #138 (Phase 4.1) and feeds the meta-labeler training loop in Phase 4.3 (#127).

## Deliverables

- `features/labeling/sample_weights.py` — 4 public helpers:
  - `compute_concurrency(t0, t1, bars)` — bar-indexed label count, O(n_samples + n_bars) via delta + cumsum + `np.searchsorted`.
  - `uniqueness_weights(t0, t1, bars)` — `u_i = mean(1/c_t for t in [t0_i, t1_i])`.
  - `return_attribution_weights(t0, t1, bars, log_returns)` — `r_i = |sum(ret_t / c_t for t in [t0_i, t1_i])|`.
  - `combined_weights(...)` — `w_i = u_i × r_i` normalized so `sum(w) == n_samples` (tol `1e-9`).
- `features/labeling/__init__.py` — re-exports.
- `tests/unit/features/labeling/test_sample_weights_uniqueness.py` — 26 tests (LdP §4.4 Table 4.1 reference reproduced exact to `1e-12`).
- `tests/unit/features/labeling/test_sample_weights_attribution.py` — 15 tests incl. Hypothesis anti-leakage property (200 cases: permuting returns strictly after `max(t1)` preserves all `r_i`).
- `tests/unit/features/labeling/test_sample_weights_combined.py` — 11 tests (normalization invariant, reproducibility, edge cases).
- `reports/phase_4_2/weights_distribution.md` — diagnostic on 100 events × 1000 bars fixture (seed 42): concurrency/u/r/w distributions, histograms, invariants table.

## Quality gates

- `ruff check` + `ruff format` clean.
- `mypy --strict` — 0 errors on `features/labeling/sample_weights.py`.
- 52 unit tests passing, **94% coverage** on the new module (DoD ≥ 92%).
- `sum(w) == n_samples` invariant observed drift: `1.42e-14` on the 100-event fixture.
- LdP §4.4 Table 4.1 triangle `[11/18, 4/9, 11/18]` reproduced exact to `1e-12`.

## Architectural note (see D035 in `docs/claude_memory/DECISIONS.md`)

The Phase 3.1 prototype `features/weights.py::SampleWeighter` is **not** touched. The canonical implementation lives as a sibling in `features/labeling/` to keep this PR reviewable and preserve the 21 existing green tests. Migration of `features/pipeline.py` to the canonical API is tracked as technical debt for the Phase 4 closure report (#133).

## References

- ADR-0005 §D2 (`docs/adr/ADR-0005-meta-labeling-fusion-methodology.md`).
- López de Prado (2018), *Advances in Financial Machine Learning*, Ch. 4.4–4.5, Table 4.1.
- Pre-implementation audit: `reports/phase_4_2/audit.md` (commit 3112790).

## Commits

- `3112790` phase(4.2): audit pré-implémentation sample weights
- `59191cd` phase(4.2): sample weights module per ADR-0005 D2
- `0cdba7d` docs(claude_memory): Phase 4.2 sample weights session update

Co-Authored-By: Claude <noreply@anthropic.com>