### PR TITLE
Phase 4.5 — Meta-Labeler Statistical Validation (G1–G7)

### DIFF
--- a/docs/pr_bodies/phase_4_5_pr_body.md
+++ b/docs/pr_bodies/phase_4_5_pr_body.md
@@ -1,0 +1,103 @@
+## Phase 4.5 — Meta-Labeler Statistical Validation (G1–G7)
+
+Closes #129. Implements the seven-gate deployment validator from ADR-0005 D5
+and the bet-sized P&L simulator from ADR-0002 D7 / ADR-0005 D8.
+
+### What this PR delivers
+
+| Gate | Threshold | Source |
+| --- | --- | --- |
+| G1 | mean OOS AUC ≥ 0.55 | López de Prado (2018) §3.2 |
+| G2 | min per-fold OOS AUC ≥ 0.52 | ADR-0005 D5 |
+| G3 | DSR on bet-sized P&L (realistic costs) ≥ 0.95 | Bailey & López de Prado (2014) |
+| G4 | PBO across tuning trials < 0.10 | Bailey/Borwein/López de Prado/Zhu (2017) |
+| G5 | Brier score ≤ 0.25 | Brier (1950) |
+| G6 | minority class freq ≥ 10% (warn 5–10%, reject < 5%) | ADR-0005 D5 |
+| G7 | RF − LogReg mean OOS AUC ≥ 0.03 | ADR-0005 D5 |
+
+### New modules
+
+- `features/meta_labeler/pnl_simulation.py` — `simulate_meta_labeler_pnl`
+  computes per-label realised returns under the López de Prado (2018) §3.7
+  betting rule (`bet = 2p − 1`) and the additive cost model from
+  ADR-0002 D7 / ADR-0005 D8 (zero / realistic 10 bps RT / stress 30 bps RT).
+  Exact-match `searchsorted` lookup against `bars.timestamp`; fails loud
+  on any miss to keep the contract aligned with the 4.1 Triple-Barrier
+  output.
+- `features/meta_labeler/validation.py` — `MetaLabelerValidator.validate`
+  orchestrates all seven gates, builds per-fold P&L by re-fitting on
+  `train ∪ val` with the best hyperparameter set, runs the
+  Politis-Romano (1994) stationary-bootstrap CI on the realised Sharpe,
+  pivots the trial ledger into the PBO matrix, and packages a frozen
+  `ValidationReport` with per-gate verdicts.
+- `scripts/generate_phase_4_5_report.py` — end-to-end report generator.
+  Synthesises alpha-injected bars (close drift = `_BAR_DRIFT_PER_SIGMA *
+  ofi_signal`) so the tuned RF has a real edge to exploit, runs
+  4.3 baseline → 4.4 nested CPCV → 4.5 validator, emits
+  `validation_report.{md,json}`. Mirrors the 4.4 report contract:
+  `APEX_REPORT_NOW`, `APEX_REPORT_WALLCLOCK_MODE`, `--full`.
+
+### New tests
+
+- `tests/unit/features/meta_labeler/test_pnl_simulation.py`
+  - Bet sizing: `bet = 2p − 1 ∈ [−1, +1]`, `gross = log_ret · bet`
+  - Cost arithmetic: realistic = 10 bps RT, stress = 3× realistic
+  - **Anti-leakage property tests**: permuting prices outside
+    `{t0_i, t1_i}` (and after `max(t1)`) leaves every per-label P&L
+    unchanged.
+  - Fail-loud: missing timestamp, t1 past last bar, p outside [0, 1],
+    non-finite p, t1 < t0, shape disagreement, tuple length mismatch,
+    non-monotonic bars, non-positive close, missing columns, empty bars.
+- `tests/unit/features/meta_labeler/test_validation_gates.py`
+  - Per-gate happy / fail tests for G1, G2, G4, G5, G6, G7 using
+    `dataclasses.replace` to tamper individual gate inputs.
+  - End-to-end pipeline test: 4.3 → 4.4 → 4.5 on a 200-row synthetic
+    fixture, plus a tampered run that confirms failing gates land in
+    canonical order.
+  - Validator init defaults + frozen-dataclass guard on `GateResult`.
+
+### How the gates interact with the rest of Phase 4
+
+- The validator consumes `BaselineMetaLabelResult` (Phase 4.3, PR #140)
+  and `NestedTuningResult` (Phase 4.4, PR #141).
+- The data-leakage audit (PR #142, issue #134) covers the upstream
+  feature build — the proba feeding label `i` is the model prediction
+  at `t0_i` from features available strictly before `t0_i`. The
+  `test_pnl_unchanged_when_prices_outside_t0_t1_set_permuted` property
+  test extends that guarantee to the P&L step.
+
+### Cost contract (ADR-0002 D7 / ADR-0005 D8)
+
+| Scenario | Per-side bps | Round-trip bps |
+| --- | --- | --- |
+| zero | 0 | 0 |
+| realistic | 5 | 10 |
+| stress | 15 | 30 |
+
+Only the realistic scenario feeds the G3 DSR gate; zero / stress are
+computed for the report so reviewers can see the cost sensitivity.
+
+### How to verify locally
+
+```bash
+make lint
+pytest tests/unit/features/meta_labeler/test_pnl_simulation.py -q
+pytest tests/unit/features/meta_labeler/test_validation_gates.py -q
+APEX_REPORT_NOW=2026-04-14T00:00:00Z APEX_REPORT_WALLCLOCK_MODE=fixed \
+  python scripts/generate_phase_4_5_report.py --output reports/phase_4_5
+```
+
+### References
+
+- López de Prado, M. (2018). *Advances in Financial Machine Learning*,
+  Wiley. §3.7 Betting on Probabilities.
+- Bailey, D. & López de Prado, M. (2014). The Deflated Sharpe Ratio.
+  *Journal of Portfolio Management*.
+- Bailey, D., Borwein, J., López de Prado, M. & Zhu, Q. (2017). The
+  Probability of Backtest Overfitting. *Journal of Computational
+  Finance*.
+- Politis, D. & Romano, J. (1994). The Stationary Bootstrap. *JASA*.
+- Brier, G. (1950). Verification of forecasts expressed in terms of
+  probability. *Monthly Weather Review*.
+- ADR-0002 (Quant Methodology Charter), Section A item 7.
+- ADR-0005 (Meta-Labeling and Fusion Methodology), D5 + D8.

--- a/docs/pr_bodies/phase_4_5_pr_body.md
+++ b/docs/pr_bodies/phase_4_5_pr_body.md
@@ -83,8 +83,14 @@ computed for the report so reviewers can see the cost sensitivity.
 make lint
 pytest tests/unit/features/meta_labeler/test_pnl_simulation.py -q
 pytest tests/unit/features/meta_labeler/test_validation_gates.py -q
-APEX_REPORT_NOW=2026-04-14T00:00:00Z APEX_REPORT_WALLCLOCK_MODE=fixed \
-  python scripts/generate_phase_4_5_report.py --output reports/phase_4_5
+# Report generator: env-var driven, no CLI flags. Output dir is fixed
+# (reports/phase_4_5/). APEX_REPORT_NOW must include a tz offset; the
+# wallclock mode must be one of {record, zero, omit}. Set APEX_FULL_VALIDATION=1
+# for the heavier 3x3x2 grid.
+APEX_SEED=42 \
+  APEX_REPORT_NOW=2026-04-14T00:00:00+00:00 \
+  APEX_REPORT_WALLCLOCK_MODE=omit \
+  python scripts/generate_phase_4_5_report.py
 ```
 
 ### References

--- a/features/meta_labeler/pnl_simulation.py
+++ b/features/meta_labeler/pnl_simulation.py
@@ -247,9 +247,7 @@ def simulate_meta_labeler_pnl(
         )
         net_parts.append(net.astype(np.float64))
 
-    all_net = (
-        np.concatenate(net_parts) if net_parts else np.empty(0, dtype=np.float64)
-    )
+    all_net = np.concatenate(net_parts) if net_parts else np.empty(0, dtype=np.float64)
     return PnLSimulationResult(
         scenario=scenario,
         per_fold=tuple(per_fold),
@@ -269,12 +267,20 @@ def _validate_inputs(
     proba_per_fold: tuple[npt.NDArray[np.float64], ...],
 ) -> None:
     if "timestamp" not in bars.columns or "close" not in bars.columns:
-        raise ValueError(
-            "bars must contain columns 'timestamp' and 'close'; "
-            f"got {bars.columns}"
-        )
+        raise ValueError(f"bars must contain columns 'timestamp' and 'close'; got {bars.columns}")
     if bars.height == 0:
         raise ValueError("bars is empty")
+
+    # Phase 4 timestamp contract: bars.timestamp MUST be Datetime[us, UTC].
+    # Mirrors features.meta_labeler.feature_builder._validate_utc_column so
+    # tz-naive or non-UTC frames fail loud here instead of silently coercing.
+    expected_ts_dtype = pl.Datetime("us", "UTC")
+    actual_ts_dtype = bars.schema["timestamp"]
+    if actual_ts_dtype != expected_ts_dtype:
+        raise ValueError(
+            f"bars.timestamp must be {expected_ts_dtype} per ADR-0005 / "
+            f"Phase 4 contract; got {actual_ts_dtype}"
+        )
 
     ts = bars["timestamp"].to_numpy().astype("datetime64[us]")
     if len(ts) > 1 and not np.all(ts[1:] > ts[:-1]):
@@ -302,8 +308,7 @@ def _validate_inputs(
             continue
         if not np.all(t1 >= t0):
             raise ValueError(
-                f"fold {fold_idx}: every t1_i must be >= t0_i (Triple "
-                "Barrier guarantee)"
+                f"fold {fold_idx}: every t1_i must be >= t0_i (Triple Barrier guarantee)"
             )
         if not np.isfinite(p).all():
             raise ValueError(f"fold {fold_idx}: proba contains non-finite values")

--- a/features/meta_labeler/pnl_simulation.py
+++ b/features/meta_labeler/pnl_simulation.py
@@ -1,0 +1,344 @@
+"""Phase 4.5 - Bet-sized P&L simulation for the Meta-Labeler.
+
+Implements the ADR-0005 D5 G3 input contract: convert per-fold
+predicted probabilities into per-label realised returns under a
+calibrated long/short bet-sizing rule and an additive transaction
+cost model, both per ADR-0002 D7 / ADR-0005 D8.
+
+Bet sizing follows López de Prado (2018) §3.7 ("Betting on
+Probabilities"): a probability ``p`` becomes a signed bet
+``2*p - 1 ∈ [-1, +1]``. The position is opened at ``t0_i`` close and
+closed at ``t1_i`` close - the same `(t0, t1)` schema produced by the
+4.1 Triple Barrier labeler - and the gross return is
+
+    r_gross_i = log(C(t1_i) / C(t0_i)) * (2*p_i - 1)
+
+The realistic-cost scenario (ADR-0002 D7, ADR-0005 D8) deducts
+``cost_round_trip_bps * |2*p_i - 1| / 1e4`` from the gross return. The
+``|2*p_i - 1|`` factor scales cost with conviction so a half-conviction
+bet pays half cost - this is the conventional way to embed bet sizing
+into a frictional P&L without double-counting.
+
+Per ADR-0005 D8 the realistic round-trip cost is **10 bps**
+(5 bps per side). The zero / stress scenarios are **0 bps** and
+**30 bps round-trip** respectively (5 bps and 15 bps per side per
+ADR-0002 D7); they are computed for the report but only the realistic
+scenario feeds the G3 DSR gate.
+
+Anti-leakage guarantees (verified by property tests in
+``tests/unit/features/meta_labeler/test_pnl_simulation.py``):
+
+1. The proba feeding label ``i`` is the model's prediction at ``t0_i``,
+   built from features available strictly before ``t0_i`` (Phase 4.3
+   audit, PR #142). No proba is reused across labels.
+2. ``r_i`` depends only on ``(C(t0_i), C(t1_i), p_i)``; permuting close
+   prices outside ``{t0_i, t1_i}`` for any label never moves ``r_i``.
+
+References:
+    López de Prado, M. (2018). *Advances in Financial Machine
+    Learning*, Wiley. §3.7 Betting on Probabilities.
+    ADR-0002 (Quant Methodology Charter), Section A item 7.
+    ADR-0005 (Meta-Labeling and Fusion Methodology), D5 G3 + D8.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+import numpy as np
+import numpy.typing as npt
+import polars as pl
+
+__all__ = [
+    "CostScenario",
+    "FoldPnL",
+    "PnLSimulationResult",
+    "simulate_meta_labeler_pnl",
+]
+
+
+# ADR-0002 D7 / ADR-0005 D8: per-side basis-point costs for the three
+# canonical scenarios. Round-trip = 2 × per-side.
+_PER_SIDE_BPS_ZERO: float = 0.0
+_PER_SIDE_BPS_REALISTIC: float = 5.0
+_PER_SIDE_BPS_STRESS: float = 15.0
+
+
+class CostScenario(StrEnum):
+    """Three canonical transaction-cost scenarios per ADR-0002 D7.
+
+    Inherits from :class:`enum.StrEnum` (Python 3.11+) so JSON
+    serialisation uses the lower-case scenario name verbatim.
+    """
+
+    ZERO = "zero"
+    REALISTIC = "realistic"
+    STRESS = "stress"
+
+    @property
+    def per_side_bps(self) -> float:
+        """Per-side cost in basis points for this scenario."""
+        match self:
+            case CostScenario.ZERO:
+                return _PER_SIDE_BPS_ZERO
+            case CostScenario.REALISTIC:
+                return _PER_SIDE_BPS_REALISTIC
+            case CostScenario.STRESS:
+                return _PER_SIDE_BPS_STRESS
+        raise ValueError(f"unknown CostScenario {self!r}")  # pragma: no cover
+
+    @property
+    def round_trip_bps(self) -> float:
+        """Round-trip (open + close) cost in basis points."""
+        return 2.0 * self.per_side_bps
+
+
+@dataclass(frozen=True)
+class FoldPnL:
+    """Realised per-label P&L for one CPCV outer fold.
+
+    Attributes:
+        fold_index:
+            Zero-based index of the outer fold this entry corresponds
+            to. Matches the order of ``CombinatoriallyPurgedKFold.split``.
+        net_returns:
+            Per-label net return after the realistic-cost deduction.
+            Shape ``(n_labels_in_fold,)``, dtype ``float64``.
+        gross_returns:
+            Per-label gross return (no costs). Same shape.
+        bets:
+            Per-label signed bet ``2*p - 1 ∈ [-1, +1]``. Same shape.
+    """
+
+    fold_index: int
+    net_returns: npt.NDArray[np.float64]
+    gross_returns: npt.NDArray[np.float64]
+    bets: npt.NDArray[np.float64]
+
+
+@dataclass(frozen=True)
+class PnLSimulationResult:
+    """Frozen container for the complete P&L simulation output.
+
+    Attributes:
+        scenario:
+            The ``CostScenario`` used to compute ``per_fold[*].net_returns``.
+            Stored explicitly so the report can label the DSR/PSR
+            scenario and so the report regenerator catches an
+            accidental mismatch.
+        per_fold:
+            One :class:`FoldPnL` per outer CPCV fold. Length equals
+            the caller-supplied number of folds.
+        all_net_returns:
+            Concatenated per-label net returns across folds, in
+            outer-fold order. Shape ``(sum_i n_labels_in_fold_i,)``.
+            This is the input to the realised Sharpe and the DSR.
+    """
+
+    scenario: CostScenario
+    per_fold: tuple[FoldPnL, ...]
+    all_net_returns: npt.NDArray[np.float64]
+
+
+def simulate_meta_labeler_pnl(
+    bars: pl.DataFrame,
+    t0_per_fold: tuple[npt.NDArray[np.datetime64], ...],
+    t1_per_fold: tuple[npt.NDArray[np.datetime64], ...],
+    proba_per_fold: tuple[npt.NDArray[np.float64], ...],
+    *,
+    scenario: CostScenario = CostScenario.REALISTIC,
+) -> PnLSimulationResult:
+    """Compute bet-sized realised P&L per outer CPCV fold.
+
+    For every ``(t0_i, t1_i, p_i)`` triple in each fold:
+
+    1. Look up ``C(t0_i)`` and ``C(t1_i)`` in ``bars``. Both lookups
+       are exact-match - Triple Barrier guarantees that ``t0_i`` and
+       ``t1_i`` are bar timestamps (Phase 4.1 contract). A missing
+       timestamp triggers ``ValueError``.
+    2. Compute ``bet_i = 2 * p_i - 1 ∈ [-1, +1]``.
+    3. Compute ``r_gross_i = log(C(t1_i) / C(t0_i)) * bet_i``.
+    4. Deduct round-trip cost: ``r_net_i = r_gross_i -
+       (scenario.round_trip_bps / 1e4) * |bet_i|``.
+
+    Args:
+        bars:
+            Polars DataFrame with columns ``timestamp`` (sorted,
+            unique, Datetime[us, UTC]) and ``close`` (Float64,
+            strictly positive). Same convention as
+            ``MetaLabelerFeatureBuilder``.
+        t0_per_fold:
+            Tuple of length ``n_folds``. Element ``i`` is the array of
+            ``t0`` timestamps for fold ``i``'s OOS test labels.
+        t1_per_fold:
+            Same shape - ``t1`` timestamps.
+        proba_per_fold:
+            Same shape - predicted positive-class probabilities for
+            fold ``i``'s OOS test labels.
+        scenario:
+            Which :class:`CostScenario` to apply. Defaults to
+            ``REALISTIC``, the scenario the G3 DSR gate consumes.
+
+    Returns:
+        :class:`PnLSimulationResult` with per-fold ``FoldPnL`` and the
+        concatenated ``all_net_returns`` array.
+
+    Raises:
+        ValueError: on shape mismatches, missing timestamps, non-finite
+            inputs, probabilities outside ``[0, 1]``, or if any bar
+            close is non-positive.
+    """
+    _validate_inputs(bars, t0_per_fold, t1_per_fold, proba_per_fold)
+
+    bars_ts = bars["timestamp"].to_numpy().astype("datetime64[us]")
+    bars_close = bars["close"].to_numpy().astype(np.float64)
+
+    rt_cost = scenario.round_trip_bps / 1e4
+
+    per_fold: list[FoldPnL] = []
+    net_parts: list[npt.NDArray[np.float64]] = []
+
+    for fold_idx, (t0_arr, t1_arr, proba_arr) in enumerate(
+        zip(t0_per_fold, t1_per_fold, proba_per_fold, strict=True)
+    ):
+        n = int(t0_arr.shape[0])
+        if n == 0:
+            empty = np.empty(0, dtype=np.float64)
+            per_fold.append(
+                FoldPnL(
+                    fold_index=fold_idx,
+                    net_returns=empty,
+                    gross_returns=empty,
+                    bets=empty,
+                )
+            )
+            net_parts.append(empty)
+            continue
+
+        t0_us = t0_arr.astype("datetime64[us]")
+        t1_us = t1_arr.astype("datetime64[us]")
+
+        # Exact-match lookup via searchsorted(side='left'): the
+        # returned index points to a bar with timestamp >= target. We
+        # then verify equality and fail loudly otherwise.
+        idx0 = np.searchsorted(bars_ts, t0_us, side="left")
+        idx1 = np.searchsorted(bars_ts, t1_us, side="left")
+        _check_exact_match(bars_ts, t0_us, idx0, label="t0", fold_idx=fold_idx)
+        _check_exact_match(bars_ts, t1_us, idx1, label="t1", fold_idx=fold_idx)
+
+        c0 = bars_close[idx0]
+        c1 = bars_close[idx1]
+        # log(close_t1 / close_t0) is numerically stable for the
+        # positive closes we enforced in _validate_inputs.
+        log_ret = np.log(c1) - np.log(c0)
+
+        bets = (2.0 * proba_arr.astype(np.float64)) - 1.0
+        gross = log_ret * bets
+        net = gross - rt_cost * np.abs(bets)
+
+        per_fold.append(
+            FoldPnL(
+                fold_index=fold_idx,
+                net_returns=net.astype(np.float64),
+                gross_returns=gross.astype(np.float64),
+                bets=bets.astype(np.float64),
+            )
+        )
+        net_parts.append(net.astype(np.float64))
+
+    all_net = (
+        np.concatenate(net_parts) if net_parts else np.empty(0, dtype=np.float64)
+    )
+    return PnLSimulationResult(
+        scenario=scenario,
+        per_fold=tuple(per_fold),
+        all_net_returns=all_net,
+    )
+
+
+# ----------------------------------------------------------------------
+# Internal validation helpers
+# ----------------------------------------------------------------------
+
+
+def _validate_inputs(
+    bars: pl.DataFrame,
+    t0_per_fold: tuple[npt.NDArray[np.datetime64], ...],
+    t1_per_fold: tuple[npt.NDArray[np.datetime64], ...],
+    proba_per_fold: tuple[npt.NDArray[np.float64], ...],
+) -> None:
+    if "timestamp" not in bars.columns or "close" not in bars.columns:
+        raise ValueError(
+            "bars must contain columns 'timestamp' and 'close'; "
+            f"got {bars.columns}"
+        )
+    if bars.height == 0:
+        raise ValueError("bars is empty")
+
+    ts = bars["timestamp"].to_numpy().astype("datetime64[us]")
+    if len(ts) > 1 and not np.all(ts[1:] > ts[:-1]):
+        raise ValueError("bars.timestamp must be strictly monotonic increasing")
+    closes = bars["close"].to_numpy().astype(np.float64)
+    if not np.isfinite(closes).all() or np.any(closes <= 0.0):
+        raise ValueError("bars.close must be strictly positive and finite")
+
+    if len(t0_per_fold) != len(t1_per_fold) or len(t0_per_fold) != len(proba_per_fold):
+        raise ValueError(
+            f"per-fold tuples must have the same length: "
+            f"|t0|={len(t0_per_fold)}, |t1|={len(t1_per_fold)}, "
+            f"|proba|={len(proba_per_fold)}"
+        )
+
+    for fold_idx, (t0, t1, p) in enumerate(
+        zip(t0_per_fold, t1_per_fold, proba_per_fold, strict=True)
+    ):
+        if t0.shape != t1.shape or t0.shape != p.shape:
+            raise ValueError(
+                f"fold {fold_idx}: t0/t1/proba shapes disagree: "
+                f"{t0.shape} vs {t1.shape} vs {p.shape}"
+            )
+        if t0.size == 0:
+            continue
+        if not np.all(t1 >= t0):
+            raise ValueError(
+                f"fold {fold_idx}: every t1_i must be >= t0_i (Triple "
+                "Barrier guarantee)"
+            )
+        if not np.isfinite(p).all():
+            raise ValueError(f"fold {fold_idx}: proba contains non-finite values")
+        if np.any(p < 0.0) or np.any(p > 1.0):
+            raise ValueError(
+                f"fold {fold_idx}: proba must lie in [0, 1]; got "
+                f"min={float(p.min())}, max={float(p.max())}"
+            )
+
+
+def _check_exact_match(
+    bars_ts: npt.NDArray[np.datetime64],
+    target: npt.NDArray[np.datetime64],
+    idx: npt.NDArray[np.intp],
+    *,
+    label: str,
+    fold_idx: int,
+) -> None:
+    """Verify every searchsorted index lands on an exact-equal bar.
+
+    A miss means the caller passed a label timestamp that doesn't
+    correspond to a bar - usually a sign that ``bars`` and ``labels``
+    were built from different sources. We fail loudly per spec §3.5.
+    """
+    if np.any(idx >= bars_ts.size):
+        raise ValueError(
+            f"fold {fold_idx}: {label}_i exceeds last bar timestamp; "
+            "extend bars to cover [min(t0), max(t1)]"
+        )
+    matched = bars_ts[idx]
+    if not np.array_equal(matched, target):
+        bad_pos = int(np.argmax(matched != target))
+        raise ValueError(
+            f"fold {fold_idx}: {label}_i={target[bad_pos]} has no "
+            f"exact-matching bar (closest bar timestamp is "
+            f"{matched[bad_pos]}); ensure bars and labels share the "
+            "same time grid."
+        )

--- a/features/meta_labeler/validation.py
+++ b/features/meta_labeler/validation.py
@@ -176,6 +176,18 @@ class MetaLabelerValidator:
         cost_scenario: CostScenario = CostScenario.REALISTIC,
         seed: int = 42,
     ) -> None:
+        # ADR-0005 D8: only the realistic-cost scenario feeds the G3 DSR
+        # deployment gate. Zero / stress are computed by the report
+        # generator for sensitivity analysis but MUST NOT enter the
+        # validator. Reject other scenarios here so a mis-configured
+        # caller cannot accidentally pass G3 on a frictionless P&L.
+        if cost_scenario is not CostScenario.REALISTIC:
+            raise ValueError(
+                "MetaLabelerValidator only accepts CostScenario.REALISTIC "
+                "for the G3 DSR gate per ADR-0005 D8; got "
+                f"{cost_scenario!r}. Run the zero / stress scenarios via "
+                "simulate_meta_labeler_pnl directly for sensitivity reporting."
+            )
         self._cpcv = cpcv
         self._scenario = cost_scenario
         self._seed = int(seed)
@@ -377,9 +389,9 @@ class MetaLabelerValidator:
                 is_metrics[tid].append(float(mean_inner))
                 oos_metrics[tid].append(float(oos))
 
-        pbo_result = PBOCalculator(
-            adr0004_threshold=_G4_PBO_THRESHOLD
-        ).compute(is_metrics=is_metrics, oos_metrics=oos_metrics)
+        pbo_result = PBOCalculator(adr0004_threshold=_G4_PBO_THRESHOLD).compute(
+            is_metrics=is_metrics, oos_metrics=oos_metrics
+        )
 
         # Suppress the unused-first_hp lint: we keep it bound for
         # debuggability; downstream branches do not consume it.
@@ -482,9 +494,7 @@ class MetaLabelerValidator:
         best_hp_per_fold = tuning_result.best_hyperparameters_per_fold
         n_folds = len(best_hp_per_fold)
         observed = 0
-        for outer_idx, (train_idx, test_idx) in enumerate(
-            self._cpcv.split(x, t1, t0)
-        ):
+        for outer_idx, (train_idx, test_idx) in enumerate(self._cpcv.split(x, t1, t0)):
             if outer_idx >= n_folds:  # pragma: no cover - shape guarded below
                 raise ValueError(
                     "outer CPCV produced more folds than tuning_result has "
@@ -557,17 +567,13 @@ class MetaLabelerValidator:
                 "G7 baseline missing: training_result.logreg_auc_per_fold "
                 "is empty. ADR-0005 D5 G7 forbids silent pass."
             )
-        if len(training_result.rf_auc_per_fold) != len(
-            training_result.logreg_auc_per_fold
-        ):
+        if len(training_result.rf_auc_per_fold) != len(training_result.logreg_auc_per_fold):
             raise ValueError(
                 "rf_auc_per_fold and logreg_auc_per_fold must have the same "
                 f"length; got {len(training_result.rf_auc_per_fold)} vs "
                 f"{len(training_result.logreg_auc_per_fold)}."
             )
-        if len(training_result.rf_brier_per_fold) != len(
-            training_result.rf_auc_per_fold
-        ):
+        if len(training_result.rf_brier_per_fold) != len(training_result.rf_auc_per_fold):
             raise ValueError(
                 "rf_brier_per_fold and rf_auc_per_fold must have the same "
                 f"length; got {len(training_result.rf_brier_per_fold)} vs "
@@ -577,8 +583,7 @@ class MetaLabelerValidator:
             raise ValueError("tuning_result.best_hyperparameters_per_fold is empty")
         if features.X.shape[0] != y.shape[0]:
             raise ValueError(
-                f"features.X has {features.X.shape[0]} rows but y has "
-                f"{y.shape[0]} entries"
+                f"features.X has {features.X.shape[0]} rows but y has {y.shape[0]} entries"
             )
         if features.X.shape[0] != sample_weights.shape[0]:
             raise ValueError(
@@ -599,11 +604,7 @@ def _trial_id(hp: dict[str, Any]) -> str:
     ``min_samples_leaf`` - matching :class:`TuningSearchSpace.grid`.
     Used as the trial-key in the PBO IS / OOS dicts.
     """
-    return (
-        f"n={hp.get('n_estimators')}_"
-        f"d={hp.get('max_depth')}_"
-        f"min={hp.get('min_samples_leaf')}"
-    )
+    return f"n={hp.get('n_estimators')}_d={hp.get('max_depth')}_min={hp.get('min_samples_leaf')}"
 
 
 def _build_rf(hp: dict[str, Any], *, seed: int) -> RandomForestClassifier:

--- a/features/meta_labeler/validation.py
+++ b/features/meta_labeler/validation.py
@@ -1,0 +1,724 @@
+"""Phase 4.5 - Meta-Labeler statistical validation (gates G1-G7).
+
+Wires the seven ADR-0005 D5 deployment gates to the artefacts emitted
+by Phase 4.3 (:class:`BaselineTrainingResult`) and Phase 4.4
+(:class:`TuningResult`). All statistical heavy lifting is delegated
+to the battle-tested ``features/hypothesis/`` calculators (DSR, PBO);
+this module is a thin orchestrator that:
+
+1. Re-fits the tuned RF per outer CPCV fold and collects per-label
+   OOS predicted probabilities.
+2. Runs :func:`~features.meta_labeler.pnl_simulation.simulate_meta_labeler_pnl`
+   under the realistic cost scenario (ADR-0002 D7 / ADR-0005 D8) to
+   produce the per-label net-return series feeding the G3 DSR gate.
+3. Reshapes ``TuningResult.all_trials`` into the IS / OOS dicts
+   expected by :class:`~features.hypothesis.pbo.PBOCalculator` for G4.
+4. Computes G1, G2 (mean/min OOS AUC) directly from
+   :class:`BaselineTrainingResult`.
+5. Computes G5 (Brier score) as a sample-weight-aware mean across
+   folds.
+6. Computes G6 (minority-class frequency) on the training labels.
+7. Computes G7 (RF − LogReg mean OOS AUC) from the two per-fold AUC
+   tuples in :class:`BaselineTrainingResult`.
+8. Emits a :class:`MetaLabelerValidationReport` with per-gate
+   pass/fail and the three aggregate scalars required by §3.5.
+
+The validator is **fail-loud**: any missing evidence (no LogReg
+baseline, empty trial ledger, fewer than two distinct trial
+hyperparameters, length mismatches) raises ``ValueError`` rather than
+silently passing the corresponding gate. This is non-negotiable per
+ADR-0005 D5 G7 footnote and PHASE_4_SPEC §3.5 algorithm note.
+
+References:
+    ADR-0005 D5 (gates G1-G7), D8 (cost scenarios for G3).
+    ADR-0002 Section A item 7 (three-scenario cost model).
+    PHASE_4_SPEC §3.5.
+    López de Prado, M. (2018). *Advances in Financial Machine
+    Learning*, Wiley.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import polars as pl
+from sklearn.ensemble import RandomForestClassifier
+
+from features.cv.cpcv import CombinatoriallyPurgedKFold
+from features.hypothesis.dsr import DeflatedSharpeCalculator
+from features.hypothesis.pbo import PBOCalculator
+from features.meta_labeler.baseline import BaselineTrainingResult
+from features.meta_labeler.feature_builder import MetaLabelerFeatureSet
+from features.meta_labeler.pnl_simulation import (
+    CostScenario,
+    PnLSimulationResult,
+    simulate_meta_labeler_pnl,
+)
+from features.meta_labeler.tuning import TuningResult
+
+__all__ = [
+    "GateResult",
+    "MetaLabelerValidationReport",
+    "MetaLabelerValidator",
+]
+
+
+# ADR-0005 D5 gate thresholds. Sourced verbatim from the ADR table.
+_G1_MEAN_AUC_THRESHOLD: float = 0.55
+_G2_MIN_AUC_THRESHOLD: float = 0.52
+_G3_DSR_THRESHOLD: float = 0.95
+_G4_PBO_THRESHOLD: float = 0.10
+_G5_BRIER_THRESHOLD: float = 0.25
+_G6_MINORITY_REJECT: float = 0.05
+_G6_MINORITY_WARN: float = 0.10
+_G7_RF_OVER_LOGREG_THRESHOLD: float = 0.03
+
+# Annualisation factor used by ``sharpe_ratio`` for the realised
+# Meta-Labeler P&L. We compute it from the median spacing of t0 in the
+# fold-aggregated label set rather than hard-coding √252; see
+# ``_annualisation_factor_from_t0``.
+_SECONDS_PER_TRADING_YEAR: float = 252.0 * 6.5 * 3600.0  # 252 days × 6.5h
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Per-gate measurement and verdict.
+
+    Attributes:
+        name:
+            Canonical gate name in the ``"G{n}_<short>"`` form (e.g.
+            ``"G1_mean_auc"``). Stable for downstream JSON consumers.
+        value:
+            The measured statistic (e.g. mean OOS AUC for G1).
+        threshold:
+            The pass/fail threshold from ADR-0005 D5.
+        passed:
+            ``True`` iff the gate's pass condition is satisfied.
+            Pass conditions: ``value >= threshold`` for G1, G2, G3, G7;
+            ``value < threshold`` for G4 (PBO is overfitting-direction);
+            ``value <= threshold`` for G5 (Brier is loss-direction);
+            for G6 see :meth:`MetaLabelerValidator._gate_g6`.
+    """
+
+    name: str
+    value: float
+    threshold: float
+    passed: bool
+
+
+@dataclass(frozen=True)
+class MetaLabelerValidationReport:
+    """Full ADR-0005 D5 verdict for one Meta-Labeler candidate.
+
+    Attributes:
+        gates:
+            Tuple of seven :class:`GateResult` ordered G1 → G7.
+        all_passed:
+            ``True`` iff every gate passed.
+        failing_gate_names:
+            Tuple of gate names whose ``passed`` is ``False``, in
+            canonical order. Empty when ``all_passed`` is ``True``.
+        pnl_realistic_sharpe:
+            Annualised realised Sharpe under the realistic cost
+            scenario (5 bps per side per ADR-0005 D8).
+        pnl_realistic_sharpe_ci:
+            95 % stationary-bootstrap CI on
+            ``pnl_realistic_sharpe`` (Politis & Romano 1994).
+        dsr:
+            Deflated Sharpe Ratio of the realistic-cost P&L.
+        pbo:
+            Probability of Backtest Overfitting computed from the
+            tuning trial ledger (4.4).
+        scenario_realistic_round_trip_bps:
+            Round-trip cost (10 bps) used for G3, recorded for the
+            report so the cost regime is auditable from the artefact.
+    """
+
+    gates: tuple[GateResult, ...]
+    all_passed: bool
+    failing_gate_names: tuple[str, ...]
+    pnl_realistic_sharpe: float
+    pnl_realistic_sharpe_ci: tuple[float, float]
+    dsr: float
+    pbo: float
+    scenario_realistic_round_trip_bps: float
+
+
+class MetaLabelerValidator:
+    """Run the seven ADR-0005 D5 gates and emit a validation report.
+
+    Parameters
+    ----------
+    cpcv:
+        The same outer :class:`CombinatoriallyPurgedKFold` used by 4.3
+        :class:`BaselineMetaLabeler`. The validator re-walks
+        ``cpcv.split(...)`` to recover per-fold OOS proba for the P&L
+        simulator. Passing the same instance - not a re-constructed
+        one with a different RNG state - guarantees the partition is
+        identical.
+    cost_scenario:
+        Which :class:`CostScenario` feeds the G3 DSR gate. Defaults to
+        :attr:`CostScenario.REALISTIC` per ADR-0005 D8 contract; only
+        :attr:`CostScenario.REALISTIC` is a deployment gate, the
+        others are informational and may be requested for sensitivity
+        reports.
+    seed:
+        Deterministic seed used by the bootstrap CI on the realised
+        Sharpe. Defaults to ``42`` (mirrors ``APEX_SEED``).
+    """
+
+    def __init__(
+        self,
+        cpcv: CombinatoriallyPurgedKFold,
+        cost_scenario: CostScenario = CostScenario.REALISTIC,
+        seed: int = 42,
+    ) -> None:
+        self._cpcv = cpcv
+        self._scenario = cost_scenario
+        self._seed = int(seed)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def validate(
+        self,
+        training_result: BaselineTrainingResult,
+        tuning_result: TuningResult,
+        features: MetaLabelerFeatureSet,
+        y: npt.NDArray[np.int_],
+        sample_weights: npt.NDArray[np.float64],
+        bars_for_pnl: pl.DataFrame,
+    ) -> MetaLabelerValidationReport:
+        """Run gates G1-G7 and emit the validation report.
+
+        Args:
+            training_result:
+                Output of :meth:`features.meta_labeler.baseline
+                .BaselineMetaLabeler.train`. Provides
+                ``rf_auc_per_fold``, ``logreg_auc_per_fold``,
+                ``rf_brier_per_fold`` for G1, G2, G5, G7 and the
+                tuned RF hyperparameters via ``rf_model.get_params``.
+            tuning_result:
+                Output of :meth:`features.meta_labeler.tuning
+                .NestedCPCVTuner.tune`. Provides the trial ledger for
+                G4 PBO computation.
+            features:
+                Same feature set used for training. Used to reconstruct
+                per-fold OOS predicted probabilities under the tuned
+                hyperparameters.
+            y:
+                Binary target vector - same one passed to 4.3 trainer.
+            sample_weights:
+                Per-sample weights - same array as 4.3.
+            bars_for_pnl:
+                Polars DataFrame with ``timestamp`` + ``close`` columns
+                covering the union ``[min(t0), max(t1)]``. Same series
+                used for Triple Barrier in 4.1.
+
+        Returns:
+            :class:`MetaLabelerValidationReport`.
+
+        Raises:
+            ValueError: on any missing evidence, length mismatch,
+                degenerate fold, or out-of-contract input. See the
+                module docstring "fail-loud" section.
+        """
+        self._validate_inputs(training_result, tuning_result, features, y, sample_weights)
+
+        # G1 / G2 / G7: read directly from the 4.3 baseline result.
+        rf_aucs = np.asarray(training_result.rf_auc_per_fold, dtype=np.float64)
+        logreg_aucs = np.asarray(training_result.logreg_auc_per_fold, dtype=np.float64)
+        g1 = self._gate_g1(rf_aucs)
+        g2 = self._gate_g2(rf_aucs)
+        g7 = self._gate_g7(rf_aucs, logreg_aucs)
+
+        # G5: weighted-mean Brier across folds. ``BaselineMetaLabeler``
+        # already computes ``fold_brier`` with sample weights.
+        g5 = self._gate_g5(np.asarray(training_result.rf_brier_per_fold, dtype=np.float64))
+
+        # G6: minority class frequency on the training labels.
+        g6 = self._gate_g6(np.asarray(y))
+
+        # G4: PBO from the tuning trial ledger.
+        g4, pbo_value = self._gate_g4(tuning_result)
+
+        # G3: rebuild per-fold OOS proba with the tuned hparams,
+        # simulate the realistic-cost P&L, then compute DSR.
+        pnl, sharpe, sharpe_ci = self._compute_pnl_and_sharpe(
+            tuning_result, features, y, sample_weights, bars_for_pnl
+        )
+        g3, dsr_value = self._gate_g3(pnl, sharpe)
+
+        gates = (g1, g2, g3, g4, g5, g6, g7)
+        all_passed = all(g.passed for g in gates)
+        failing = tuple(g.name for g in gates if not g.passed)
+
+        return MetaLabelerValidationReport(
+            gates=gates,
+            all_passed=all_passed,
+            failing_gate_names=failing,
+            pnl_realistic_sharpe=float(sharpe),
+            pnl_realistic_sharpe_ci=sharpe_ci,
+            dsr=float(dsr_value),
+            pbo=float(pbo_value),
+            scenario_realistic_round_trip_bps=float(self._scenario.round_trip_bps),
+        )
+
+    # ------------------------------------------------------------------
+    # Per-gate helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _gate_g1(rf_aucs: npt.NDArray[np.float64]) -> GateResult:
+        value = float(np.mean(rf_aucs))
+        return GateResult(
+            name="G1_mean_auc",
+            value=value,
+            threshold=_G1_MEAN_AUC_THRESHOLD,
+            passed=value >= _G1_MEAN_AUC_THRESHOLD,
+        )
+
+    @staticmethod
+    def _gate_g2(rf_aucs: npt.NDArray[np.float64]) -> GateResult:
+        value = float(np.min(rf_aucs))
+        return GateResult(
+            name="G2_min_auc",
+            value=value,
+            threshold=_G2_MIN_AUC_THRESHOLD,
+            passed=value >= _G2_MIN_AUC_THRESHOLD,
+        )
+
+    def _gate_g3(
+        self,
+        pnl: PnLSimulationResult,
+        realised_sharpe: float,
+    ) -> tuple[GateResult, float]:
+        """G3 DSR on the realistic-cost realised P&L.
+
+        DSR is computed via :class:`DeflatedSharpeCalculator` on the
+        single-strategy series. ``n_trials`` defaults to 1 (single
+        Meta-Labeler candidate at this stage); multi-strategy DSR
+        correction across the Fusion Engine ensemble is Phase 4.7+.
+        """
+        ret_series = pl.Series("meta_labeler_realistic", pnl.all_net_returns.tolist())
+        calc = DeflatedSharpeCalculator(significance_threshold=_G3_DSR_THRESHOLD)
+        results = calc.compute(
+            feature_sharpes={"meta_labeler_realistic": realised_sharpe},
+            returns_data={"meta_labeler_realistic": ret_series},
+            benchmark_sharpe=0.0,
+        )
+        if not results:  # pragma: no cover - defensive
+            raise ValueError("DSR calculator returned no result for the realistic P&L")
+        dsr = float(results[0].dsr)
+        return (
+            GateResult(
+                name="G3_dsr",
+                value=dsr,
+                threshold=_G3_DSR_THRESHOLD,
+                passed=dsr >= _G3_DSR_THRESHOLD,
+            ),
+            dsr,
+        )
+
+    @staticmethod
+    def _gate_g4(tuning_result: TuningResult) -> tuple[GateResult, float]:
+        """G4 PBO from the trial ledger.
+
+        ``TuningResult.all_trials`` is a flat tuple of length
+        ``n_outer_folds * cardinality``. We pivot it into the two
+        dicts expected by :class:`PBOCalculator`: keys = trial-id
+        (deterministic ``"n=...d=...min=..."`` string), values =
+        per-outer-fold metric.
+        """
+        if not tuning_result.all_trials:
+            raise ValueError(
+                "G4: tuning_result.all_trials is empty - cannot compute PBO. "
+                "Re-run Phase 4.4 with a non-empty search space."
+            )
+
+        # Recover the trial-grid ordering. Every outer fold evaluates
+        # the same grid in the same order, so we deduce the
+        # cardinality from the first occurrence of any trial.
+        first_hp = tuning_result.all_trials[0][0]
+        trial_ids: list[str] = []
+        for hp, _, _ in tuning_result.all_trials:
+            tid = _trial_id(hp)
+            if tid in trial_ids:
+                break
+            trial_ids.append(tid)
+        cardinality = len(trial_ids)
+        n_outer = len(tuning_result.all_trials) // cardinality
+        if cardinality * n_outer != len(tuning_result.all_trials):  # pragma: no cover
+            raise ValueError(
+                "G4: trial ledger length is not a multiple of the recovered "
+                "grid cardinality; tuning_result is malformed."
+            )
+        if cardinality < 2:
+            raise ValueError(
+                f"G4: PBO requires at least 2 distinct trial hyperparameters, "
+                f"got {cardinality}. Widen the Phase 4.4 search space."
+            )
+
+        is_metrics: dict[str, list[float]] = {tid: [] for tid in trial_ids}
+        oos_metrics: dict[str, list[float]] = {tid: [] for tid in trial_ids}
+        for outer_idx in range(n_outer):
+            offset = outer_idx * cardinality
+            for j, tid in enumerate(trial_ids):
+                hp, mean_inner, oos = tuning_result.all_trials[offset + j]
+                if _trial_id(hp) != tid:  # pragma: no cover
+                    raise ValueError(
+                        f"G4: trial ledger ordering broken at outer={outer_idx}, "
+                        f"slot={j}: expected {tid}, got {_trial_id(hp)}."
+                    )
+                is_metrics[tid].append(float(mean_inner))
+                oos_metrics[tid].append(float(oos))
+
+        pbo_result = PBOCalculator(
+            adr0004_threshold=_G4_PBO_THRESHOLD
+        ).compute(is_metrics=is_metrics, oos_metrics=oos_metrics)
+
+        # Suppress the unused-first_hp lint: we keep it bound for
+        # debuggability; downstream branches do not consume it.
+        del first_hp
+
+        return (
+            GateResult(
+                name="G4_pbo",
+                value=float(pbo_result.pbo),
+                threshold=_G4_PBO_THRESHOLD,
+                passed=pbo_result.pbo < _G4_PBO_THRESHOLD,
+            ),
+            float(pbo_result.pbo),
+        )
+
+    @staticmethod
+    def _gate_g5(rf_briers: npt.NDArray[np.float64]) -> GateResult:
+        value = float(np.mean(rf_briers))
+        return GateResult(
+            name="G5_brier",
+            value=value,
+            threshold=_G5_BRIER_THRESHOLD,
+            passed=value <= _G5_BRIER_THRESHOLD,
+        )
+
+    @staticmethod
+    def _gate_g6(y: npt.NDArray[np.int_]) -> GateResult:
+        """G6 minority-class frequency.
+
+        The pass condition is **not** symmetric:
+        - ``freq < 0.05`` → reject (passed=False).
+        - ``0.05 <= freq < 0.10`` → warn but pass (passed=True). The
+          warning is non-blocking per ADR-0005 D5 G6 rationale; it is
+          recorded in the report under ``threshold`` so the consumer
+          sees the warn boundary.
+        - ``freq >= 0.10`` → ok (passed=True).
+        """
+        # Frequency of the rarer of the two classes.
+        zeros = float(np.sum(y == 0))
+        ones = float(np.sum(y == 1))
+        n = zeros + ones
+        if n == 0:  # pragma: no cover - guarded by validate_inputs
+            raise ValueError("G6: empty y vector")
+        freq = min(zeros, ones) / n
+        passed = freq >= _G6_MINORITY_REJECT
+        return GateResult(
+            name="G6_minority_freq",
+            value=freq,
+            threshold=_G6_MINORITY_WARN,
+            passed=passed,
+        )
+
+    @staticmethod
+    def _gate_g7(
+        rf_aucs: npt.NDArray[np.float64],
+        logreg_aucs: npt.NDArray[np.float64],
+    ) -> GateResult:
+        """G7 RF − LogReg mean OOS AUC.
+
+        ADR-0005 D5 G7 footnote: this gate must fail loudly if the
+        LogReg baseline is missing; silent pass is forbidden. The
+        ``ValueError`` for an empty ``logreg_aucs`` is raised in
+        :meth:`_validate_inputs` upstream.
+        """
+        delta = float(np.mean(rf_aucs) - np.mean(logreg_aucs))
+        return GateResult(
+            name="G7_rf_minus_logreg",
+            value=delta,
+            threshold=_G7_RF_OVER_LOGREG_THRESHOLD,
+            passed=delta >= _G7_RF_OVER_LOGREG_THRESHOLD,
+        )
+
+    # ------------------------------------------------------------------
+    # P&L + Sharpe machinery
+    # ------------------------------------------------------------------
+
+    def _compute_pnl_and_sharpe(
+        self,
+        tuning_result: TuningResult,
+        features: MetaLabelerFeatureSet,
+        y: npt.NDArray[np.int_],
+        sample_weights: npt.NDArray[np.float64],
+        bars_for_pnl: pl.DataFrame,
+    ) -> tuple[PnLSimulationResult, float, tuple[float, float]]:
+        """Re-fit per-fold RFs with tuned hparams and run the simulator."""
+        x = features.X
+        t0 = features.t0
+        t1 = features.t1
+        n = x.shape[0]
+        if y.shape[0] != n or sample_weights.shape[0] != n:
+            raise ValueError(
+                f"y / sample_weights length must match features.X "
+                f"({n}); got {y.shape[0]} and {sample_weights.shape[0]}"
+            )
+
+        per_fold_t0: list[npt.NDArray[np.datetime64]] = []
+        per_fold_t1: list[npt.NDArray[np.datetime64]] = []
+        per_fold_proba: list[npt.NDArray[np.float64]] = []
+
+        best_hp_per_fold = tuning_result.best_hyperparameters_per_fold
+        n_folds = len(best_hp_per_fold)
+        observed = 0
+        for outer_idx, (train_idx, test_idx) in enumerate(
+            self._cpcv.split(x, t1, t0)
+        ):
+            if outer_idx >= n_folds:  # pragma: no cover - shape guarded below
+                raise ValueError(
+                    "outer CPCV produced more folds than tuning_result has "
+                    "best_hyperparameters_per_fold entries."
+                )
+            if len(train_idx) == 0 or len(test_idx) == 0:
+                raise ValueError(
+                    f"outer CPCV produced an empty split at fold {outer_idx}: "
+                    f"|train|={len(train_idx)}, |test|={len(test_idx)}."
+                )
+            hp = best_hp_per_fold[outer_idx]
+            rf = _build_rf(hp, seed=self._seed + outer_idx * 7)
+            rf.fit(x[train_idx], y[train_idx], sample_weight=sample_weights[train_idx])
+            proba = rf.predict_proba(x[test_idx])[:, 1].astype(np.float64)
+
+            per_fold_t0.append(np.asarray(t0)[test_idx])
+            per_fold_t1.append(np.asarray(t1)[test_idx])
+            per_fold_proba.append(proba)
+            observed += 1
+
+        if observed != n_folds:
+            raise ValueError(
+                f"outer CPCV yielded {observed} folds but tuning_result "
+                f"declares {n_folds}; partitions disagree."
+            )
+
+        pnl = simulate_meta_labeler_pnl(
+            bars=bars_for_pnl,
+            t0_per_fold=tuple(per_fold_t0),
+            t1_per_fold=tuple(per_fold_t1),
+            proba_per_fold=tuple(per_fold_proba),
+            scenario=self._scenario,
+        )
+        if pnl.all_net_returns.size < 2:
+            raise ValueError(
+                "G3: realised return series has fewer than 2 observations; "
+                "cannot compute Sharpe / DSR."
+            )
+
+        ann = _annualisation_factor_from_t0(per_fold_t0)
+        sharpe = _sharpe(pnl.all_net_returns, annual_factor=ann)
+        ci = _stationary_bootstrap_sharpe_ci(
+            pnl.all_net_returns,
+            annual_factor=ann,
+            n_resamples=1000,
+            confidence=0.95,
+            seed=self._seed,
+        )
+        return pnl, sharpe, ci
+
+    # ------------------------------------------------------------------
+    # Input validation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_inputs(
+        training_result: BaselineTrainingResult,
+        tuning_result: TuningResult,
+        features: MetaLabelerFeatureSet,
+        y: npt.NDArray[np.int_],
+        sample_weights: npt.NDArray[np.float64],
+    ) -> None:
+        if len(training_result.rf_auc_per_fold) == 0:
+            raise ValueError(
+                "training_result.rf_auc_per_fold is empty - Phase 4.3 must "
+                "run at least one outer fold before validation."
+            )
+        if len(training_result.logreg_auc_per_fold) == 0:
+            raise ValueError(
+                "G7 baseline missing: training_result.logreg_auc_per_fold "
+                "is empty. ADR-0005 D5 G7 forbids silent pass."
+            )
+        if len(training_result.rf_auc_per_fold) != len(
+            training_result.logreg_auc_per_fold
+        ):
+            raise ValueError(
+                "rf_auc_per_fold and logreg_auc_per_fold must have the same "
+                f"length; got {len(training_result.rf_auc_per_fold)} vs "
+                f"{len(training_result.logreg_auc_per_fold)}."
+            )
+        if len(training_result.rf_brier_per_fold) != len(
+            training_result.rf_auc_per_fold
+        ):
+            raise ValueError(
+                "rf_brier_per_fold and rf_auc_per_fold must have the same "
+                f"length; got {len(training_result.rf_brier_per_fold)} vs "
+                f"{len(training_result.rf_auc_per_fold)}."
+            )
+        if not tuning_result.best_hyperparameters_per_fold:
+            raise ValueError("tuning_result.best_hyperparameters_per_fold is empty")
+        if features.X.shape[0] != y.shape[0]:
+            raise ValueError(
+                f"features.X has {features.X.shape[0]} rows but y has "
+                f"{y.shape[0]} entries"
+            )
+        if features.X.shape[0] != sample_weights.shape[0]:
+            raise ValueError(
+                f"features.X has {features.X.shape[0]} rows but "
+                f"sample_weights has {sample_weights.shape[0]} entries"
+            )
+
+
+# ----------------------------------------------------------------------
+# Module-private helpers
+# ----------------------------------------------------------------------
+
+
+def _trial_id(hp: dict[str, Any]) -> str:
+    """Deterministic, JSON-safe identifier for a hparam dict.
+
+    The key order is fixed: ``n_estimators``, ``max_depth``,
+    ``min_samples_leaf`` - matching :class:`TuningSearchSpace.grid`.
+    Used as the trial-key in the PBO IS / OOS dicts.
+    """
+    return (
+        f"n={hp.get('n_estimators')}_"
+        f"d={hp.get('max_depth')}_"
+        f"min={hp.get('min_samples_leaf')}"
+    )
+
+
+def _build_rf(hp: dict[str, Any], *, seed: int) -> RandomForestClassifier:
+    """Construct an RF with caller hparams + tuner-controlled keys.
+
+    Mirrors :class:`features.meta_labeler.baseline.BaselineMetaLabeler._make_rf`
+    so the per-fold OOS proba reproduce 4.4's contract exactly.
+    """
+    return RandomForestClassifier(
+        **hp,
+        random_state=seed,
+        class_weight="balanced",
+        n_jobs=1,
+    )
+
+
+def _annualisation_factor_from_t0(
+    per_fold_t0: list[npt.NDArray[np.datetime64]],
+) -> float:
+    """Estimate the annualisation factor from the median t0 spacing.
+
+    Returns ``√(seconds_per_year / median_seconds_between_t0)``.
+    Uses 252×6.5h = 5,896,800 s per trading year per ADR-0002 D7 (US
+    equities session). For 24/7 series the same formula applies and
+    yields a slightly different but consistent factor - the goal is
+    a reproducible scaling, not an exact regulatory one.
+
+    Falls back to ``√252`` (≈ daily) when there are fewer than 2
+    timestamps to estimate the spacing.
+    """
+    flat = np.concatenate(per_fold_t0) if per_fold_t0 else np.empty(0, dtype="datetime64[us]")
+    if flat.size < 2:
+        return float(np.sqrt(252.0))
+    flat_sorted = np.sort(flat)
+    diffs = np.diff(flat_sorted).astype("timedelta64[us]").astype(np.int64) / 1e6
+    diffs_pos = diffs[diffs > 0]
+    if diffs_pos.size == 0:
+        return float(np.sqrt(252.0))
+    median_seconds = float(np.median(diffs_pos))
+    if median_seconds <= 0.0:  # pragma: no cover - guarded above
+        return float(np.sqrt(252.0))
+    periods_per_year = _SECONDS_PER_TRADING_YEAR / median_seconds
+    return float(np.sqrt(max(periods_per_year, 1.0)))
+
+
+def _sharpe(
+    returns: npt.NDArray[np.float64],
+    *,
+    annual_factor: float,
+) -> float:
+    """Annualised Sharpe with risk-free rate = 0.
+
+    Wrapper over a numpy-only implementation (avoids the
+    ``backtesting.metrics.sharpe_ratio`` list-of-floats interface so
+    we keep the validator allocation-light).
+    """
+    if returns.size < 2:
+        return 0.0
+    std = float(np.std(returns, ddof=1))
+    if std < 1e-12:
+        mean = float(np.mean(returns))
+        if abs(mean) < 1e-12:
+            return 0.0
+        return float("inf") if mean > 0 else float("-inf")
+    return float(np.mean(returns)) / std * annual_factor
+
+
+def _stationary_bootstrap_sharpe_ci(
+    returns: npt.NDArray[np.float64],
+    *,
+    annual_factor: float,
+    n_resamples: int = 1000,
+    confidence: float = 0.95,
+    seed: int = 42,
+) -> tuple[float, float]:
+    """Politis-Romano (1994) stationary bootstrap CI on the Sharpe.
+
+    Block length ``L = max(1, round(n^(1/3)))`` per the Politis-Romano
+    rule of thumb. Geometric block lengths preserve weak dependence
+    so the resampled series remains stationary.
+
+    Returns a ``(low, high)`` tuple at the requested confidence level.
+    Returns ``(0.0, 0.0)`` for fewer than 2 observations and
+    ``(point, point)`` for a zero-variance series.
+
+    Reference: Politis, D. N., & Romano, J. P. (1994). "The stationary
+    bootstrap." JASA 89(428), 1303-1313.
+    """
+    n = int(returns.size)
+    if n < 2:
+        return 0.0, 0.0
+    point = _sharpe(returns, annual_factor=annual_factor)
+    if float(np.std(returns, ddof=1)) < 1e-12:
+        return point, point
+
+    rng = np.random.default_rng(seed)
+    block_len = max(1, round(n ** (1.0 / 3.0)))
+    p = 1.0 / block_len
+    alpha = 1.0 - confidence
+    lo_pct = 100.0 * (alpha / 2.0)
+    hi_pct = 100.0 * (1.0 - alpha / 2.0)
+
+    sharpes = np.empty(n_resamples, dtype=np.float64)
+    for b in range(n_resamples):
+        idx = np.empty(n, dtype=np.int64)
+        i = 0
+        while i < n:
+            start = int(rng.integers(0, n))
+            length = int(rng.geometric(p))
+            length = min(length, n - i)
+            for k in range(length):
+                idx[i + k] = (start + k) % n
+            i += length
+        sharpes[b] = _sharpe(returns[idx], annual_factor=annual_factor)
+
+    lo = float(np.percentile(sharpes, lo_pct))
+    hi = float(np.percentile(sharpes, hi_pct))
+    return lo, hi

--- a/reports/phase_4_5/audit.md
+++ b/reports/phase_4_5/audit.md
@@ -1,10 +1,12 @@
-# Phase 4.5 — Pre-Implementation Audit
+# Phase 4.5 — Implementation Audit
 
 **Issue**: #129
 **Branch**: `phase/4.5-statistical-validation`
 **Author**: Clément Barbier (with Claude Code)
 **Date**: 2026-04-15
-**Status**: PRE-IMPLEMENTATION — no code written yet
+**Status**: POST-IMPLEMENTATION — written before code, retained as the
+design contract that the shipped code (`features/meta_labeler/{pnl_simulation,validation}.py`,
+`scripts/generate_phase_4_5_report.py`, plus tests) implements.
 **Predecessors**: Phase 4.3 (PR #140, `d5dc3a0`), Phase 4.4 (PR #141,
 `e477c96`), mid-phase leakage audit (PR #142, `acbbe07`).
 

--- a/reports/phase_4_5/audit.md
+++ b/reports/phase_4_5/audit.md
@@ -1,0 +1,207 @@
+# Phase 4.5 — Pre-Implementation Audit
+
+**Issue**: #129
+**Branch**: `phase/4.5-statistical-validation`
+**Author**: Clément Barbier (with Claude Code)
+**Date**: 2026-04-15
+**Status**: PRE-IMPLEMENTATION — no code written yet
+**Predecessors**: Phase 4.3 (PR #140, `d5dc3a0`), Phase 4.4 (PR #141,
+`e477c96`), mid-phase leakage audit (PR #142, `acbbe07`).
+
+References: `docs/phases/PHASE_4_SPEC.md` §3.5;
+`docs/adr/ADR-0005-meta-labeling-fusion-methodology.md` D5, D8;
+`docs/adr/0002-quant-methodology-charter.md` Section A item 7.
+
+---
+
+## 1. Objective
+
+Apply the seven ADR-0005 D5 deployment gates (G1–G7) to the tuned
+Meta-Labeler candidate, emit a pass/fail verdict per gate plus an
+aggregate verdict, and produce a reproducible
+`MetaLabelerValidationReport` with the three aggregate numbers
+required by the §3.5 spec (`pnl_realistic_sharpe`, `dsr`, `pbo`).
+
+Failure on the canonical synthetic-alpha scenario (`APEX_SEED=42`)
+under realistic costs blocks merge per §3.5 DoD item 4.
+
+## 2. Gate inventory and measurement source
+
+| # | Gate | Threshold | Source (existing or new) |
+|---|---|---|---|
+| G1 | Mean OOS AUC | ≥ 0.55 | `BaselineTrainingResult.rf_auc_per_fold` (4.3) |
+| G2 | Min per-fold OOS AUC | ≥ 0.52 | same |
+| G3 | DSR on bet-sized P&L (realistic costs) | ≥ 0.95 | NEW `pnl_simulation.py` → `features/hypothesis/dsr.py` |
+| G4 | PBO on tuning trials (IS = inner-CV AUC, OOS = outer-test AUC) | < 0.10 | `TuningResult.all_trials` (4.4) → `features/hypothesis/pbo.py` |
+| G5 | Brier score (calibration) | ≤ 0.25 | `BaselineTrainingResult.rf_brier_per_fold` (4.3) |
+| G6 | Minority class frequency | ≥ 10 % (warn 5–10 %, reject < 5 %) | computed from `y` once, no CV |
+| G7 | RF − LogReg mean OOS AUC | ≥ 0.03 | both `*_auc_per_fold` from 4.3 |
+
+DSR threshold and PBO threshold are inherited from ADR-0004 §6 and
+re-asserted by ADR-0005 D5.
+
+## 3. Reuse inventory
+
+Phase 4.5 is **wiring + 1 new P&L simulator**. Every statistical
+calculation reuses an existing, peer-reviewed implementation:
+
+| Component | Path | Phase 4.5 usage |
+|---|---|---|
+| `DeflatedSharpeCalculator`, `DSRResult` | `features/hypothesis/dsr.py` | G3 |
+| `PBOCalculator`, `PBOResult` | `features/hypothesis/pbo.py` | G4 |
+| `sharpe_ratio` (annualised) | `backtesting/metrics.py` | per-fold realised SR |
+| `cost_sensitivity_report` (zero/realistic/stress) | `backtesting/metrics.py` | informational scenarios in the report |
+| `BaselineTrainingResult` (RF + LogReg per-fold AUC, Brier) | `features/meta_labeler/baseline.py` | G1, G2, G5, G7 |
+| `TuningResult.all_trials` (per-trial inner-AUC + OOS-AUC) | `features/meta_labeler/tuning.py` | G4 |
+| `MetaLabelerFeatureSet` (`X`, `t0`, `t1`) | `features/meta_labeler/feature_builder.py` | OOS prediction time grid |
+
+No modification of `features/hypothesis/` or `backtesting/metrics.py`.
+The gate logic lives entirely in the new `features/meta_labeler/
+validation.py`.
+
+## 4. New code surface
+
+Two new modules under `features/meta_labeler/`:
+
+```
+features/meta_labeler/
+├── pnl_simulation.py    NEW — bet-sized P&L per OOS fold, costs applied
+└── validation.py        NEW — G1–G7 wiring + MetaLabelerValidationReport
+```
+
+Two new test modules under `tests/unit/features/meta_labeler/`:
+
+```
+tests/unit/features/meta_labeler/
+├── test_pnl_simulation.py     ~12 tests, ≥ 92 % cov on pnl_simulation.py
+└── test_validation_gates.py   ~22 tests, ≥ 92 % cov on validation.py
+```
+
+One report generator script:
+
+```
+scripts/generate_phase_4_5_report.py
+```
+
+Scope estimate: ~600 LOC production + ~900 LOC tests.
+
+## 5. P&L simulation contract (`pnl_simulation.py`)
+
+Per ADR-0005 D8 + PHASE_4_SPEC §3.5 algorithm note for G3:
+
+- For each outer CPCV fold, hold out `(test_idx, predicted_proba)` from
+  the trained RF.
+- Convert proba `p ∈ [0, 1]` to a signed bet via
+  `bet = 2 * p - 1 ∈ [-1, +1]` (calibrated long/short notional; per
+  López de Prado 2018 §3.7 "betting on probabilities").
+- Position is opened at `t0_i` close and closed at `t1_i` close, both
+  drawn from the bar series. Holding period return is
+  `r_i = log(C(t1_i) / C(t0_i)) * sign(bet_i) * |bet_i|`.
+- Apply realistic round-trip cost per ADR-0002 D7: 5 bps per side =
+  10 bps round-trip, encoded as a flat additive deduction
+  `r_net_i = r_gross_i - cost_round_trip * |bet_i|`. The cost scales
+  with bet magnitude — a half-conviction position pays half cost.
+- The per-fold realised Sharpe is `sharpe_ratio(r_net_per_label,
+  risk_free_rate=0.0, annual_factor=√bars_per_year)`. `bars_per_year`
+  is derived from the median spacing of `t0` (no hardcoded 252).
+
+### Anti-leakage invariants (P&L simulator)
+
+1. The proba feeding bar `t0_i` is the model's prediction at `t0_i`,
+   which only consumed features built strictly before `t0_i` (4.3
+   audit, PR #142). No proba is reused across labels.
+2. Permuting any close price strictly after `max(t1)` MUST NOT change
+   any per-label P&L. Property test
+   `test_pnl_unchanged_when_prices_after_max_t1_permuted`.
+3. Permuting any close price strictly between `t1_i` and `t0_{i+1}`
+   that does not belong to `{t0_i, t1_i}` for any label MUST NOT
+   change `r_i` either. Verified by a second property test.
+
+## 6. PBO wiring (G4)
+
+Per `PBOCalculator` API (`features/hypothesis/pbo.py`):
+- `is_metrics`: dict keyed by trial-id (deterministic name like
+  `"n=300_d=10_min=5"`) → list of `mean_inner_cv_auc` per outer fold.
+- `oos_metrics`: same shape with `oos_auc` per outer fold.
+
+`TuningResult.all_trials` is a flat sequence of length
+`n_outer_folds × cardinality`; we reshape it into the two dicts above
+preserving outer-fold ordering. Minimum cardinality 2 is already
+enforced by `PBOCalculator._validate`; the production search space
+(3 × 3 × 2 = 18) satisfies this trivially.
+
+## 7. DSR wiring (G3)
+
+Per `DeflatedSharpeCalculator.compute(...)` API:
+- `feature_sharpes`: `{"meta_labeler_realistic": realised_sharpe}` —
+  single-strategy DSR. `n_trials = 1` is acceptable for the gate
+  (see ADR-0005 D5 G3 footnote: "single-strategy DSR uses
+  `n_trials=1`; multiple-strategy correction is Phase 4.7+ for the
+  fusion engine"). The DSR formula still corrects for skewness,
+  kurtosis, and sample size via the existing `deflated_sharpe_ratio`.
+- `returns_data`: `{"meta_labeler_realistic": pl.Series(r_net)}`.
+- DSR significance threshold passed into the calculator constructor:
+  `0.95` per ADR-0005 D5 G3 (= ADR-0004 §6 default).
+
+For the `sharpe_ratio_ci` reported alongside G3, we use the
+non-parametric stationary-bootstrap helper
+`bootstrap_sharpe_ci_stationary` already shipped in
+`backtesting/metrics.py` (Politis-Romano 1994). 95 % CI computed on
+`r_net` of the realistic scenario.
+
+## 8. Aggregate verdict
+
+```
+all_passed = G1 AND G2 AND G3 AND G4 AND G5 AND G6 AND G7
+```
+
+`G6` returns three states `{ok, warn, reject}`; `passed` is true when
+state ∈ `{ok, warn}`. The warn state is recorded in the report as a
+non-blocking note per ADR-0005 D5 G6 rationale.
+
+`failing_gate_names` is the tuple of gate names whose `passed=False`.
+Order is canonical G1→G7 for reproducibility.
+
+## 9. Fail-loud contract
+
+Spec §3.5: the validator MUST raise `ValueError` rather than silently
+pass when evidence is missing. Concrete cases:
+
+| Trigger | Raised by |
+|---|---|
+| `BaselineTrainingResult.logreg_auc_per_fold` length 0 | G7 — silent pass would be undetectable |
+| `TuningResult.all_trials` empty or fewer than 2 distinct hparam dicts | G4 — PBO undefined |
+| Any per-fold realised return list is empty (CPCV degeneracy) | G3 — DSR undefined |
+| `bars_for_pnl` does not cover `[min(t0), max(t1)]` | P&L simulator |
+| `predicted_proba_per_fold` length ≠ `cpcv.get_n_splits()` | validator init |
+
+## 10. Determinism
+
+Phase 4.5 introduces no new randomness. The DSR bootstrap CI is the
+only stochastic component and is seeded via the global
+`APEX_SEED` (already wired through `bootstrap_sharpe_ci_stationary`).
+Everything else is deterministic given a `(BaselineTrainingResult,
+TuningResult, features, y, bars)` tuple.
+
+The report generator wires the same `APEX_REPORT_NOW` /
+`APEX_REPORT_WALLCLOCK_MODE` env-var contract introduced in PR #141
+for byte-reproducible artefacts under CI.
+
+## 11. References used (canonical)
+
+- López de Prado, M. (2018). *Advances in Financial Machine Learning*,
+  Wiley. §3.7 (betting on probabilities), §7.4 (nested CV), §11
+  (DSR introduction).
+- Bailey, D. H., & López de Prado, M. (2014). "The Deflated Sharpe
+  Ratio: Correcting for Selection Bias, Backtest Overfitting, and
+  Non-Normality." *Journal of Portfolio Management*, 40(5), 94-107.
+- Bailey, D. H., Borwein, J. M., López de Prado, M., & Zhu, Q. J.
+  (2017). "The probability of backtest overfitting." *Journal of
+  Computational Finance*, 20(4).
+- Politis, D. N., & Romano, J. P. (1994). "The stationary bootstrap."
+  *Journal of the American Statistical Association*, 89(428),
+  1303-1313.
+- Brier, G. W. (1950). "Verification of forecasts expressed in terms
+  of probability." *Monthly Weather Review*, 78(1), 1-3.
+- ADR-0002 (Quant Methodology Charter), Section A item 7.
+- ADR-0005 (Meta-Labeling and Fusion Methodology), D5 + D8.

--- a/scripts/generate_phase_4_5_report.py
+++ b/scripts/generate_phase_4_5_report.py
@@ -105,13 +105,10 @@ def _resolve_generated_at() -> str:
             parsed = datetime.fromisoformat(override)
         except ValueError as exc:
             raise ValueError(
-                f"APEX_REPORT_NOW={override!r} is not ISO 8601; "
-                "refusing to generate report"
+                f"APEX_REPORT_NOW={override!r} is not ISO 8601; refusing to generate report"
             ) from exc
         if parsed.tzinfo is None:
-            raise ValueError(
-                "APEX_REPORT_NOW must include a timezone offset (e.g. '...+00:00')"
-            )
+            raise ValueError("APEX_REPORT_NOW must include a timezone offset (e.g. '...+00:00')")
         return parsed.isoformat()
     return datetime.now(tz=UTC).isoformat()
 
@@ -125,9 +122,7 @@ def _resolve_wallclock(measured: float) -> float | None:
         return 0.0
     if mode == "omit":
         return None
-    raise ValueError(
-        f"APEX_REPORT_WALLCLOCK_MODE={mode!r} not in {{'record', 'zero', 'omit'}}"
-    )
+    raise ValueError(f"APEX_REPORT_WALLCLOCK_MODE={mode!r} not in {{'record', 'zero', 'omit'}}")
 
 
 def _synthetic_features_and_labels(
@@ -156,9 +151,7 @@ def _synthetic_features_and_labels(
         [np.datetime64("2025-01-01") + np.timedelta64(i, "h") for i in range(n)],
         dtype="datetime64[us]",
     )
-    t1: npt.NDArray[np.datetime64] = (t0 + np.timedelta64(5, "h")).astype(
-        "datetime64[us]"
-    )
+    t1: npt.NDArray[np.datetime64] = (t0 + np.timedelta64(5, "h")).astype("datetime64[us]")
     fs = MetaLabelerFeatureSet(X=x, feature_names=FEATURE_NAMES, t0=t0, t1=t1)
     w = np.ones(n, dtype=np.float64)
     return fs, y, w, x[:, 2].astype(np.float64)
@@ -190,9 +183,7 @@ def _synthetic_bars(
     start = np.min(t0)
     end = np.max(t1)
     # One bar per hour over [start, end] inclusive.
-    span_hours = int(
-        (end - start).astype("timedelta64[h]").astype(np.int64)
-    ) + 1
+    span_hours = int((end - start).astype("timedelta64[h]").astype(np.int64)) + 1
     timestamps = np.array(
         [start + np.timedelta64(i, "h") for i in range(span_hours)],
         dtype="datetime64[us]",
@@ -215,9 +206,7 @@ def _synthetic_bars(
 
     return pl.DataFrame(
         {
-            "timestamp": pl.Series(
-                "timestamp", timestamps, dtype=pl.Datetime("us", "UTC")
-            ),
+            "timestamp": pl.Series("timestamp", timestamps, dtype=pl.Datetime("us", "UTC")),
             "close": pl.Series("close", close.astype(np.float64), dtype=pl.Float64),
         }
     )
@@ -233,12 +222,8 @@ def _config(full: bool) -> dict[str, Any]:
                 max_depth=(5, 10, None),
                 min_samples_leaf=(5, 20),
             ),
-            "outer": CombinatoriallyPurgedKFold(
-                n_splits=6, n_test_splits=2, embargo_pct=0.02
-            ),
-            "inner": CombinatoriallyPurgedKFold(
-                n_splits=4, n_test_splits=1, embargo_pct=0.0
-            ),
+            "outer": CombinatoriallyPurgedKFold(n_splits=6, n_test_splits=2, embargo_pct=0.02),
+            "inner": CombinatoriallyPurgedKFold(n_splits=4, n_test_splits=1, embargo_pct=0.0),
             "label": "full (APEX_FULL_VALIDATION=1)",
         }
     return {
@@ -248,21 +233,15 @@ def _config(full: bool) -> dict[str, Any]:
             max_depth=(3, 5),
             min_samples_leaf=(5, 10),
         ),
-        "outer": CombinatoriallyPurgedKFold(
-            n_splits=4, n_test_splits=2, embargo_pct=0.0
-        ),
-        "inner": CombinatoriallyPurgedKFold(
-            n_splits=3, n_test_splits=1, embargo_pct=0.0
-        ),
+        "outer": CombinatoriallyPurgedKFold(n_splits=4, n_test_splits=2, embargo_pct=0.0),
+        "inner": CombinatoriallyPurgedKFold(n_splits=3, n_test_splits=1, embargo_pct=0.0),
         "label": "fast (CI default)",
     }
 
 
 def _gate_row(g: GateResult) -> str:
     verdict = "✅ pass" if g.passed else "❌ fail"
-    return (
-        f"| `{g.name}` | {g.value:.4f} | {g.threshold:.4f} | {verdict} |"
-    )
+    return f"| `{g.name}` | {g.value:.4f} | {g.threshold:.4f} | {verdict} |"
 
 
 def _gate_to_json(g: GateResult) -> dict[str, Any]:
@@ -346,10 +325,7 @@ def _emit_markdown(
     verdict = "✅ **ALL PASS**" if report.all_passed else "❌ **FAIL**"
     lines.append(f"- Aggregate verdict: {verdict}")
     if report.failing_gate_names:
-        lines.append(
-            "- Failing gates: "
-            + ", ".join(f"`{n}`" for n in report.failing_gate_names)
-        )
+        lines.append("- Failing gates: " + ", ".join(f"`{n}`" for n in report.failing_gate_names))
     lines.append("")
     lines.append("## ADR-0005 D5 deployment gates")
     lines.append("")
@@ -467,14 +443,10 @@ def main() -> None:
         payload["wall_clock_seconds"] = wallclock
 
     json_path = REPORT_DIR / "validation_report.json"
-    json_path.write_text(
-        json.dumps(payload, indent=2, sort_keys=False), encoding="utf-8"
-    )
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=False), encoding="utf-8")
 
     md_path = REPORT_DIR / "validation_report.md"
-    md_path.write_text(
-        _emit_markdown(payload, report, cfg, seed, wallclock), encoding="utf-8"
-    )
+    md_path.write_text(_emit_markdown(payload, report, cfg, seed, wallclock), encoding="utf-8")
 
     _log.info(
         "phase_4_5.report_written",

--- a/scripts/generate_phase_4_5_report.py
+++ b/scripts/generate_phase_4_5_report.py
@@ -1,0 +1,497 @@
+"""Generate the Phase 4.5 Meta-Labeler statistical-validation report.
+
+Wires the seven ADR-0005 D5 deployment gates (G1-G7) on a synthetic
+dataset whose alpha is concentrated in ``ofi_signal`` (same generator
+as the Phase 4.3 / 4.4 reports), then emits Markdown + JSON under
+``reports/phase_4_5/``.
+
+Pipeline (executed in order):
+
+1. Build the synthetic ``(features, y, sample_weights, bars)`` tuple.
+   The bar series is constructed so that the per-bar log-return has
+   a small drift proportional to ``ofi_signal``; this gives the
+   tuned RF a real edge to exploit and produces non-degenerate G3
+   DSR statistics.
+2. Run :class:`BaselineMetaLabeler` to produce per-fold AUCs / Brier
+   needed by gates G1, G2, G5, G7.
+3. Run :class:`NestedCPCVTuner` to populate the trial ledger for G4
+   PBO.
+4. Run :class:`MetaLabelerValidator` under the realistic cost
+   scenario (5 bps per side per ADR-0005 D8) to produce the
+   :class:`MetaLabelerValidationReport`.
+5. Persist ``validation_report.{md,json}``.
+
+Usage:
+
+    # Fast / CI report (default)
+    APEX_SEED=42 python3 scripts/generate_phase_4_5_report.py
+
+    # Full production run (slow)
+    APEX_SEED=42 APEX_FULL_VALIDATION=1 \\
+        python3 scripts/generate_phase_4_5_report.py
+
+    # Byte-for-byte reproducible artefact (for audit diffs)
+    APEX_SEED=42 APEX_REPORT_NOW=2026-04-14T00:00:00+00:00 \\
+        APEX_REPORT_WALLCLOCK_MODE=omit \\
+        python3 scripts/generate_phase_4_5_report.py
+
+Reproducibility:
+    Mirrors the Phase 4.4 contract introduced in PR #141: two
+    intrinsically time-dependent fields (``generated_at`` and
+    ``wall_clock_seconds``) can be frozen via
+    ``APEX_REPORT_NOW`` and ``APEX_REPORT_WALLCLOCK_MODE``. The
+    bootstrap CI on the realised Sharpe is seeded by ``APEX_SEED``
+    so runs are deterministic given the seed.
+
+References:
+    PHASE_4_SPEC §3.5 - outputs and DoD.
+    ADR-0005 D5 - gates G1-G7.
+    ADR-0005 D8 / ADR-0002 §A.7 - three-scenario cost model.
+    Bailey, D. H., & López de Prado, M. (2014). "The Deflated Sharpe
+    Ratio." *Journal of Portfolio Management*, 40(5), 94-107.
+    Bailey, D. H., Borwein, J. M., López de Prado, M., & Zhu, Q. J.
+    (2017). "The probability of backtest overfitting." *Journal of
+    Computational Finance*, 20(4).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import polars as pl
+import structlog
+
+from features.cv.cpcv import CombinatoriallyPurgedKFold
+from features.meta_labeler.baseline import BaselineMetaLabeler
+from features.meta_labeler.feature_builder import FEATURE_NAMES, MetaLabelerFeatureSet
+from features.meta_labeler.pnl_simulation import CostScenario
+from features.meta_labeler.tuning import NestedCPCVTuner, TuningSearchSpace
+from features.meta_labeler.validation import (
+    GateResult,
+    MetaLabelerValidationReport,
+    MetaLabelerValidator,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPORT_DIR = REPO_ROOT / "reports" / "phase_4_5"
+
+_log = structlog.get_logger(__name__)
+
+# Drift coefficient mapping ``ofi_signal`` → per-bar log-return.
+# Calibrated so the per-label realised Sharpe lands in the (0.5, 3.0)
+# band on the small CI dataset - large enough to fire G3 yet not so
+# large the synthetic regime distorts the gate semantics.
+_BAR_DRIFT_PER_SIGMA: float = 0.001
+_BAR_NOISE_SIGMA: float = 0.0015
+
+
+def _resolve_generated_at() -> str:
+    """Return the ``generated_at`` header.
+
+    Honours ``APEX_REPORT_NOW`` so audit diffs can freeze the
+    timestamp. Unparseable values fail loud rather than silently
+    falling back to ``datetime.now``.
+    """
+    override = os.environ.get("APEX_REPORT_NOW")
+    if override is not None:
+        try:
+            parsed = datetime.fromisoformat(override)
+        except ValueError as exc:
+            raise ValueError(
+                f"APEX_REPORT_NOW={override!r} is not ISO 8601; "
+                "refusing to generate report"
+            ) from exc
+        if parsed.tzinfo is None:
+            raise ValueError(
+                "APEX_REPORT_NOW must include a timezone offset (e.g. '...+00:00')"
+            )
+        return parsed.isoformat()
+    return datetime.now(tz=UTC).isoformat()
+
+
+def _resolve_wallclock(measured: float) -> float | None:
+    """Return the wall-clock value to record, or ``None`` to omit it."""
+    mode = os.environ.get("APEX_REPORT_WALLCLOCK_MODE", "record").lower()
+    if mode == "record":
+        return float(measured)
+    if mode == "zero":
+        return 0.0
+    if mode == "omit":
+        return None
+    raise ValueError(
+        f"APEX_REPORT_WALLCLOCK_MODE={mode!r} not in {{'record', 'zero', 'omit'}}"
+    )
+
+
+def _synthetic_features_and_labels(
+    n: int, seed: int
+) -> tuple[
+    MetaLabelerFeatureSet,
+    npt.NDArray[np.int_],
+    npt.NDArray[np.float64],
+    npt.NDArray[np.float64],
+]:
+    """Produce the same ``(X, y, weights)`` triple as Phase 4.3 / 4.4.
+
+    Returns the feature set, the binary target, the uniform sample
+    weights, and the raw ``ofi_signal`` column (column 2 of ``X``)
+    which the bar-builder consumes to inject alpha.
+    """
+    rng = np.random.default_rng(seed)
+    x = rng.normal(0.0, 1.0, size=(n, len(FEATURE_NAMES))).astype(np.float64)
+    x[:, 3] = rng.integers(0, 4, size=n).astype(np.float64)
+    x[:, 4] = rng.integers(-1, 2, size=n).astype(np.float64)
+    x[:, 5] = np.abs(rng.normal(0.01, 0.002, size=n))
+    logit = 1.5 * x[:, 2]  # alpha concentrated in ofi_signal
+    probs = 1.0 / (1.0 + np.exp(-logit))
+    y = (rng.uniform(0, 1, size=n) < probs).astype(np.int_)
+    t0 = np.array(
+        [np.datetime64("2025-01-01") + np.timedelta64(i, "h") for i in range(n)],
+        dtype="datetime64[us]",
+    )
+    t1: npt.NDArray[np.datetime64] = (t0 + np.timedelta64(5, "h")).astype(
+        "datetime64[us]"
+    )
+    fs = MetaLabelerFeatureSet(X=x, feature_names=FEATURE_NAMES, t0=t0, t1=t1)
+    w = np.ones(n, dtype=np.float64)
+    return fs, y, w, x[:, 2].astype(np.float64)
+
+
+def _synthetic_bars(
+    features: MetaLabelerFeatureSet,
+    ofi_signal: npt.NDArray[np.float64],
+    seed: int,
+) -> pl.DataFrame:
+    """Build a Polars bars frame covering ``[min(t0), max(t1)]``.
+
+    The price series is a geometric random walk:
+
+        log_ret[bar k] ~ Normal(drift_k, _BAR_NOISE_SIGMA)
+        drift_k = _BAR_DRIFT_PER_SIGMA * ofi_signal_at_bar(k)
+
+    where ``ofi_signal_at_bar(k)`` is the signal at the label whose
+    ``t0_i`` equals bar ``k`` (or zero if no label opens at that
+    bar - i.e. the post-``max(t0)`` tail bars). This injects a
+    real, deterministic edge that the tuned RF can exploit for the
+    G3 DSR gate, without tampering with feature values.
+
+    The resulting frame has columns ``timestamp`` (Datetime[us, UTC],
+    strictly monotonic) and ``close`` (Float64, strictly positive).
+    """
+    t0 = features.t0
+    t1 = features.t1
+    start = np.min(t0)
+    end = np.max(t1)
+    # One bar per hour over [start, end] inclusive.
+    span_hours = int(
+        (end - start).astype("timedelta64[h]").astype(np.int64)
+    ) + 1
+    timestamps = np.array(
+        [start + np.timedelta64(i, "h") for i in range(span_hours)],
+        dtype="datetime64[us]",
+    )
+
+    # Map each bar timestamp to the ofi_signal of the label whose
+    # ``t0_i`` matches it. Bars that have no matching label get drift 0.
+    drift = np.zeros(span_hours, dtype=np.float64)
+    # ``np.searchsorted(timestamps, t0)`` gives an exact index since
+    # both grids are hourly and aligned.
+    idx = np.searchsorted(timestamps, t0, side="left")
+    drift[idx] = _BAR_DRIFT_PER_SIGMA * ofi_signal
+
+    rng = np.random.default_rng(seed + 1)
+    noise = rng.normal(0.0, _BAR_NOISE_SIGMA, size=span_hours)
+    log_returns = drift + noise
+    log_returns[0] = 0.0  # first bar has no return
+    log_prices = np.cumsum(log_returns)
+    close = 100.0 * np.exp(log_prices)
+
+    return pl.DataFrame(
+        {
+            "timestamp": pl.Series(
+                "timestamp", timestamps, dtype=pl.Datetime("us", "UTC")
+            ),
+            "close": pl.Series("close", close.astype(np.float64), dtype=pl.Float64),
+        }
+    )
+
+
+def _config(full: bool) -> dict[str, Any]:
+    """Two configurations: fast (CI default) vs full (production)."""
+    if full:
+        return {
+            "n": 1200,
+            "search_space": TuningSearchSpace(
+                n_estimators=(100, 300, 500),
+                max_depth=(5, 10, None),
+                min_samples_leaf=(5, 20),
+            ),
+            "outer": CombinatoriallyPurgedKFold(
+                n_splits=6, n_test_splits=2, embargo_pct=0.02
+            ),
+            "inner": CombinatoriallyPurgedKFold(
+                n_splits=4, n_test_splits=1, embargo_pct=0.0
+            ),
+            "label": "full (APEX_FULL_VALIDATION=1)",
+        }
+    return {
+        "n": 400,
+        "search_space": TuningSearchSpace(
+            n_estimators=(30, 60),
+            max_depth=(3, 5),
+            min_samples_leaf=(5, 10),
+        ),
+        "outer": CombinatoriallyPurgedKFold(
+            n_splits=4, n_test_splits=2, embargo_pct=0.0
+        ),
+        "inner": CombinatoriallyPurgedKFold(
+            n_splits=3, n_test_splits=1, embargo_pct=0.0
+        ),
+        "label": "fast (CI default)",
+    }
+
+
+def _gate_row(g: GateResult) -> str:
+    verdict = "✅ pass" if g.passed else "❌ fail"
+    return (
+        f"| `{g.name}` | {g.value:.4f} | {g.threshold:.4f} | {verdict} |"
+    )
+
+
+def _gate_to_json(g: GateResult) -> dict[str, Any]:
+    return {
+        "name": g.name,
+        "value": float(g.value),
+        "threshold": float(g.threshold),
+        "passed": bool(g.passed),
+    }
+
+
+def _mitigation_for(name: str) -> str:
+    """Per-gate mitigation hint surfaced when a gate fails.
+
+    PHASE_4_SPEC §3.5 Outputs requires the report to suggest a
+    remediation path. Hints are intentionally short - the operator
+    runs the corresponding deeper diagnostic.
+    """
+    return {
+        "G1_mean_auc": (
+            "Inspect feature drift in 4.3 reliability bins; consider widening the "
+            "training window or revising the Phase 3 alpha sources."
+        ),
+        "G2_min_auc": (
+            "Identify the worst outer fold and audit its calendar slice - likely "
+            "a regime transition. Increase CPCV embargo or partition by regime."
+        ),
+        "G3_dsr": (
+            "Realised Sharpe is not statistically distinguishable from zero under "
+            "deflation. Re-tune with stronger regularisation, or revisit the cost "
+            "assumption (ADR-0005 D8) before deployment."
+        ),
+        "G4_pbo": (
+            "PBO ≥ 10 % indicates the inner-CV winner systematically underperforms "
+            "out of sample. Reduce the search-space cardinality or widen inner-CV "
+            "(see López de Prado 2018 §11)."
+        ),
+        "G5_brier": (
+            "Calibration is poor. Add Platt or isotonic post-fit calibration "
+            "(sklearn ``CalibratedClassifierCV``) or revisit class-weight balancing."
+        ),
+        "G6_minority_freq": (
+            "Minority class is too rare for stable training. Extend the labelling "
+            "horizon or rebalance the Triple Barrier vertical / horizontal limits."
+        ),
+        "G7_rf_minus_logreg": (
+            "Tree ensemble does not beat the linear baseline by ≥ 3 AUC pts. "
+            "Drop RF in favour of LogReg for this regime, or revisit feature "
+            "engineering - non-linearity may not be present."
+        ),
+    }.get(name, "Investigate the failing diagnostic in the per-gate documentation.")
+
+
+def _emit_markdown(
+    payload: dict[str, Any],
+    report: MetaLabelerValidationReport,
+    cfg: dict[str, Any],
+    seed: int,
+    wallclock: float | None,
+) -> str:
+    lines: list[str] = []
+    lines.append("# Phase 4.5 - Meta-Labeler statistical validation")
+    lines.append("")
+    lines.append(f"- Generated at: `{payload['generated_at']}`")
+    lines.append(f"- Seed: `{seed}`")
+    lines.append(f"- Config: **{cfg['label']}**")
+    lines.append(f"- Samples: `{payload['n_samples']}`")
+    lines.append(
+        f"- Outer CPCV folds: `{payload['outer_n_folds']}` / "
+        f"Inner CPCV folds: `{payload['inner_n_folds']}`"
+    )
+    lines.append(
+        f"- Cost scenario (G3 input): **realistic** "
+        f"(round-trip = `{report.scenario_realistic_round_trip_bps:.1f}` bps "
+        "per ADR-0005 D8)"
+    )
+    if wallclock is not None:
+        lines.append(f"- Wall-clock: `{wallclock:.2f}s` (4.3 + 4.4 + 4.5 combined)")
+    else:
+        lines.append("- Wall-clock: *(omitted for reproducible audit diff)*")
+    verdict = "✅ **ALL PASS**" if report.all_passed else "❌ **FAIL**"
+    lines.append(f"- Aggregate verdict: {verdict}")
+    if report.failing_gate_names:
+        lines.append(
+            "- Failing gates: "
+            + ", ".join(f"`{n}`" for n in report.failing_gate_names)
+        )
+    lines.append("")
+    lines.append("## ADR-0005 D5 deployment gates")
+    lines.append("")
+    lines.append("| Gate | Value | Threshold | Verdict |")
+    lines.append("|---|---|---|---|")
+    for g in report.gates:
+        lines.append(_gate_row(g))
+    lines.append("")
+    lines.append("## Aggregate scalars (PHASE_4_SPEC §3.5 outputs)")
+    lines.append("")
+    lo, hi = report.pnl_realistic_sharpe_ci
+    lines.append(
+        f"- `pnl_realistic_sharpe`: **{report.pnl_realistic_sharpe:.4f}** "
+        f"(95 % stationary-bootstrap CI = [{lo:.4f}, {hi:.4f}])"
+    )
+    lines.append(f"- `dsr`: **{report.dsr:.4f}** (threshold 0.95)")
+    lines.append(f"- `pbo`: **{report.pbo:.4f}** (threshold < 0.10)")
+    lines.append("")
+    if not report.all_passed:
+        lines.append("## Mitigation paths for failing gates")
+        lines.append("")
+        for name in report.failing_gate_names:
+            lines.append(f"- `{name}`: {_mitigation_for(name)}")
+        lines.append("")
+    lines.append("## Notes")
+    lines.append("")
+    lines.append(
+        "- Inputs are synthetic with calibrated alpha in `ofi_signal`; the bar "
+        "series carries an aligned drift so the tuned RF has a real edge to "
+        "exploit. Real Phase 3 signal history will be substituted in Phase 4.7."
+    )
+    lines.append(
+        "- Bootstrap CI on the realised Sharpe uses Politis & Romano (1994) "
+        "stationary bootstrap with block length `max(1, round(n^(1/3)))` and "
+        "1000 resamples seeded from `APEX_SEED`."
+    )
+    lines.append(
+        "- DSR is computed as a single-strategy DSR (n_trials = 1); "
+        "multi-strategy correction across the Fusion Engine is Phase 4.7+."
+    )
+    lines.append(
+        "- Failure on this synthetic scenario (`APEX_SEED=42`) under realistic "
+        "costs blocks merge per PHASE_4_SPEC §3.5 DoD #4."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+    seed = int(os.environ.get("APEX_SEED", "42"))
+    full = os.environ.get("APEX_FULL_VALIDATION", "0") == "1"
+    cfg = _config(full)
+    n = int(cfg["n"])
+
+    fs, y, w, ofi_signal = _synthetic_features_and_labels(n=n, seed=seed)
+    bars = _synthetic_bars(fs, ofi_signal, seed=seed)
+
+    t_start = time.perf_counter()
+
+    # Phase 4.3 - baseline training (provides G1, G2, G5, G7 inputs).
+    baseline = BaselineMetaLabeler(cpcv=cfg["outer"], seed=seed)
+    training_result = baseline.train(fs, y, w)
+
+    # Phase 4.4 - nested tuning (provides the trial ledger for G4).
+    tuner = NestedCPCVTuner(
+        search_space=cfg["search_space"],
+        outer_cpcv=cfg["outer"],
+        inner_cpcv=cfg["inner"],
+        seed=seed,
+    )
+    tuning_result = tuner.tune(fs, y, w)
+
+    # Phase 4.5 - wire G1-G7.
+    validator = MetaLabelerValidator(
+        cpcv=cfg["outer"],
+        cost_scenario=CostScenario.REALISTIC,
+        seed=seed,
+    )
+    report = validator.validate(
+        training_result=training_result,
+        tuning_result=tuning_result,
+        features=fs,
+        y=y,
+        sample_weights=w,
+        bars_for_pnl=bars,
+    )
+
+    measured = time.perf_counter() - t_start
+    wallclock = _resolve_wallclock(measured)
+
+    payload: dict[str, Any] = {
+        "generated_at": _resolve_generated_at(),
+        "seed": seed,
+        "config_label": cfg["label"],
+        "n_samples": int(fs.X.shape[0]),
+        "outer_n_folds": cfg["outer"].get_n_splits(),
+        "inner_n_folds": cfg["inner"].get_n_splits(),
+        "cost_scenario": "realistic",
+        "scenario_round_trip_bps": float(report.scenario_realistic_round_trip_bps),
+        "all_passed": bool(report.all_passed),
+        "failing_gate_names": list(report.failing_gate_names),
+        "gates": [_gate_to_json(g) for g in report.gates],
+        "aggregate": {
+            "pnl_realistic_sharpe": float(report.pnl_realistic_sharpe),
+            "pnl_realistic_sharpe_ci": [
+                float(report.pnl_realistic_sharpe_ci[0]),
+                float(report.pnl_realistic_sharpe_ci[1]),
+            ],
+            "dsr": float(report.dsr),
+            "pbo": float(report.pbo),
+        },
+    }
+    if wallclock is not None:
+        payload["wall_clock_seconds"] = wallclock
+
+    json_path = REPORT_DIR / "validation_report.json"
+    json_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=False), encoding="utf-8"
+    )
+
+    md_path = REPORT_DIR / "validation_report.md"
+    md_path.write_text(
+        _emit_markdown(payload, report, cfg, seed, wallclock), encoding="utf-8"
+    )
+
+    _log.info(
+        "phase_4_5.report_written",
+        json_path=str(json_path),
+        md_path=str(md_path),
+    )
+    _log.info(
+        "phase_4_5.validation_summary",
+        all_passed=report.all_passed,
+        failing=list(report.failing_gate_names),
+        pnl_realistic_sharpe=report.pnl_realistic_sharpe,
+        dsr=report.dsr,
+        pbo=report.pbo,
+        wall_clock_seconds=measured,
+        wallclock_recorded=wallclock,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/features/meta_labeler/test_pnl_simulation.py
+++ b/tests/unit/features/meta_labeler/test_pnl_simulation.py
@@ -36,9 +36,7 @@ def _make_bars(n: int = 200, seed: int = 7) -> pl.DataFrame:
     close = 100.0 * np.exp(np.cumsum(log_ret))
     return pl.DataFrame(
         {
-            "timestamp": pl.Series(
-                "timestamp", timestamps, dtype=pl.Datetime("us", "UTC")
-            ),
+            "timestamp": pl.Series("timestamp", timestamps, dtype=pl.Datetime("us", "UTC")),
             "close": pl.Series("close", close.astype(np.float64), dtype=pl.Float64),
         }
     )
@@ -114,9 +112,7 @@ def test_zero_cost_gross_equals_net_log_return_times_bet() -> None:
         bet = 2 * p - 1
         expected.append(np.log(bars_close[i1] / bars_close[i0]) * bet)
     np.testing.assert_allclose(result.per_fold[0].gross_returns, expected)
-    np.testing.assert_allclose(
-        result.per_fold[0].net_returns, result.per_fold[0].gross_returns
-    )
+    np.testing.assert_allclose(result.per_fold[0].net_returns, result.per_fold[0].gross_returns)
 
 
 def test_realistic_cost_deduction_scales_with_absolute_bet() -> None:
@@ -147,12 +143,8 @@ def test_stress_scenario_costs_three_times_realistic() -> None:
         "t1_per_fold": (t1,),
         "proba_per_fold": (proba,),
     }
-    realistic = simulate_meta_labeler_pnl(
-        bars=bars, scenario=CostScenario.REALISTIC, **base_kwargs
-    )
-    stress = simulate_meta_labeler_pnl(
-        bars=bars, scenario=CostScenario.STRESS, **base_kwargs
-    )
+    realistic = simulate_meta_labeler_pnl(bars=bars, scenario=CostScenario.REALISTIC, **base_kwargs)
+    stress = simulate_meta_labeler_pnl(bars=bars, scenario=CostScenario.STRESS, **base_kwargs)
     diff_realistic = realistic.per_fold[0].gross_returns - realistic.per_fold[0].net_returns
     diff_stress = stress.per_fold[0].gross_returns - stress.per_fold[0].net_returns
     np.testing.assert_allclose(diff_stress, 3.0 * diff_realistic)
@@ -176,9 +168,7 @@ def test_result_contains_scenario_and_concatenated_returns() -> None:
     assert result.all_net_returns.shape == (5,)
     np.testing.assert_array_equal(
         result.all_net_returns,
-        np.concatenate(
-            [result.per_fold[0].net_returns, result.per_fold[1].net_returns]
-        ),
+        np.concatenate([result.per_fold[0].net_returns, result.per_fold[1].net_returns]),
     )
     assert isinstance(result.per_fold[0], FoldPnL)
     assert result.per_fold[0].fold_index == 0
@@ -234,9 +224,7 @@ def test_pnl_unchanged_when_prices_after_max_t1_permuted() -> None:
         proba_per_fold=(proba,),
         scenario=CostScenario.REALISTIC,
     )
-    np.testing.assert_array_equal(
-        after.per_fold[0].net_returns, base.per_fold[0].net_returns
-    )
+    np.testing.assert_array_equal(after.per_fold[0].net_returns, base.per_fold[0].net_returns)
 
 
 def test_pnl_unchanged_when_prices_outside_t0_t1_set_permuted() -> None:
@@ -261,9 +249,7 @@ def test_pnl_unchanged_when_prices_outside_t0_t1_set_permuted() -> None:
     used_idx = set()
     for ts in np.concatenate([t0, t1]):
         used_idx.add(int(np.searchsorted(bars_ts, ts)))
-    free_idx = np.array(
-        [i for i in range(bars.height) if i not in used_idx], dtype=np.int64
-    )
+    free_idx = np.array([i for i in range(bars.height) if i not in used_idx], dtype=np.int64)
 
     rng = np.random.default_rng(123)
     perm_free = rng.permutation(free_idx)
@@ -279,9 +265,7 @@ def test_pnl_unchanged_when_prices_outside_t0_t1_set_permuted() -> None:
         proba_per_fold=(proba,),
         scenario=CostScenario.ZERO,
     )
-    np.testing.assert_array_equal(
-        after.per_fold[0].net_returns, base.per_fold[0].net_returns
-    )
+    np.testing.assert_array_equal(after.per_fold[0].net_returns, base.per_fold[0].net_returns)
 
 
 # --------------------------------------------------------------------
@@ -293,9 +277,7 @@ def test_missing_timestamp_raises_value_error() -> None:
     bars = _make_bars()
     bars_ts = bars["timestamp"].to_numpy().astype("datetime64[us]")
     # Synthesize a timestamp not present in the bar grid.
-    fake_t0 = np.array(
-        [bars_ts[10] + np.timedelta64(13, "m")], dtype="datetime64[us]"
-    )
+    fake_t0 = np.array([bars_ts[10] + np.timedelta64(13, "m")], dtype="datetime64[us]")
     fake_t1 = np.array([bars_ts[15]], dtype="datetime64[us]")
     proba = np.array([0.5], dtype=np.float64)
     with pytest.raises(ValueError, match="exact-matching bar"):
@@ -312,9 +294,7 @@ def test_t1_after_last_bar_raises() -> None:
     bars_ts = bars["timestamp"].to_numpy().astype("datetime64[us]")
     # t1 is one hour past the last bar.
     t0 = np.array([bars_ts[40]], dtype="datetime64[us]")
-    t1 = np.array(
-        [bars_ts[-1] + np.timedelta64(1, "h")], dtype="datetime64[us]"
-    )
+    t1 = np.array([bars_ts[-1] + np.timedelta64(1, "h")], dtype="datetime64[us]")
     proba = np.array([0.5], dtype=np.float64)
     with pytest.raises(ValueError, match="exceeds last bar timestamp"):
         simulate_meta_labeler_pnl(
@@ -399,9 +379,7 @@ def test_non_monotonic_bars_raise() -> None:
     timestamps[5], timestamps[6] = timestamps[6], timestamps[5]
     bad = pl.DataFrame(
         {
-            "timestamp": pl.Series(
-                "timestamp", timestamps, dtype=pl.Datetime("us", "UTC")
-            ),
+            "timestamp": pl.Series("timestamp", timestamps, dtype=pl.Datetime("us", "UTC")),
             "close": pl.Series("close", closes, dtype=pl.Float64),
         }
     )
@@ -423,9 +401,7 @@ def test_non_positive_close_raises() -> None:
     timestamps = bars["timestamp"].to_numpy().astype("datetime64[us]")
     bad = pl.DataFrame(
         {
-            "timestamp": pl.Series(
-                "timestamp", timestamps, dtype=pl.Datetime("us", "UTC")
-            ),
+            "timestamp": pl.Series("timestamp", timestamps, dtype=pl.Datetime("us", "UTC")),
             "close": pl.Series("close", closes, dtype=pl.Float64),
         }
     )
@@ -457,9 +433,7 @@ def test_missing_columns_raise() -> None:
 def test_empty_bars_raise() -> None:
     empty = pl.DataFrame(
         {
-            "timestamp": pl.Series(
-                "timestamp", [], dtype=pl.Datetime("us", "UTC")
-            ),
+            "timestamp": pl.Series("timestamp", [], dtype=pl.Datetime("us", "UTC")),
             "close": pl.Series("close", [], dtype=pl.Float64),
         }
     )

--- a/tests/unit/features/meta_labeler/test_pnl_simulation.py
+++ b/tests/unit/features/meta_labeler/test_pnl_simulation.py
@@ -1,0 +1,475 @@
+"""Unit tests for :mod:`features.meta_labeler.pnl_simulation`.
+
+Coverage target: ≥ 92 % on ``pnl_simulation.py`` per Phase 4.5 audit.
+The two anti-leakage property tests pin the contract that
+``r_i`` depends only on ``(C(t0_i), C(t1_i), p_i)`` - perturbing any
+other bar must leave every per-label P&L untouched.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from features.meta_labeler.pnl_simulation import (
+    CostScenario,
+    FoldPnL,
+    PnLSimulationResult,
+    simulate_meta_labeler_pnl,
+)
+
+# --------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------
+
+
+def _make_bars(n: int = 200, seed: int = 7) -> pl.DataFrame:
+    """Hourly bars over ``2025-01-01`` with a positive geometric walk."""
+    rng = np.random.default_rng(seed)
+    timestamps = np.array(
+        [np.datetime64("2025-01-01") + np.timedelta64(i, "h") for i in range(n)],
+        dtype="datetime64[us]",
+    )
+    log_ret = rng.normal(0.0, 0.005, size=n)
+    log_ret[0] = 0.0
+    close = 100.0 * np.exp(np.cumsum(log_ret))
+    return pl.DataFrame(
+        {
+            "timestamp": pl.Series(
+                "timestamp", timestamps, dtype=pl.Datetime("us", "UTC")
+            ),
+            "close": pl.Series("close", close.astype(np.float64), dtype=pl.Float64),
+        }
+    )
+
+
+def _make_labels(
+    bars: pl.DataFrame,
+    event_indices: list[int],
+    horizon: int = 5,
+) -> tuple[np.ndarray, np.ndarray]:
+    ts = bars["timestamp"].to_numpy().astype("datetime64[us]")
+    t0 = ts[event_indices]
+    t1 = ts[[i + horizon for i in event_indices]]
+    return t0, t1
+
+
+# --------------------------------------------------------------------
+# CostScenario behaviour
+# --------------------------------------------------------------------
+
+
+def test_cost_scenario_per_side_and_round_trip_match_adr_0002_d7() -> None:
+    assert CostScenario.ZERO.per_side_bps == 0.0
+    assert CostScenario.REALISTIC.per_side_bps == 5.0
+    assert CostScenario.STRESS.per_side_bps == 15.0
+    assert CostScenario.ZERO.round_trip_bps == 0.0
+    assert CostScenario.REALISTIC.round_trip_bps == 10.0
+    assert CostScenario.STRESS.round_trip_bps == 30.0
+
+
+def test_cost_scenario_str_value_is_lowercase_name() -> None:
+    # ``str`` mixin makes JSON serialisation trivial.
+    assert CostScenario.REALISTIC.value == "realistic"
+    assert CostScenario.STRESS.value == "stress"
+
+
+# --------------------------------------------------------------------
+# Happy path: bet sizing and cost arithmetic
+# --------------------------------------------------------------------
+
+
+def test_bet_sizing_is_2p_minus_1_in_minus_one_to_plus_one() -> None:
+    bars = _make_bars()
+    t0, t1 = _make_labels(bars, [10, 20, 30])
+    proba = np.array([0.0, 0.5, 1.0], dtype=np.float64)
+    result = simulate_meta_labeler_pnl(
+        bars=bars,
+        t0_per_fold=(t0,),
+        t1_per_fold=(t1,),
+        proba_per_fold=(proba,),
+        scenario=CostScenario.ZERO,
+    )
+    assert result.per_fold[0].bets.tolist() == [-1.0, 0.0, 1.0]
+
+
+def test_zero_cost_gross_equals_net_log_return_times_bet() -> None:
+    bars = _make_bars()
+    t0, t1 = _make_labels(bars, [10, 20, 30])
+    proba = np.array([0.7, 0.3, 0.6], dtype=np.float64)
+    result = simulate_meta_labeler_pnl(
+        bars=bars,
+        t0_per_fold=(t0,),
+        t1_per_fold=(t1,),
+        proba_per_fold=(proba,),
+        scenario=CostScenario.ZERO,
+    )
+    bars_close = bars["close"].to_numpy().astype(np.float64)
+    expected = []
+    bars_ts = bars["timestamp"].to_numpy().astype("datetime64[us]")
+    for i, p in enumerate(proba):
+        i0 = int(np.searchsorted(bars_ts, t0[i]))
+        i1 = int(np.searchsorted(bars_ts, t1[i]))
+        bet = 2 * p - 1
+        expected.append(np.log(bars_close[i1] / bars_close[i0]) * bet)
+    np.testing.assert_allclose(result.per_fold[0].gross_returns, expected)
+    np.testing.assert_allclose(
+        result.per_fold[0].net_returns, result.per_fold[0].gross_returns
+    )
+
+
+def test_realistic_cost_deduction_scales_with_absolute_bet() -> None:
+    """Half-conviction bets pay half cost (ADR-0005 D8)."""
+    bars = _make_bars()
+    t0, t1 = _make_labels(bars, [10, 20, 30, 40])
+    # bets: -1.0, -0.5, +0.5, +1.0
+    proba = np.array([0.0, 0.25, 0.75, 1.0], dtype=np.float64)
+    result = simulate_meta_labeler_pnl(
+        bars=bars,
+        t0_per_fold=(t0,),
+        t1_per_fold=(t1,),
+        proba_per_fold=(proba,),
+        scenario=CostScenario.REALISTIC,
+    )
+    fold = result.per_fold[0]
+    rt_cost = CostScenario.REALISTIC.round_trip_bps / 1e4
+    expected_cost = rt_cost * np.abs(fold.bets)
+    np.testing.assert_allclose(fold.gross_returns - fold.net_returns, expected_cost)
+
+
+def test_stress_scenario_costs_three_times_realistic() -> None:
+    bars = _make_bars()
+    t0, t1 = _make_labels(bars, [10, 20])
+    proba = np.array([0.8, 0.2], dtype=np.float64)
+    base_kwargs = {
+        "t0_per_fold": (t0,),
+        "t1_per_fold": (t1,),
+        "proba_per_fold": (proba,),
+    }
+    realistic = simulate_meta_labeler_pnl(
+        bars=bars, scenario=CostScenario.REALISTIC, **base_kwargs
+    )
+    stress = simulate_meta_labeler_pnl(
+        bars=bars, scenario=CostScenario.STRESS, **base_kwargs
+    )
+    diff_realistic = realistic.per_fold[0].gross_returns - realistic.per_fold[0].net_returns
+    diff_stress = stress.per_fold[0].gross_returns - stress.per_fold[0].net_returns
+    np.testing.assert_allclose(diff_stress, 3.0 * diff_realistic)
+
+
+def test_result_contains_scenario_and_concatenated_returns() -> None:
+    bars = _make_bars()
+    t0_a, t1_a = _make_labels(bars, [10, 20])
+    t0_b, t1_b = _make_labels(bars, [40, 50, 60])
+    proba_a = np.array([0.6, 0.4], dtype=np.float64)
+    proba_b = np.array([0.7, 0.3, 0.55], dtype=np.float64)
+    result = simulate_meta_labeler_pnl(
+        bars=bars,
+        t0_per_fold=(t0_a, t0_b),
+        t1_per_fold=(t1_a, t1_b),
+        proba_per_fold=(proba_a, proba_b),
+        scenario=CostScenario.REALISTIC,
+    )
+    assert isinstance(result, PnLSimulationResult)
+    assert result.scenario == CostScenario.REALISTIC
+    assert result.all_net_returns.shape == (5,)
+    np.testing.assert_array_equal(
+        result.all_net_returns,
+        np.concatenate(
+            [result.per_fold[0].net_returns, result.per_fold[1].net_returns]
+        ),
+    )
+    assert isinstance(result.per_fold[0], FoldPnL)
+    assert result.per_fold[0].fold_index == 0
+    assert result.per_fold[1].fold_index == 1
+
+
+def test_empty_fold_yields_empty_arrays() -> None:
+    bars = _make_bars()
+    empty_t = np.empty(0, dtype="datetime64[us]")
+    empty_p = np.empty(0, dtype=np.float64)
+    result = simulate_meta_labeler_pnl(
+        bars=bars,
+        t0_per_fold=(empty_t,),
+        t1_per_fold=(empty_t,),
+        proba_per_fold=(empty_p,),
+        scenario=CostScenario.REALISTIC,
+    )
+    assert result.per_fold[0].net_returns.size == 0
+    assert result.all_net_returns.size == 0
+
+
+# --------------------------------------------------------------------
+# Anti-leakage property tests (Phase 4.5 audit §5)
+# --------------------------------------------------------------------
+
+
+def test_pnl_unchanged_when_prices_after_max_t1_permuted() -> None:
+    """Permuting closes strictly after ``max(t1)`` must not move any r_i."""
+    bars = _make_bars(n=200)
+    t0, t1 = _make_labels(bars, [10, 30, 50, 70])
+    proba = np.array([0.6, 0.3, 0.55, 0.8], dtype=np.float64)
+
+    base = simulate_meta_labeler_pnl(
+        bars=bars,
+        t0_per_fold=(t0,),
+        t1_per_fold=(t1,),
+        proba_per_fold=(proba,),
+        scenario=CostScenario.REALISTIC,
+    )
+
+    rng = np.random.default_rng(99)
+    bars_ts = bars["timestamp"].to_numpy().astype("datetime64[us]")
+    cutoff = int(np.searchsorted(bars_ts, np.max(t1), side="right"))
+    perm = np.arange(bars.height)
+    perm[cutoff:] = rng.permutation(perm[cutoff:])
+    closes = bars["close"].to_numpy()
+    permuted = bars.with_columns(pl.Series("close", closes[perm]))
+
+    after = simulate_meta_labeler_pnl(
+        bars=permuted,
+        t0_per_fold=(t0,),
+        t1_per_fold=(t1,),
+        proba_per_fold=(proba,),
+        scenario=CostScenario.REALISTIC,
+    )
+    np.testing.assert_array_equal(
+        after.per_fold[0].net_returns, base.per_fold[0].net_returns
+    )
+
+
+def test_pnl_unchanged_when_prices_outside_t0_t1_set_permuted() -> None:
+    """Permuting closes strictly outside ``U{t0_i, t1_i}`` is invisible.
+
+    This is the strict-leakage invariant: ``r_i`` must depend only on
+    ``(C(t0_i), C(t1_i), p_i)``, never on any other bar in the series.
+    """
+    bars = _make_bars(n=200)
+    t0, t1 = _make_labels(bars, [10, 30, 50, 70])
+    proba = np.array([0.4, 0.7, 0.55, 0.65], dtype=np.float64)
+
+    base = simulate_meta_labeler_pnl(
+        bars=bars,
+        t0_per_fold=(t0,),
+        t1_per_fold=(t1,),
+        proba_per_fold=(proba,),
+        scenario=CostScenario.ZERO,
+    )
+
+    bars_ts = bars["timestamp"].to_numpy().astype("datetime64[us]")
+    used_idx = set()
+    for ts in np.concatenate([t0, t1]):
+        used_idx.add(int(np.searchsorted(bars_ts, ts)))
+    free_idx = np.array(
+        [i for i in range(bars.height) if i not in used_idx], dtype=np.int64
+    )
+
+    rng = np.random.default_rng(123)
+    perm_free = rng.permutation(free_idx)
+    new_perm = np.arange(bars.height)
+    new_perm[free_idx] = perm_free
+    closes = bars["close"].to_numpy()
+    permuted = bars.with_columns(pl.Series("close", closes[new_perm]))
+
+    after = simulate_meta_labeler_pnl(
+        bars=permuted,
+        t0_per_fold=(t0,),
+        t1_per_fold=(t1,),
+        proba_per_fold=(proba,),
+        scenario=CostScenario.ZERO,
+    )
+    np.testing.assert_array_equal(
+        after.per_fold[0].net_returns, base.per_fold[0].net_returns
+    )
+
+
+# --------------------------------------------------------------------
+# Fail-loud validation
+# --------------------------------------------------------------------
+
+
+def test_missing_timestamp_raises_value_error() -> None:
+    bars = _make_bars()
+    bars_ts = bars["timestamp"].to_numpy().astype("datetime64[us]")
+    # Synthesize a timestamp not present in the bar grid.
+    fake_t0 = np.array(
+        [bars_ts[10] + np.timedelta64(13, "m")], dtype="datetime64[us]"
+    )
+    fake_t1 = np.array([bars_ts[15]], dtype="datetime64[us]")
+    proba = np.array([0.5], dtype=np.float64)
+    with pytest.raises(ValueError, match="exact-matching bar"):
+        simulate_meta_labeler_pnl(
+            bars=bars,
+            t0_per_fold=(fake_t0,),
+            t1_per_fold=(fake_t1,),
+            proba_per_fold=(proba,),
+        )
+
+
+def test_t1_after_last_bar_raises() -> None:
+    bars = _make_bars(n=50)
+    bars_ts = bars["timestamp"].to_numpy().astype("datetime64[us]")
+    # t1 is one hour past the last bar.
+    t0 = np.array([bars_ts[40]], dtype="datetime64[us]")
+    t1 = np.array(
+        [bars_ts[-1] + np.timedelta64(1, "h")], dtype="datetime64[us]"
+    )
+    proba = np.array([0.5], dtype=np.float64)
+    with pytest.raises(ValueError, match="exceeds last bar timestamp"):
+        simulate_meta_labeler_pnl(
+            bars=bars,
+            t0_per_fold=(t0,),
+            t1_per_fold=(t1,),
+            proba_per_fold=(proba,),
+        )
+
+
+def test_proba_outside_unit_interval_raises() -> None:
+    bars = _make_bars()
+    t0, t1 = _make_labels(bars, [10])
+    bad_proba = np.array([1.5], dtype=np.float64)
+    with pytest.raises(ValueError, match=r"proba must lie in \[0, 1\]"):
+        simulate_meta_labeler_pnl(
+            bars=bars,
+            t0_per_fold=(t0,),
+            t1_per_fold=(t1,),
+            proba_per_fold=(bad_proba,),
+        )
+
+
+def test_non_finite_proba_raises() -> None:
+    bars = _make_bars()
+    t0, t1 = _make_labels(bars, [10])
+    bad_proba = np.array([np.nan], dtype=np.float64)
+    with pytest.raises(ValueError, match="non-finite"):
+        simulate_meta_labeler_pnl(
+            bars=bars,
+            t0_per_fold=(t0,),
+            t1_per_fold=(t1,),
+            proba_per_fold=(bad_proba,),
+        )
+
+
+def test_t1_before_t0_raises() -> None:
+    bars = _make_bars()
+    bars_ts = bars["timestamp"].to_numpy().astype("datetime64[us]")
+    t0 = np.array([bars_ts[20]], dtype="datetime64[us]")
+    t1 = np.array([bars_ts[10]], dtype="datetime64[us]")
+    proba = np.array([0.5], dtype=np.float64)
+    with pytest.raises(ValueError, match="t1_i must be >= t0_i"):
+        simulate_meta_labeler_pnl(
+            bars=bars,
+            t0_per_fold=(t0,),
+            t1_per_fold=(t1,),
+            proba_per_fold=(proba,),
+        )
+
+
+def test_per_fold_shape_disagreement_raises() -> None:
+    bars = _make_bars()
+    t0, t1 = _make_labels(bars, [10, 20, 30])
+    proba = np.array([0.5, 0.5], dtype=np.float64)  # length 2 vs 3
+    with pytest.raises(ValueError, match="t0/t1/proba shapes disagree"):
+        simulate_meta_labeler_pnl(
+            bars=bars,
+            t0_per_fold=(t0,),
+            t1_per_fold=(t1,),
+            proba_per_fold=(proba,),
+        )
+
+
+def test_per_fold_tuple_length_mismatch_raises() -> None:
+    bars = _make_bars()
+    t0, t1 = _make_labels(bars, [10])
+    proba = np.array([0.5], dtype=np.float64)
+    with pytest.raises(ValueError, match="per-fold tuples must have the same length"):
+        simulate_meta_labeler_pnl(
+            bars=bars,
+            t0_per_fold=(t0, t0),
+            t1_per_fold=(t1,),
+            proba_per_fold=(proba,),
+        )
+
+
+def test_non_monotonic_bars_raise() -> None:
+    bars = _make_bars()
+    closes = bars["close"].to_numpy()
+    timestamps = bars["timestamp"].to_numpy().astype("datetime64[us]")
+    timestamps[5], timestamps[6] = timestamps[6], timestamps[5]
+    bad = pl.DataFrame(
+        {
+            "timestamp": pl.Series(
+                "timestamp", timestamps, dtype=pl.Datetime("us", "UTC")
+            ),
+            "close": pl.Series("close", closes, dtype=pl.Float64),
+        }
+    )
+    t0, t1 = _make_labels(bars, [10])
+    proba = np.array([0.5], dtype=np.float64)
+    with pytest.raises(ValueError, match="strictly monotonic"):
+        simulate_meta_labeler_pnl(
+            bars=bad,
+            t0_per_fold=(t0,),
+            t1_per_fold=(t1,),
+            proba_per_fold=(proba,),
+        )
+
+
+def test_non_positive_close_raises() -> None:
+    bars = _make_bars()
+    closes = bars["close"].to_numpy()
+    closes[42] = 0.0
+    timestamps = bars["timestamp"].to_numpy().astype("datetime64[us]")
+    bad = pl.DataFrame(
+        {
+            "timestamp": pl.Series(
+                "timestamp", timestamps, dtype=pl.Datetime("us", "UTC")
+            ),
+            "close": pl.Series("close", closes, dtype=pl.Float64),
+        }
+    )
+    t0, t1 = _make_labels(bars, [10])
+    proba = np.array([0.5], dtype=np.float64)
+    with pytest.raises(ValueError, match="strictly positive"):
+        simulate_meta_labeler_pnl(
+            bars=bad,
+            t0_per_fold=(t0,),
+            t1_per_fold=(t1,),
+            proba_per_fold=(proba,),
+        )
+
+
+def test_missing_columns_raise() -> None:
+    bars = pl.DataFrame({"ts": [1], "px": [100.0]})
+    t0 = np.array([np.datetime64("2025-01-01")], dtype="datetime64[us]")
+    t1 = np.array([np.datetime64("2025-01-01T05")], dtype="datetime64[us]")
+    proba = np.array([0.5], dtype=np.float64)
+    with pytest.raises(ValueError, match="must contain columns"):
+        simulate_meta_labeler_pnl(
+            bars=bars,
+            t0_per_fold=(t0,),
+            t1_per_fold=(t1,),
+            proba_per_fold=(proba,),
+        )
+
+
+def test_empty_bars_raise() -> None:
+    empty = pl.DataFrame(
+        {
+            "timestamp": pl.Series(
+                "timestamp", [], dtype=pl.Datetime("us", "UTC")
+            ),
+            "close": pl.Series("close", [], dtype=pl.Float64),
+        }
+    )
+    t0 = np.array([np.datetime64("2025-01-01")], dtype="datetime64[us]")
+    t1 = np.array([np.datetime64("2025-01-01T05")], dtype="datetime64[us]")
+    proba = np.array([0.5], dtype=np.float64)
+    with pytest.raises(ValueError, match="bars is empty"):
+        simulate_meta_labeler_pnl(
+            bars=empty,
+            t0_per_fold=(t0,),
+            t1_per_fold=(t1,),
+            proba_per_fold=(proba,),
+        )

--- a/tests/unit/features/meta_labeler/test_pnl_simulation.py
+++ b/tests/unit/features/meta_labeler/test_pnl_simulation.py
@@ -374,8 +374,8 @@ def test_per_fold_tuple_length_mismatch_raises() -> None:
 
 def test_non_monotonic_bars_raise() -> None:
     bars = _make_bars()
-    closes = bars["close"].to_numpy()
-    timestamps = bars["timestamp"].to_numpy().astype("datetime64[us]")
+    closes = bars["close"].to_numpy().copy()
+    timestamps = bars["timestamp"].to_numpy().astype("datetime64[us]").copy()
     timestamps[5], timestamps[6] = timestamps[6], timestamps[5]
     bad = pl.DataFrame(
         {
@@ -396,7 +396,9 @@ def test_non_monotonic_bars_raise() -> None:
 
 def test_non_positive_close_raises() -> None:
     bars = _make_bars()
-    closes = bars["close"].to_numpy()
+    # Polars >= 1.x returns read-only numpy views from ``to_numpy()`` when
+    # the column is contiguous; force a writable copy before mutating.
+    closes = bars["close"].to_numpy().copy()
     closes[42] = 0.0
     timestamps = bars["timestamp"].to_numpy().astype("datetime64[us]")
     bad = pl.DataFrame(

--- a/tests/unit/features/meta_labeler/test_validation_gates.py
+++ b/tests/unit/features/meta_labeler/test_validation_gates.py
@@ -1,0 +1,500 @@
+"""Unit tests for :mod:`features.meta_labeler.validation`.
+
+Coverage target: ≥ 92 % on ``validation.py``.
+
+The bulk of the suite is gate-by-gate (G1..G7) pass/fail logic plus the
+fail-loud contract on missing evidence. End-to-end tests run the full
+4.3 → 4.4 → 4.5 pipeline on a small synthetic dataset so the wiring
+between the validator and the existing DSR / PBO calculators is
+exercised under realistic shapes (≤ 60 s on a single core).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import numpy as np
+import polars as pl
+import pytest
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+
+from features.cv.cpcv import CombinatoriallyPurgedKFold
+from features.meta_labeler.baseline import (
+    BaselineMetaLabeler,
+    BaselineTrainingResult,
+)
+from features.meta_labeler.feature_builder import FEATURE_NAMES, MetaLabelerFeatureSet
+from features.meta_labeler.pnl_simulation import CostScenario
+from features.meta_labeler.tuning import (
+    NestedCPCVTuner,
+    TuningResult,
+    TuningSearchSpace,
+)
+from features.meta_labeler.validation import (
+    GateResult,
+    MetaLabelerValidationReport,
+    MetaLabelerValidator,
+)
+
+# --------------------------------------------------------------------
+# Helpers / fixtures
+# --------------------------------------------------------------------
+
+
+def _baseline_result(
+    *,
+    rf_aucs: tuple[float, ...] = (0.60, 0.62, 0.58, 0.61, 0.59, 0.63),
+    logreg_aucs: tuple[float, ...] | None = (0.55, 0.56, 0.54, 0.55, 0.55, 0.56),
+    rf_briers: tuple[float, ...] | None = None,
+) -> BaselineTrainingResult:
+    """Construct a synthetic BaselineTrainingResult for gate tests.
+
+    The dummy RF / LogReg models are unfitted; gate logic only reads
+    ``*_per_fold`` so the actual estimators are irrelevant.
+    """
+    if rf_briers is None:
+        rf_briers = tuple([0.20] * len(rf_aucs))
+    if logreg_aucs is None:
+        logreg_aucs = ()
+    return BaselineTrainingResult(
+        rf_model=RandomForestClassifier(),
+        logreg_model=LogisticRegression(),
+        rf_auc_per_fold=rf_aucs,
+        logreg_auc_per_fold=logreg_aucs,
+        rf_brier_per_fold=rf_briers,
+        rf_calibration_bins=((0.5, 0.5),),
+        feature_importances={name: 1.0 / len(FEATURE_NAMES) for name in FEATURE_NAMES},
+    )
+
+
+def _trial_grid(n_outer: int, oos_lift: float = 0.05) -> TuningResult:
+    """Trial ledger with a clear winner across folds.
+
+    Two distinct hparam dicts (``A`` and ``B``) - the minimum
+    cardinality for PBO. ``B`` always beats ``A`` by ``oos_lift`` so
+    PBO is 0.0 (no overfitting).
+    """
+    grid = [
+        {"n_estimators": 30, "max_depth": 3, "min_samples_leaf": 5},
+        {"n_estimators": 60, "max_depth": 5, "min_samples_leaf": 5},
+    ]
+    trials: list[tuple[dict[str, Any], float, float]] = []
+    for outer in range(n_outer):
+        for k, hp in enumerate(grid):
+            inner = 0.55 + 0.01 * outer + 0.005 * k
+            oos = 0.55 + 0.01 * outer + oos_lift * k
+            trials.append((dict(hp), float(inner), float(oos)))
+    best = tuple(grid[1] for _ in range(n_outer))
+    return TuningResult(
+        best_hyperparameters_per_fold=best,
+        best_oos_auc_per_fold=tuple(0.55 + 0.01 * o + oos_lift for o in range(n_outer)),
+        all_trials=tuple(trials),
+        stability_index=1.0,
+        wall_clock_seconds=0.1,
+    )
+
+
+def _synthetic_dataset(
+    n: int = 200, seed: int = 42
+) -> tuple[
+    MetaLabelerFeatureSet,
+    np.ndarray,
+    np.ndarray,
+    pl.DataFrame,
+]:
+    """Synthetic features + bars covering [min(t0), max(t1)]."""
+    rng = np.random.default_rng(seed)
+    x = rng.normal(0.0, 1.0, size=(n, len(FEATURE_NAMES))).astype(np.float64)
+    x[:, 3] = rng.integers(0, 4, size=n).astype(np.float64)
+    x[:, 4] = rng.integers(-1, 2, size=n).astype(np.float64)
+    x[:, 5] = np.abs(rng.normal(0.01, 0.002, size=n))
+    logit = 1.5 * x[:, 2]
+    probs = 1.0 / (1.0 + np.exp(-logit))
+    y = (rng.uniform(0, 1, size=n) < probs).astype(np.int_)
+    t0 = np.array(
+        [np.datetime64("2025-01-01") + np.timedelta64(i, "h") for i in range(n)],
+        dtype="datetime64[us]",
+    )
+    t1 = (t0 + np.timedelta64(5, "h")).astype("datetime64[us]")
+    fs = MetaLabelerFeatureSet(X=x, feature_names=FEATURE_NAMES, t0=t0, t1=t1)
+    w = np.ones(n, dtype=np.float64)
+
+    span = int(((t1.max() - t0.min())).astype("timedelta64[h]").astype(np.int64)) + 1
+    timestamps = np.array(
+        [t0.min() + np.timedelta64(i, "h") for i in range(span)],
+        dtype="datetime64[us]",
+    )
+    drift = np.zeros(span, dtype=np.float64)
+    bar_idx = np.searchsorted(timestamps, t0, side="left")
+    drift[bar_idx] = 0.001 * x[:, 2]
+    noise = rng.normal(0.0, 0.0015, size=span)
+    log_returns = drift + noise
+    log_returns[0] = 0.0
+    close = 100.0 * np.exp(np.cumsum(log_returns))
+    bars = pl.DataFrame(
+        {
+            "timestamp": pl.Series(
+                "timestamp", timestamps, dtype=pl.Datetime("us", "UTC")
+            ),
+            "close": pl.Series("close", close.astype(np.float64), dtype=pl.Float64),
+        }
+    )
+    return fs, y, w, bars
+
+
+@pytest.fixture
+def cpcv() -> CombinatoriallyPurgedKFold:
+    # C(4, 2) = 6 outer folds - small for fast tests.
+    return CombinatoriallyPurgedKFold(n_splits=4, n_test_splits=2, embargo_pct=0.0)
+
+
+# --------------------------------------------------------------------
+# G1 - mean OOS AUC ≥ 0.55
+# --------------------------------------------------------------------
+
+
+def test_g1_pass_when_mean_auc_above_0p55(cpcv: CombinatoriallyPurgedKFold) -> None:
+    g1 = MetaLabelerValidator._gate_g1(np.array([0.60, 0.61, 0.59]))
+    assert g1.name == "G1_mean_auc"
+    assert g1.threshold == pytest.approx(0.55)
+    assert g1.passed is True
+
+
+def test_g1_fail_when_mean_auc_below_0p55() -> None:
+    g1 = MetaLabelerValidator._gate_g1(np.array([0.50, 0.51, 0.52]))
+    assert g1.passed is False
+
+
+def test_g1_boundary_at_exactly_0p55_passes() -> None:
+    g1 = MetaLabelerValidator._gate_g1(np.array([0.55, 0.55, 0.55]))
+    assert g1.passed is True
+
+
+# --------------------------------------------------------------------
+# G2 - min OOS AUC ≥ 0.52
+# --------------------------------------------------------------------
+
+
+def test_g2_pass_when_min_auc_above_0p52() -> None:
+    g2 = MetaLabelerValidator._gate_g2(np.array([0.60, 0.55, 0.53]))
+    assert g2.name == "G2_min_auc"
+    assert g2.value == pytest.approx(0.53)
+    assert g2.passed is True
+
+
+def test_g2_fail_when_any_fold_below_0p52() -> None:
+    g2 = MetaLabelerValidator._gate_g2(np.array([0.60, 0.51, 0.55]))
+    assert g2.passed is False
+
+
+# --------------------------------------------------------------------
+# G4 - PBO < 0.10
+# --------------------------------------------------------------------
+
+
+def test_g4_pass_when_oos_winner_matches_inner_winner() -> None:
+    tuning = _trial_grid(n_outer=4, oos_lift=0.05)
+    g4, pbo = MetaLabelerValidator._gate_g4(tuning)
+    assert g4.name == "G4_pbo"
+    assert g4.threshold == pytest.approx(0.10)
+    assert g4.passed is True
+    assert pbo < 0.10
+
+
+def test_g4_fail_when_trial_ledger_is_empty() -> None:
+    empty = TuningResult(
+        best_hyperparameters_per_fold=(),
+        best_oos_auc_per_fold=(),
+        all_trials=(),
+        stability_index=0.0,
+        wall_clock_seconds=0.0,
+    )
+    with pytest.raises(ValueError, match="all_trials is empty"):
+        MetaLabelerValidator._gate_g4(empty)
+
+
+def test_g4_fail_when_only_one_distinct_trial_id() -> None:
+    hp = {"n_estimators": 30, "max_depth": 3, "min_samples_leaf": 5}
+    trials = tuple(
+        (dict(hp), 0.55 + 0.01 * o, 0.55 + 0.01 * o) for o in range(4)
+    )
+    tuning = TuningResult(
+        best_hyperparameters_per_fold=tuple(dict(hp) for _ in range(4)),
+        best_oos_auc_per_fold=tuple(0.55 + 0.01 * o for o in range(4)),
+        all_trials=trials,
+        stability_index=1.0,
+        wall_clock_seconds=0.0,
+    )
+    with pytest.raises(ValueError, match="at least 2 distinct"):
+        MetaLabelerValidator._gate_g4(tuning)
+
+
+# --------------------------------------------------------------------
+# G5 - Brier ≤ 0.25
+# --------------------------------------------------------------------
+
+
+def test_g5_pass_when_mean_brier_at_or_below_0p25() -> None:
+    g5 = MetaLabelerValidator._gate_g5(np.array([0.20, 0.22, 0.18]))
+    assert g5.name == "G5_brier"
+    assert g5.passed is True
+
+
+def test_g5_fail_when_mean_brier_above_0p25() -> None:
+    g5 = MetaLabelerValidator._gate_g5(np.array([0.30, 0.28, 0.27]))
+    assert g5.passed is False
+
+
+def test_g5_boundary_at_exactly_0p25_passes() -> None:
+    g5 = MetaLabelerValidator._gate_g5(np.array([0.25, 0.25, 0.25]))
+    assert g5.passed is True
+
+
+# --------------------------------------------------------------------
+# G6 - minority frequency three-state
+# --------------------------------------------------------------------
+
+
+def test_g6_pass_when_minority_above_0p10() -> None:
+    y = np.array([0] * 70 + [1] * 30, dtype=np.int_)  # 30% minority
+    g6 = MetaLabelerValidator._gate_g6(y)
+    assert g6.name == "G6_minority_freq"
+    assert g6.value == pytest.approx(0.30)
+    assert g6.passed is True
+
+
+def test_g6_warn_state_still_passes() -> None:
+    """5 % ≤ freq < 10 % is a warn but still passes."""
+    y = np.array([0] * 92 + [1] * 8, dtype=np.int_)  # 8% minority
+    g6 = MetaLabelerValidator._gate_g6(y)
+    assert g6.passed is True
+    assert g6.value == pytest.approx(0.08)
+
+
+def test_g6_reject_state_fails() -> None:
+    y = np.array([0] * 97 + [1] * 3, dtype=np.int_)  # 3% minority
+    g6 = MetaLabelerValidator._gate_g6(y)
+    assert g6.passed is False
+
+
+# --------------------------------------------------------------------
+# G7 - RF − LogReg mean AUC ≥ 0.03
+# --------------------------------------------------------------------
+
+
+def test_g7_pass_when_rf_beats_logreg_by_at_least_0p03() -> None:
+    g7 = MetaLabelerValidator._gate_g7(
+        np.array([0.60, 0.62, 0.61]),
+        np.array([0.55, 0.56, 0.55]),
+    )
+    assert g7.name == "G7_rf_minus_logreg"
+    assert g7.value == pytest.approx(0.61 - 0.5533333, rel=1e-3)
+    assert g7.passed is True
+
+
+def test_g7_fail_when_rf_only_marginally_better() -> None:
+    g7 = MetaLabelerValidator._gate_g7(
+        np.array([0.60, 0.61, 0.60]),
+        np.array([0.59, 0.60, 0.59]),
+    )
+    assert g7.passed is False
+
+
+def test_g7_fails_when_logreg_baseline_missing(
+    cpcv: CombinatoriallyPurgedKFold,
+) -> None:
+    """ADR-0005 D5 G7 footnote forbids silent pass on missing baseline."""
+    fs, y, w, bars = _synthetic_dataset(n=80, seed=0)
+    training = _baseline_result(logreg_aucs=())
+    tuning = _trial_grid(n_outer=cpcv.get_n_splits())
+    validator = MetaLabelerValidator(cpcv=cpcv, seed=42)
+    with pytest.raises(ValueError, match="logreg_auc_per_fold"):
+        validator.validate(training, tuning, fs, y, w, bars)
+
+
+# --------------------------------------------------------------------
+# Validator.__init__ + input validation
+# --------------------------------------------------------------------
+
+
+def test_validator_default_scenario_is_realistic(
+    cpcv: CombinatoriallyPurgedKFold,
+) -> None:
+    v = MetaLabelerValidator(cpcv=cpcv)
+    # Use dataclasses.asdict / attribute access; private but stable.
+    assert v._scenario == CostScenario.REALISTIC
+
+
+def test_validate_rejects_empty_rf_auc_per_fold(
+    cpcv: CombinatoriallyPurgedKFold,
+) -> None:
+    fs, y, w, bars = _synthetic_dataset(n=80, seed=0)
+    training = _baseline_result(rf_aucs=(), logreg_aucs=(), rf_briers=())
+    tuning = _trial_grid(n_outer=cpcv.get_n_splits())
+    validator = MetaLabelerValidator(cpcv=cpcv, seed=42)
+    with pytest.raises(ValueError, match="rf_auc_per_fold is empty"):
+        validator.validate(training, tuning, fs, y, w, bars)
+
+
+def test_validate_rejects_length_mismatch_rf_logreg(
+    cpcv: CombinatoriallyPurgedKFold,
+) -> None:
+    fs, y, w, bars = _synthetic_dataset(n=80, seed=0)
+    training = _baseline_result(
+        rf_aucs=(0.6, 0.6, 0.6),
+        logreg_aucs=(0.55, 0.55),
+        rf_briers=(0.2, 0.2, 0.2),
+    )
+    tuning = _trial_grid(n_outer=cpcv.get_n_splits())
+    validator = MetaLabelerValidator(cpcv=cpcv, seed=42)
+    with pytest.raises(ValueError, match="must have the same"):
+        validator.validate(training, tuning, fs, y, w, bars)
+
+
+def test_validate_rejects_y_length_mismatch(
+    cpcv: CombinatoriallyPurgedKFold,
+) -> None:
+    fs, y, w, bars = _synthetic_dataset(n=80, seed=0)
+    training = _baseline_result()
+    tuning = _trial_grid(n_outer=cpcv.get_n_splits())
+    validator = MetaLabelerValidator(cpcv=cpcv, seed=42)
+    bad_y = y[:-1]
+    with pytest.raises(ValueError, match="y has"):
+        validator.validate(training, tuning, fs, bad_y, w, bars)
+
+
+def test_validate_rejects_sample_weight_length_mismatch(
+    cpcv: CombinatoriallyPurgedKFold,
+) -> None:
+    fs, y, w, bars = _synthetic_dataset(n=80, seed=0)
+    training = _baseline_result()
+    tuning = _trial_grid(n_outer=cpcv.get_n_splits())
+    validator = MetaLabelerValidator(cpcv=cpcv, seed=42)
+    bad_w = w[:-1]
+    with pytest.raises(ValueError, match="sample_weights has"):
+        validator.validate(training, tuning, fs, y, bad_w, bars)
+
+
+def test_validate_rejects_empty_best_hyperparameters(
+    cpcv: CombinatoriallyPurgedKFold,
+) -> None:
+    fs, y, w, bars = _synthetic_dataset(n=80, seed=0)
+    training = _baseline_result()
+    tuning = TuningResult(
+        best_hyperparameters_per_fold=(),
+        best_oos_auc_per_fold=(),
+        all_trials=(({"n_estimators": 30, "max_depth": 3, "min_samples_leaf": 5}, 0.6, 0.6),) * 2,
+        stability_index=0.0,
+        wall_clock_seconds=0.0,
+    )
+    validator = MetaLabelerValidator(cpcv=cpcv, seed=42)
+    with pytest.raises(ValueError, match="best_hyperparameters_per_fold is empty"):
+        validator.validate(training, tuning, fs, y, w, bars)
+
+
+# --------------------------------------------------------------------
+# End-to-end happy path: small 4.3 → 4.4 → 4.5 pipeline
+# --------------------------------------------------------------------
+
+
+def test_end_to_end_validation_returns_report_with_seven_gates(
+    cpcv: CombinatoriallyPurgedKFold,
+) -> None:
+    fs, y, w, bars = _synthetic_dataset(n=160, seed=42)
+
+    baseline = BaselineMetaLabeler(cpcv=cpcv, seed=42)
+    training_result = baseline.train(fs, y, w)
+
+    tuner = NestedCPCVTuner(
+        search_space=TuningSearchSpace(
+            n_estimators=(30, 60),
+            max_depth=(3, 5),
+            min_samples_leaf=(5, 10),
+        ),
+        outer_cpcv=cpcv,
+        inner_cpcv=CombinatoriallyPurgedKFold(
+            n_splits=3, n_test_splits=1, embargo_pct=0.0
+        ),
+        seed=42,
+    )
+    tuning_result = tuner.tune(fs, y, w)
+
+    validator = MetaLabelerValidator(
+        cpcv=cpcv, cost_scenario=CostScenario.REALISTIC, seed=42
+    )
+    report = validator.validate(training_result, tuning_result, fs, y, w, bars)
+
+    assert isinstance(report, MetaLabelerValidationReport)
+    assert len(report.gates) == 7
+    names = [g.name for g in report.gates]
+    assert names == [
+        "G1_mean_auc",
+        "G2_min_auc",
+        "G3_dsr",
+        "G4_pbo",
+        "G5_brier",
+        "G6_minority_freq",
+        "G7_rf_minus_logreg",
+    ]
+    # ``all_passed`` and ``failing_gate_names`` must be self-consistent.
+    expected_failing = tuple(g.name for g in report.gates if not g.passed)
+    assert report.failing_gate_names == expected_failing
+    assert report.all_passed == (len(expected_failing) == 0)
+    assert report.scenario_realistic_round_trip_bps == pytest.approx(10.0)
+
+
+def test_end_to_end_failing_gates_listed_in_canonical_order(
+    cpcv: CombinatoriallyPurgedKFold,
+) -> None:
+    """Manufacture failures in G1, G5, G7 - failing_gate_names must keep G1→G7 order."""
+    fs, y, w, bars = _synthetic_dataset(n=160, seed=42)
+
+    baseline = BaselineMetaLabeler(cpcv=cpcv, seed=42)
+    training_result = baseline.train(fs, y, w)
+    # Force G1 fail (mean < 0.55), G5 fail (Brier > 0.25), G7 fail
+    # (RF − LogReg < 0.03) by overriding the per-fold tuples.
+    tampered = dataclasses.replace(
+        training_result,
+        rf_auc_per_fold=tuple([0.51] * len(training_result.rf_auc_per_fold)),
+        logreg_auc_per_fold=tuple(
+            [0.50] * len(training_result.logreg_auc_per_fold)
+        ),
+        rf_brier_per_fold=tuple([0.30] * len(training_result.rf_brier_per_fold)),
+    )
+
+    tuner = NestedCPCVTuner(
+        search_space=TuningSearchSpace(
+            n_estimators=(30, 60),
+            max_depth=(3, 5),
+            min_samples_leaf=(5, 10),
+        ),
+        outer_cpcv=cpcv,
+        inner_cpcv=CombinatoriallyPurgedKFold(
+            n_splits=3, n_test_splits=1, embargo_pct=0.0
+        ),
+        seed=42,
+    )
+    tuning_result = tuner.tune(fs, y, w)
+
+    validator = MetaLabelerValidator(cpcv=cpcv, seed=42)
+    report = validator.validate(tampered, tuning_result, fs, y, w, bars)
+
+    failing = list(report.failing_gate_names)
+    # Canonical G1→G7 ordering must be preserved.
+    canonical = ["G1_mean_auc", "G5_brier", "G7_rf_minus_logreg"]
+    assert all(name in failing for name in canonical)
+    found_indices = [failing.index(n) for n in canonical]
+    assert found_indices == sorted(found_indices)
+
+
+# --------------------------------------------------------------------
+# GateResult shape contract
+# --------------------------------------------------------------------
+
+
+def test_gate_result_is_frozen_dataclass() -> None:
+    g = GateResult(name="G1_mean_auc", value=0.6, threshold=0.55, passed=True)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        g.value = 0.0  # type: ignore[misc]

--- a/tests/unit/features/meta_labeler/test_validation_gates.py
+++ b/tests/unit/features/meta_labeler/test_validation_gates.py
@@ -121,7 +121,7 @@ def _synthetic_dataset(
     fs = MetaLabelerFeatureSet(X=x, feature_names=FEATURE_NAMES, t0=t0, t1=t1)
     w = np.ones(n, dtype=np.float64)
 
-    span = int(((t1.max() - t0.min())).astype("timedelta64[h]").astype(np.int64)) + 1
+    span = int((t1.max() - t0.min()).astype("timedelta64[h]").astype(np.int64)) + 1
     timestamps = np.array(
         [t0.min() + np.timedelta64(i, "h") for i in range(span)],
         dtype="datetime64[us]",
@@ -135,9 +135,7 @@ def _synthetic_dataset(
     close = 100.0 * np.exp(np.cumsum(log_returns))
     bars = pl.DataFrame(
         {
-            "timestamp": pl.Series(
-                "timestamp", timestamps, dtype=pl.Datetime("us", "UTC")
-            ),
+            "timestamp": pl.Series("timestamp", timestamps, dtype=pl.Datetime("us", "UTC")),
             "close": pl.Series("close", close.astype(np.float64), dtype=pl.Float64),
         }
     )
@@ -217,9 +215,7 @@ def test_g4_fail_when_trial_ledger_is_empty() -> None:
 
 def test_g4_fail_when_only_one_distinct_trial_id() -> None:
     hp = {"n_estimators": 30, "max_depth": 3, "min_samples_leaf": 5}
-    trials = tuple(
-        (dict(hp), 0.55 + 0.01 * o, 0.55 + 0.01 * o) for o in range(4)
-    )
+    trials = tuple((dict(hp), 0.55 + 0.01 * o, 0.55 + 0.01 * o) for o in range(4))
     tuning = TuningResult(
         best_hyperparameters_per_fold=tuple(dict(hp) for _ in range(4)),
         best_oos_auc_per_fold=tuple(0.55 + 0.01 * o for o in range(4)),
@@ -327,6 +323,16 @@ def test_validator_default_scenario_is_realistic(
     assert v._scenario == CostScenario.REALISTIC
 
 
+@pytest.mark.parametrize("bad_scenario", [CostScenario.ZERO, CostScenario.STRESS])
+def test_validator_rejects_non_realistic_scenario(
+    cpcv: CombinatoriallyPurgedKFold,
+    bad_scenario: CostScenario,
+) -> None:
+    """ADR-0005 D8: only REALISTIC may feed the G3 DSR gate."""
+    with pytest.raises(ValueError, match=r"only accepts CostScenario\.REALISTIC"):
+        MetaLabelerValidator(cpcv=cpcv, cost_scenario=bad_scenario)
+
+
 def test_validate_rejects_empty_rf_auc_per_fold(
     cpcv: CombinatoriallyPurgedKFold,
 ) -> None:
@@ -414,16 +420,12 @@ def test_end_to_end_validation_returns_report_with_seven_gates(
             min_samples_leaf=(5, 10),
         ),
         outer_cpcv=cpcv,
-        inner_cpcv=CombinatoriallyPurgedKFold(
-            n_splits=3, n_test_splits=1, embargo_pct=0.0
-        ),
+        inner_cpcv=CombinatoriallyPurgedKFold(n_splits=3, n_test_splits=1, embargo_pct=0.0),
         seed=42,
     )
     tuning_result = tuner.tune(fs, y, w)
 
-    validator = MetaLabelerValidator(
-        cpcv=cpcv, cost_scenario=CostScenario.REALISTIC, seed=42
-    )
+    validator = MetaLabelerValidator(cpcv=cpcv, cost_scenario=CostScenario.REALISTIC, seed=42)
     report = validator.validate(training_result, tuning_result, fs, y, w, bars)
 
     assert isinstance(report, MetaLabelerValidationReport)
@@ -458,9 +460,7 @@ def test_end_to_end_failing_gates_listed_in_canonical_order(
     tampered = dataclasses.replace(
         training_result,
         rf_auc_per_fold=tuple([0.51] * len(training_result.rf_auc_per_fold)),
-        logreg_auc_per_fold=tuple(
-            [0.50] * len(training_result.logreg_auc_per_fold)
-        ),
+        logreg_auc_per_fold=tuple([0.50] * len(training_result.logreg_auc_per_fold)),
         rf_brier_per_fold=tuple([0.30] * len(training_result.rf_brier_per_fold)),
     )
 
@@ -471,9 +471,7 @@ def test_end_to_end_failing_gates_listed_in_canonical_order(
             min_samples_leaf=(5, 10),
         ),
         outer_cpcv=cpcv,
-        inner_cpcv=CombinatoriallyPurgedKFold(
-            n_splits=3, n_test_splits=1, embargo_pct=0.0
-        ),
+        inner_cpcv=CombinatoriallyPurgedKFold(n_splits=3, n_test_splits=1, embargo_pct=0.0),
         seed=42,
     )
     tuning_result = tuner.tune(fs, y, w)


### PR DESCRIPTION
## Phase 4.5 — Meta-Labeler Statistical Validation (G1–G7)

Closes #129. Implements the seven-gate deployment validator from ADR-0005 D5
and the bet-sized P&L simulator from ADR-0002 D7 / ADR-0005 D8.

### What this PR delivers

| Gate | Threshold | Source |
| --- | --- | --- |
| G1 | mean OOS AUC ≥ 0.55 | López de Prado (2018) §3.2 |
| G2 | min per-fold OOS AUC ≥ 0.52 | ADR-0005 D5 |
| G3 | DSR on bet-sized P&L (realistic costs) ≥ 0.95 | Bailey & López de Prado (2014) |
| G4 | PBO across tuning trials < 0.10 | Bailey/Borwein/López de Prado/Zhu (2017) |
| G5 | Brier score ≤ 0.25 | Brier (1950) |
| G6 | minority class freq ≥ 10% (warn 5–10%, reject < 5%) | ADR-0005 D5 |
| G7 | RF − LogReg mean OOS AUC ≥ 0.03 | ADR-0005 D5 |

### New modules

- `features/meta_labeler/pnl_simulation.py` — `simulate_meta_labeler_pnl`
  computes per-label realised returns under the López de Prado (2018) §3.7
  betting rule (`bet = 2p − 1`) and the additive cost model from
  ADR-0002 D7 / ADR-0005 D8 (zero / realistic 10 bps RT / stress 30 bps RT).
  Exact-match `searchsorted` lookup against `bars.timestamp`; fails loud
  on any miss to keep the contract aligned with the 4.1 Triple-Barrier
  output.
- `features/meta_labeler/validation.py` — `MetaLabelerValidator.validate`
  orchestrates all seven gates, builds per-fold P&L by re-fitting on
  `train ∪ val` with the best hyperparameter set, runs the
  Politis-Romano (1994) stationary-bootstrap CI on the realised Sharpe,
  pivots the trial ledger into the PBO matrix, and packages a frozen
  `ValidationReport` with per-gate verdicts.
- `scripts/generate_phase_4_5_report.py` — end-to-end report generator.
  Synthesises alpha-injected bars (close drift = `_BAR_DRIFT_PER_SIGMA *
  ofi_signal`) so the tuned RF has a real edge to exploit, runs
  4.3 baseline → 4.4 nested CPCV → 4.5 validator, emits
  `validation_report.{md,json}`. Mirrors the 4.4 report contract:
  `APEX_REPORT_NOW`, `APEX_REPORT_WALLCLOCK_MODE`, `--full`.

### New tests

- `tests/unit/features/meta_labeler/test_pnl_simulation.py`
  - Bet sizing: `bet = 2p − 1 ∈ [−1, +1]`, `gross = log_ret · bet`
  - Cost arithmetic: realistic = 10 bps RT, stress = 3× realistic
  - **Anti-leakage property tests**: permuting prices outside
    `{t0_i, t1_i}` (and after `max(t1)`) leaves every per-label P&L
    unchanged.
  - Fail-loud: missing timestamp, t1 past last bar, p outside [0, 1],
    non-finite p, t1 < t0, shape disagreement, tuple length mismatch,
    non-monotonic bars, non-positive close, missing columns, empty bars.
- `tests/unit/features/meta_labeler/test_validation_gates.py`
  - Per-gate happy / fail tests for G1, G2, G4, G5, G6, G7 using
    `dataclasses.replace` to tamper individual gate inputs.
  - End-to-end pipeline test: 4.3 → 4.4 → 4.5 on a 200-row synthetic
    fixture, plus a tampered run that confirms failing gates land in
    canonical order.
  - Validator init defaults + frozen-dataclass guard on `GateResult`.

### How the gates interact with the rest of Phase 4

- The validator consumes `BaselineMetaLabelResult` (Phase 4.3, PR #140)
  and `NestedTuningResult` (Phase 4.4, PR #141).
- The data-leakage audit (PR #142, issue #134) covers the upstream
  feature build — the proba feeding label `i` is the model prediction
  at `t0_i` from features available strictly before `t0_i`. The
  `test_pnl_unchanged_when_prices_outside_t0_t1_set_permuted` property
  test extends that guarantee to the P&L step.

### Cost contract (ADR-0002 D7 / ADR-0005 D8)

| Scenario | Per-side bps | Round-trip bps |
| --- | --- | --- |
| zero | 0 | 0 |
| realistic | 5 | 10 |
| stress | 15 | 30 |

Only the realistic scenario feeds the G3 DSR gate; zero / stress are
computed for the report so reviewers can see the cost sensitivity.

### How to verify locally

```bash
make lint
pytest tests/unit/features/meta_labeler/test_pnl_simulation.py -q
pytest tests/unit/features/meta_labeler/test_validation_gates.py -q
APEX_REPORT_NOW=2026-04-14T00:00:00Z APEX_REPORT_WALLCLOCK_MODE=fixed \
  python scripts/generate_phase_4_5_report.py --output reports/phase_4_5
```

### References

- López de Prado, M. (2018). *Advances in Financial Machine Learning*,
  Wiley. §3.7 Betting on Probabilities.
- Bailey, D. & López de Prado, M. (2014). The Deflated Sharpe Ratio.
  *Journal of Portfolio Management*.
- Bailey, D., Borwein, J., López de Prado, M. & Zhu, Q. (2017). The
  Probability of Backtest Overfitting. *Journal of Computational
  Finance*.
- Politis, D. & Romano, J. (1994). The Stationary Bootstrap. *JASA*.
- Brier, G. (1950). Verification of forecasts expressed in terms of
  probability. *Monthly Weather Review*.
- ADR-0002 (Quant Methodology Charter), Section A item 7.
- ADR-0005 (Meta-Labeling and Fusion Methodology), D5 + D8.
