### PR TITLE
docs(phases): Phase 5 spec v2 — scope reduced + re-sequenced

### DIFF
--- a/docs/phases/PHASE_5_SPEC.md
+++ b/docs/phases/PHASE_5_SPEC.md
@@ -18,7 +18,7 @@
 
 # PHASE 5 — Live Integration & Infrastructure Hardening — Specification
 
-**Status**: v1 — PARTIALLY SUPERSEDED pending PHASE_5_SPEC_v2.md.
+**Status**: v1 — SUPERSEDED by [`PHASE_5_SPEC_v2.md`](PHASE_5_SPEC_v2.md).
 Design-gate merged 2026-04-16 (PR #155). Sub-phase 5.1 Fail-Closed
 merged 2026-04-17 (PR #177; issue #148 closed). Sub-phases 5.6 (ZMQ
 P2P), 5.7 (SBE/FlatBuffers), and 5.9 (Rust FFI Hot Path) are
@@ -28,8 +28,7 @@ Infrastructure Hardening backlog per
 Remaining sub-phases re-sequenced as 5.1 (DONE) → 5.2 → 5.3 → 5.5 →
 5.4 → 5.8 → 5.10. **REVISION NOTE**: This v1 document stays as the
 historical design record for the 9-sub-phase proposal; the canonical
-active spec is PHASE_5_SPEC_v2.md (to be published in Batch C of the
-post-audit execution).
+active spec is [`PHASE_5_SPEC_v2.md`](PHASE_5_SPEC_v2.md).
 
 **Related ADRs**: ADR-0002 (Quant Methodology Charter), ADR-0005
 (Meta-Labeling and Fusion Methodology), ADR-0006 (Fail-Closed

--- a/docs/phases/PHASE_5_SPEC.md
+++ b/docs/phases/PHASE_5_SPEC.md
@@ -1,3 +1,21 @@
+> **⚠️ SUPERSEDED — 2026-04-17**
+>
+> This v1 specification (9 sub-phases, three tracks) is superseded by
+> [`PHASE_5_SPEC_v2.md`](PHASE_5_SPEC_v2.md), which is the canonical source of truth
+> for Phase 5 as of 2026-04-17.
+>
+> **v2 differences**:
+> - Sub-phases 5.6 (ZMQ P2P), 5.7 (SBE/FlatBuffers), 5.9 (Rust FFI) are **dropped** from Phase 5
+>   and moved to [`PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md`](PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md).
+> - Remaining sub-phases re-sequenced: **5.1 (DONE) → 5.2 → 5.3 → 5.5 → 5.4 → 5.8 → 5.10**.
+> - Sub-phase 5.8 substitutes GDELT 2.0 + FinBERT for the proprietary WorldMonitor gRPC feed.
+> - Sub-phase 5.2 expanded to include **producer writers** for the eight orphan-read S05 context keys.
+>
+> **Rationale**: see [`STRATEGIC_AUDIT_2026-04-17_PHASE_5_AND_GLOBAL.md`](../audits/STRATEGIC_AUDIT_2026-04-17_PHASE_5_AND_GLOBAL.md).
+> This v1 document is preserved as historical design record; do not act on it.
+
+---
+
 # PHASE 5 — Live Integration & Infrastructure Hardening — Specification
 
 **Status**: v1 — PARTIALLY SUPERSEDED pending PHASE_5_SPEC_v2.md.

--- a/docs/phases/PHASE_5_SPEC_v2.md
+++ b/docs/phases/PHASE_5_SPEC_v2.md
@@ -120,7 +120,7 @@ Eliminate the eight-key Redis batch-read from S05's hot path. Replace with an ev
 
 **OUT (deferred):**
 
-- Correlation matrix writer — 5.5 or Phase 6 (see §3.2 scope IN bullet 1.7).
+- Correlation matrix writer — 5.5 or Phase 6 (see §3.2 Producers list, `correlation:matrix` item).
 - Rust rewrite of S05 — Phase 7.5 (deferred from v1 §3.9).
 - Persistent event-log replay — Phase 6.
 

--- a/docs/phases/PHASE_5_SPEC_v2.md
+++ b/docs/phases/PHASE_5_SPEC_v2.md
@@ -1,0 +1,680 @@
+# PHASE 5 — Live Integration — Specification **v2**
+
+**Status**: ACTIVE — replaces [PHASE_5_SPEC.md](PHASE_5_SPEC.md) v1 as the canonical Phase 5 source of truth.
+**Date**: 2026-04-17
+**Strategic basis**: [`docs/audits/STRATEGIC_AUDIT_2026-04-17_PHASE_5_AND_GLOBAL.md`](../audits/STRATEGIC_AUDIT_2026-04-17_PHASE_5_AND_GLOBAL.md).
+**Related ADRs**: ADR-0002 (Quant Methodology Charter), ADR-0005 (Meta-Labeling and Fusion Methodology), ADR-0006 (Fail-Closed Pre-Trade Risk Controls, ACCEPTED 2026-04-17), ADR-0001 (ZMQ Broker Topology — remains ACCEPTED; supersession deferred to Phase 7.5).
+**Predecessor**: Phase 4 (closed via PR #147).
+**Successor**: Phase 6 (DMA research, advanced regime-switching, multi-asset expansion).
+
+---
+
+## 1. Scope summary
+
+Phase 5 bridges the gap between Phase 4's offline ML pipeline and a paper-trading-ready live system. Five remaining sub-phases on a single strict sequence, one dropped category (infrastructure hardening moved to Phase 7.5).
+
+| Sub-phase | Title | Status |
+|---|---|---|
+| 5.1 | Fail-Closed Pre-Trade Risk Controls | ✅ DONE (PR #177, 2026-04-17) |
+| 5.2 | Event Sourcing / In-Memory State + Required Producers | NEXT |
+| 5.3 | Streaming Inference Wiring | PENDING |
+| 5.5 | Drift Monitoring & Feedback Loop | PENDING (promoted ahead of 5.4) |
+| 5.4 | Short-Side Meta-Labeler + Regime-Conditional Fusion | PENDING |
+| 5.8 | Geopolitical NLP Overlay (GDELT 2.0 + FinBERT) | PENDING |
+| 5.10 | Phase 5 Closure Report | PENDING |
+
+**Dropped from Phase 5** and moved to Phase 7.5 Infrastructure Hardening ([`PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md`](PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md)):
+
+| Former sub-phase | Title | Rationale |
+|---|---|---|
+| 5.6 | ZMQ Peer-to-Peer Bus | Premature at solo-operator scale (one host, 10 containers — no SPOF isolation win). |
+| 5.7 | SBE / FlatBuffers Serialization | JSON is not the bottleneck at mid-frequency cadence. |
+| 5.9 | Rust FFI Hot Path Migration | Defer until live-trading benchmarks prove Python is the bottleneck. |
+
+**Hard dependency chain:**
+
+```
+5.1 (DONE)
+  ↓
+5.2 Event Sourcing + Producers      ← unblocks all downstream; resolves orphan-read trap
+  ↓
+5.3 Streaming Inference Wiring      ← live alpha path (Phase 4 artifacts → production)
+  ↓
+5.5 Drift Monitoring                ← safety instrumentation before alpha extension
+  ↓
+5.4 Short-Side + Regime Fusion      ← alpha extension
+  ↓
+5.8 Geopolitical NLP (GDELT/FinBERT)
+  ↓
+5.10 Closure Report  →  Phase 7 Paper Trading
+```
+
+---
+
+## 2. Transverse principles (binding on every sub-phase)
+
+1. **Fail-loud heritage** preserved from Phases 3+4 and 5.1. Missing state → `ValueError`. Invalid model card → `ValueError`. Stale heartbeat → `DEGRADED` state transition, never silent continuation.
+2. **Decimal / UTC / structlog** — non-negotiable per CLAUDE.md §10. No new code introduces `float` for PnL/capital/exposure; no `datetime.now()` without `timezone.utc`.
+3. **No mocks in production, no silent fallbacks.** The Redis writer audit confirmed eight orphan-read keys in S05's pre-trade context. Sub-phase 5.2 resolves this by introducing **real producers**, not by restoring fallback defaults.
+4. **Coverage gate**: unit-test coverage ≥ 85% on new code. Integration tests mandatory when a new ZMQ topic or Redis key is added.
+5. **Budget discipline**: every sub-phase has a stated LOC / test count / week estimate. Overruns > 25% trigger a re-plan, not silent extension.
+6. **ADR bookkeeping**: a new ADR is required whenever a sub-phase crosses a previously decided architectural boundary. ADR-0006 (5.1) is the precedent.
+
+---
+
+## 3. Sub-phase specifications
+
+### 3.1 Sub-phase 5.1 — Fail-Closed Pre-Trade Risk Controls
+
+**Status**: ✅ MERGED 2026-04-17 via PR #177 (commit `1b7c3b5`). Issue #148 CLOSED.
+
+- ADR-0006 ACCEPTED.
+- Deliverables: `SystemRiskState` / `SystemRiskStateCause` / `SystemRiskStateChange` / `SystemRiskMonitor` ([core/state.py:365-600](../../core/state.py)), `FailClosedGuard` ([services/s05_risk_manager/fail_closed.py](../../services/s05_risk_manager/fail_closed.py)), `Topics.RISK_SYSTEM_STATE_CHANGE` ([core/topics.py:48](../../core/topics.py)).
+- Follow-up observability (S10 subscribe + dashboard endpoint + alert) merged in PR #178 (Batch A of the post-audit execution).
+- Residual debt: S05 `service.py` now 530 LOC (SOLID-S). Decomposed in Batch D of the post-audit execution.
+
+Nothing further in v2 scope for 5.1.
+
+---
+
+### 3.2 Sub-phase 5.2 — Event Sourcing / In-Memory State + Required Producers
+
+#### Objective
+
+Eliminate the eight-key Redis batch-read from S05's hot path. Replace with an event-sourced in-memory state machine fed by ZMQ topics. **Crucially, build the producers at the same time** — per the [Redis writer audit](../audits/REDIS_KEYS_WRITER_AUDIT_2026-04-17.md), none of the eight keys currently have a production writer.
+
+#### Scope
+
+**IN:**
+
+1. **Producers** (new writers + new ZMQ topics):
+   - **`portfolio:capital`** — new `PortfolioTracker` component in S06 (or a lightweight S09 extension) that tracks available + total capital, updated on every fill. Topic: `portfolio.capital` (snapshot) + Redis key refresh.
+   - **`pnl:daily`** + **`pnl:intraday_30m`** — new `PnLTracker` component in S09 (existing `trade_analyzer.py` is the natural home). Computes daily and rolling 30-min PnL; writes to Redis keys + emits on `portfolio.pnl` topic.
+   - **`portfolio:positions`** — new aggregator reading `positions:{symbol}` hash from S06 (the per-symbol writer already exists) and emitting an aggregated list on `portfolio.position` topic + Redis key `portfolio:positions`. Owner: S09 or S07, to be decided in 5.2 design review.
+   - **`session:current`** — S03 `session_tracker.py` gets a Redis persistence shim. Session transitions publish on existing `session.pattern.*` topic AND persist to `session:current`.
+   - **`macro:vix_current`** + **`macro:vix_1h_ago`** — S01 `macro_feed.py` persistence shim. Every FRED VIX poll writes `macro:vix_current`; a rolling-snapshot task (new) copies it to `macro:vix_1h_ago` every hour.
+   - **`correlation:matrix`** — **OUT OF 5.2 SCOPE.** For 5.2, S05 reads with a fallback to the identity matrix (explicit constant, logged as a 5.2 known gap; blocked-by-issue tracked for 5.5 or Phase 6). This is a deliberate Principle 1 trade-off: correlation is not on the short critical path to live PnL.
+
+2. **Consumer** (`InMemoryRiskState`):
+   - New module `services/s05_risk_manager/in_memory_state.py` exposing an `InMemoryRiskState` dataclass keyed by canonical field name (`capital`, `daily_pnl`, `intraday_loss_30m`, `positions`, `session`, `vix_current`, `vix_1h_ago`).
+   - `on_message()` handler in S05 updates the state on each topic receipt.
+   - Order validation reads **only** from in-memory state — zero network calls, zero `await` in the hot path.
+
+3. **Reconciliation loop** (`services/s05_risk_manager/reconciliation.py`):
+   - Every 5 s, compares in-memory state against Redis snapshot (Redis remains the durable store written by producers).
+   - Discrepancies > 0.01 % emit `structlog.warning()`.
+   - Discrepancies > 1 % transition `SystemRiskState` to `DEGRADED` (5.1 FailClosedGuard rejects 100 % of orders per ADR-0006 §D7).
+
+4. **Staleness timeout**:
+   - In-memory state carries a `last_update_ts` per field. If any required field is > 10 s stale, `SystemRiskState` → `DEGRADED`.
+
+5. **New Topics constants** added to [`core/topics.py`](../../core/topics.py):
+   - `PORTFOLIO_CAPITAL = "portfolio.capital"`
+   - `PORTFOLIO_POSITION = "portfolio.position"`
+   - `PORTFOLIO_PNL = "portfolio.pnl"`
+
+6. **S05 SOLID-S refactor** (piggybacks on this sub-phase — from audit ACTION 25 / Batch D originally):
+   - Extract `RiskChainOrchestrator`, `ContextLoader` (now feeds from in-memory state, not Redis), `RiskDecisionBuilder`.
+   - `service.py` retains only BaseService lifecycle + dispatch.
+   - If Batch D lands first, this sub-phase consumes its output.
+
+**OUT (deferred):**
+
+- Correlation matrix writer — 5.5 or Phase 6 (see §3.2 scope IN bullet 1.7).
+- Rust rewrite of S05 — Phase 7.5 (deferred from v1 §3.9).
+- Persistent event-log replay — Phase 6.
+
+#### Module structure
+
+```
+services/s05_risk_manager/
+├── in_memory_state.py           # NEW — InMemoryRiskState dataclass + update handlers
+├── reconciliation.py            # NEW — periodic Redis ↔ in-memory comparison
+├── chain_orchestrator.py        # NEW — extracted from service.py (Batch D)
+├── context_loader.py            # NEW — reads from InMemoryRiskState (not Redis)
+├── decision_builder.py          # NEW — approved/blocked constructor
+├── service.py                   # MODIFY — slimmed to lifecycle + dispatch
+
+services/s09_feedback_loop/
+├── pnl_tracker.py               # NEW — daily + intraday_30m PnL
+├── position_aggregator.py       # NEW — positions:{symbol} → portfolio:positions
+
+services/s06_execution/
+├── portfolio_tracker.py         # NEW — capital on-fill updates
+
+services/s03_regime_detector/
+├── session_tracker.py           # MODIFY — add Redis persistence shim
+
+services/s01_data_ingestion/
+├── macro_feed.py                # MODIFY — persist macro:vix_current; rolling-snapshot task
+
+core/topics.py                   # MODIFY — add PORTFOLIO_* topics
+
+tests/unit/services/s05_risk_manager/
+├── test_in_memory_state.py      (~20 tests)
+├── test_reconciliation.py       (~14 tests)
+├── test_chain_orchestrator.py   (~16 tests)
+├── test_context_loader.py       (~10 tests)
+├── test_decision_builder.py     (~10 tests)
+
+tests/unit/services/s06_execution/test_portfolio_tracker.py     (~10)
+tests/unit/services/s09_feedback_loop/test_pnl_tracker.py       (~14)
+tests/unit/services/s09_feedback_loop/test_position_aggregator.py  (~10)
+tests/unit/services/s03_regime_detector/test_session_redis_shim.py  (~8)
+tests/unit/services/s01_data_ingestion/test_macro_feed_redis.py    (~10)
+
+tests/integration/
+├── test_event_sourcing_convergence.py  (~8 tests)
+```
+
+#### Algorithm notes
+
+- **In-memory state update**: on each ZMQ topic receipt, the handler mutates a single field and refreshes `last_update_ts`. No locking required because S05 uses single-threaded asyncio.
+- **Order validation hot path**: zero `await` calls, zero network I/O. Pure dict reads + Decimal arithmetic. Target P99 latency < 100 µs (post-decomposition).
+- **Reconciliation**: every 5 s, read all eight Redis keys, compare against in-memory. Use `Decimal` tolerance 0.01 % for financial fields; exact equality for enums (`Session`). Drift > 1 % = critical.
+- **Correlation matrix fallback**: if `correlation:matrix` is absent, use `numpy.eye(n)` scaled to unit correlation (i.e., all pairs uncorrelated). Log the fallback at `structlog.warning()` level on every risk check; add a `correlation_fallback_active` boolean to every `risk.audit` event. **This is NOT a silent fallback** — it is an explicit, logged, observable design decision with a tracked issue for future closure.
+
+#### Criteria — Definition of Done
+
+1. **Orphan-read resolved** — all eight keys have a production writer or an explicit documented fallback (correlation only). Grep audit in CI confirms.
+2. **Benchmark**: P99 order validation latency < 100 µs (profiler confirms zero socket/Redis calls in `process_order_candidate` hot path).
+3. **Convergence test**: after 1000 simulated fills injected into the producers, in-memory state matches Redis within Decimal(0.0001) tolerance.
+4. **Staleness test**: stopping a producer causes `SystemRiskState` → `DEGRADED` within 11 s (10 s staleness + 1 s scheduler slack). Every `OrderCandidate` subsequently rejected.
+5. **S05 service.py reduced to ≤ 200 LOC** after decomposition; each extracted class ≤ 250 LOC, all unit-testable in isolation.
+6. **mypy --strict clean**, **ruff clean**, **unit test coverage ≥ 90%** on new S05 modules, **≥ 85%** on new producer modules.
+7. **New Topics constants added to [core/topics.py](../../core/topics.py)**.
+8. **Integration test**: full loop from `order.filled` → `portfolio.capital` producer → S05 in-memory update → next `OrderCandidate` sees updated capital.
+
+#### Dependencies
+
+- 5.1 merged ✅.
+- S05 `service.py` SOLID-S refactor (overlaps with Batch D of the post-audit execution; whichever lands first, the other rebases).
+
+#### Estimated scope
+
+- LOC: ~900–1,200 (producers + consumer + reconciliation + tests).
+- Tests: ~130.
+- Complexity: **high** (multi-service change; reconciliation is subtle).
+- Estimated weeks: **2**.
+- Copilot review cycles: 3.
+
+#### References
+
+- Martin Thompson, "Mechanical Sympathy".
+- LMAX Disruptor pattern.
+- ADR-0006 (5.1 fail-closed contract; the in-memory state must remain consistent with that contract).
+- CLAUDE.md §3 (continuous adaptation), §5 (hot-path allocations).
+- [`docs/audits/REDIS_KEYS_WRITER_AUDIT_2026-04-17.md`](../audits/REDIS_KEYS_WRITER_AUDIT_2026-04-17.md).
+
+---
+
+### 3.3 Sub-phase 5.3 — Streaming Inference Wiring
+
+#### Objective
+
+Wire Phase 4's trained Meta-Labeler and IC-weighted Fusion into the live S02 → S04 tick path. Phase 3 calculators transition from batch-only to streaming. Reinstate G7 as a blocking gate on real market data.
+
+#### Scope
+
+**IN:**
+
+- `services/s02_signal_engine/streaming_adapter.py` — new per-tick wrapper around Phase 3 calculators. Each calculator that supports incremental computation exposes `compute_incremental(new_bar, evicted_bar | None) -> features`. Calculators without an incremental interface fall back to bounded-window batch `compute()`, with documented window size + P99 latency evidence.
+- `services/s02_signal_engine/pipeline.py` — SOLID-S decomposition (per-stage classes) — prerequisite from Batch D.
+- `services/s04_fusion_engine/live_meta_labeler.py` — loads persisted `.joblib` model + `.json` model card at startup. Strict card validation: if invalid or mismatched SHA, S04 **refuses to start** (fail-loud; no fallback to deterministic scorer).
+- `services/s04_fusion_engine/live_fusion.py` — IC-weighted fusion in streaming mode. Reads frozen weights from the persisted `ICWeightedFusionConfig`.
+- `services/s04_fusion_engine/service.py` — per-tick `predict_proba → 2p-1 Kelly bet-size → OrderCandidate` publishes on `order.candidate`. Redis key `meta_label:latest:{symbol}` updated live (for S05 `MetaLabelGate` consumption).
+- **G7 gate reinstated as blocking on real data.** If G7 fails during live operation, the deployment is halted; model must be retrained or feature set expanded.
+- **CVDKyle vectorization (#115)** — prerequisite. The loops at `features/calculators/cvd_kyle.py:306, 361, 408` are on the streaming hot path.
+
+**OUT (deferred):**
+
+- Short-side (`direction = -1`) — 5.4.
+- Regime-conditional weights — 5.4.
+- Drift monitoring — 5.5.
+- Rust hot path — Phase 7.5.
+
+#### Module structure
+
+```
+services/s02_signal_engine/
+├── streaming_adapter.py         # NEW — incremental calculator wrapper
+├── pipeline.py                  # DECOMPOSED (from Batch D)
+├── stages/                      # NEW — step classes per Batch D
+
+services/s04_fusion_engine/
+├── live_meta_labeler.py         # NEW
+├── live_fusion.py               # NEW
+├── service.py                   # MODIFY
+
+features/calculators/
+├── cvd_kyle.py                  # MODIFY — vectorize loops at :306, :361, :408 (issue #115)
+
+tests/unit/services/s02_signal_engine/test_streaming_adapter.py   (~18)
+tests/unit/services/s04_fusion_engine/test_live_meta_labeler.py   (~14)
+tests/unit/services/s04_fusion_engine/test_live_fusion.py         (~10)
+tests/unit/features/calculators/test_cvd_kyle_vectorized.py       (~6)
+tests/integration/test_streaming_pipeline.py                      (~10)
+```
+
+#### Algorithm notes
+
+- **Streaming adapter** wraps each calculator in a stateful rolling-window context. On each tick, pushes new bar → updates state → emits only the derived feature(s). Never recomputes full window on every tick unless the calculator explicitly opts in via `USE_BATCH_FALLBACK = True` with documented window size.
+- **Model card validation at S04 startup** — mandatory `ModelCardV1.validate()` call; missing fields → `ValueError`; mismatched dataset SHA → `ValueError`. Card schema defined in `features/meta_labeler/model_card.py`.
+- **Kelly bet-size** — `bet_size = 2 * predict_proba - 1`, clamped to configured bounds (per ADR-0005 D8). Published to Redis `meta_label:latest:{symbol}` within 5 ms of each tick.
+- **G7 reinstated**: on real data, if RF AUC − LogReg AUC < 0.03 over a rolling 200-label window, S04 emits `feedback.drift.critical` and halts new `OrderCandidate` emission.
+
+#### Criteria — Definition of Done
+
+1. Per-tick latency < 1 ms P99 for full signal → fusion → bet-size path (synthetic stream).
+2. Redis `meta_label:latest:{symbol}` updated within 5 ms of each tick (P99).
+3. Model card validation at S04 startup — missing/invalid card prevents launch (integration test with corrupted card).
+4. 1000-tick synthetic stream produces bet-sizes matching batch computation within floating-point tolerance.
+5. CVDKyleCalculator vectorized; benchmark shows ≥ 10× speedup on 500-bar windows.
+6. All tests pass; coverage ≥ 88% on new modules.
+7. mypy --strict + ruff clean.
+
+#### Dependencies
+
+- 5.2 merged (in-memory risk state is the validation target of S05 feeding from S04).
+- Batch D decomposition of S02 `pipeline.py` (or concurrent).
+- Issue #115 (CVDKyle vectorization) resolved as part of 5.3.
+- Issue #123 (streaming calculators) resolved as part of 5.3.
+
+#### Estimated scope
+
+- LOC: ~700–1,000.
+- Tests: ~58.
+- Complexity: **high**.
+- Estimated weeks: **3**.
+- Copilot review cycles: 3.
+
+#### References
+
+- ADR-0005 D6, D7, D8.
+- Phase 4 closure report §5.1.
+- GitHub issues #123, #115.
+
+---
+
+### 3.4 Sub-phase 5.5 — Drift Monitoring & Feedback Loop (PROMOTED AHEAD OF 5.4)
+
+#### Objective
+
+Detect feature drift, calibration degradation, and signal decay in real time. When drift crosses thresholds, S09 publishes alerts and can trigger S05 Kelly reduction or recalibration.
+
+**Why before 5.4**: 5.4 extends the model (short-side, regime-conditional). Without drift instrumentation in place first, the extension's impact on production is unobservable. Ship safety before alpha per Principle 1.
+
+#### Scope
+
+**IN:**
+
+- `services/s09_feedback_loop/drift_monitor.py` — new module implementing:
+  - **PSI (Population Stability Index)** on rolling 500-bar windows vs training distribution. PSI > 0.10 = warning, PSI > 0.25 = critical.
+  - **Rolling AUC** on last 200 realized labels (from Triple Barrier t1 outcomes). If below G1 (0.55) for 3 consecutive windows → critical.
+  - **Brier score calibration divergence** on rolling window. If > G5 (0.25) → critical.
+- `services/s09_feedback_loop/alert_engine.py` — new module publishing `feedback.drift.critical` and `feedback.recalibration.requested` topics on threshold breach.
+- S05 `MetaLabelGate` extension: subscribes to `feedback.drift.critical` and applies Kelly × 0.5 defensive multiplier until manual reset (or automatic recalibration in Phase 6).
+- New Topics constants in `core/topics.py`: `FEEDBACK_DRIFT_CRITICAL = "feedback.drift.critical"`, `FEEDBACK_RECALIBRATION_REQUESTED = "feedback.recalibration.requested"`.
+
+**OUT:**
+
+- Automatic retraining — Phase 6.
+- A/B testing / champion-challenger — Phase 6.
+
+#### Module structure
+
+```
+services/s09_feedback_loop/
+├── drift_monitor.py             # NEW — PSI + rolling AUC + Brier
+├── alert_engine.py              # NEW — threshold-based publisher
+├── service.py                   # MODIFY — integrate drift monitor
+
+services/s05_risk_manager/
+├── meta_label_gate.py           # MODIFY — Kelly × 0.5 on drift.critical
+
+core/topics.py                   # MODIFY — FEEDBACK_* constants
+
+tests/unit/services/s09_feedback_loop/test_drift_monitor.py   (~20)
+tests/unit/services/s09_feedback_loop/test_alert_engine.py    (~10)
+tests/integration/test_drift_feedback_loop.py                 (~8)
+```
+
+#### Algorithm notes
+
+- **PSI**: standard industry formula `sum_i (actual_pct_i − expected_pct_i) * ln(actual_pct_i / expected_pct_i)` over 10 deciles.
+- **Rolling AUC**: computed on realized labels from completed Triple Barrier events (where `t1` has elapsed).
+- **Kelly de-risking**: `kelly_adj = kelly * 0.5` when `drift.critical` event received within last 5 min. Manual-reset admin endpoint exposed via S10 `/api/v1/risk/drift-reset` (confirmation token required per S10 security model).
+- **Recalibration trigger**: emits the current model card hash + drift metrics; a future Phase 6 orchestrator consumes this to schedule retraining. For 5.5 MVP: logs only, no consumer.
+
+#### Criteria — Definition of Done
+
+1. PSI detects a synthetic 1 σ mean shift (injected test) → PSI > 0.25 within 1 window.
+2. Rolling AUC degradation detected within 3 consecutive windows of synthetic model decay.
+3. Kelly × 0.5 applied within 100 ms of `drift.critical` receipt (integration test).
+4. Topics registered; mypy --strict clean; ruff clean.
+5. Coverage ≥ 90 %.
+
+#### Dependencies
+
+- 5.3 merged (live predictions required to monitor).
+
+#### Estimated scope
+
+- LOC: ~500–700.
+- Tests: ~38.
+- Complexity: **medium**.
+- Estimated weeks: **2**.
+- Copilot review cycles: 2.
+
+#### References
+
+- Tsay (2010) Ch. 2 (time-varying parameters).
+- PSI methodology (credit-risk industry standard).
+- Phase 4 closure §5.2.
+
+---
+
+### 3.5 Sub-phase 5.4 — Short-Side Meta-Labeler + Regime-Conditional Fusion
+
+#### Objective
+
+Extend the Meta-Labeler to `direction ∈ {+1, −1}` and implement regime-conditional fusion weights that adapt to the current volatility regime detected by S03.
+
+#### Scope
+
+**IN:**
+
+- `features/labeling/triple_barrier_binary.py` — `direction = -1` support (upper barrier = stop-loss, lower barrier = take-profit; binary target flips).
+- `features/meta_labeler/feature_builder.py` — add `direction_code` (±1) as a 9th feature.
+- `features/meta_labeler/baseline.py` — train direction-aware model (single model with `direction_code` feature — senior-quant tie-breaker: simpler than two separate models).
+- `features/fusion/regime_conditional.py` — new `RegimeConditionalFusion` holding N frozen weight vectors (one per regime state: LOW / NORMAL / HIGH / CRISIS). S03's regime selects the active weight vector at each tick.
+- `features/fusion/ic_weighted.py` — extend with regime-stratified IC reports.
+- Transition smoothing at regime boundaries: linear blend over 5-bar window to avoid whipsaw.
+- CPCV validation of the short-side model; G1–G6 gates must pass on a synthetic directional-alpha scenario.
+
+**OUT:**
+
+- Multi-asset options hedging — Phase 11.
+
+#### Module structure
+
+```
+features/labeling/
+├── triple_barrier_binary.py     # MODIFY — direction=-1 support
+
+features/meta_labeler/
+├── feature_builder.py           # MODIFY — direction_code feature
+├── baseline.py                  # MODIFY — direction-aware training
+
+features/fusion/
+├── regime_conditional.py        # NEW — regime-aware weight switching
+├── ic_weighted.py               # EXTEND — per-regime IC
+
+tests/unit/features/labeling/test_short_side_labeling.py       (~14)
+tests/unit/features/meta_labeler/test_short_side_model.py      (~16)
+tests/unit/features/fusion/test_regime_conditional.py          (~18)
+```
+
+#### Criteria — Definition of Done
+
+1. Short-side model passes G1–G6 on synthetic directional-alpha scenario.
+2. Regime-conditional fusion Sharpe ≥ global-fusion Sharpe on multi-regime synthetic scenario.
+3. Regime transition smoothing — no fusion-score jumps > 2 σ across boundaries.
+4. mypy --strict clean; ruff clean; coverage ≥ 90 %.
+
+#### Dependencies
+
+- 5.3 merged (streaming pipeline for live regime-conditional switching).
+- 5.5 merged (drift instrumentation ready to observe the extension's impact).
+
+#### Estimated scope
+
+- LOC: ~500–700.
+- Tests: ~48.
+- Complexity: **medium–high**.
+- Estimated weeks: **2**.
+- Copilot review cycles: 2–3.
+
+#### References
+
+- López de Prado (2018) §3.4.
+- ADR-0005 D1.
+- Phase 4 closure §5.2.
+
+---
+
+### 3.6 Sub-phase 5.8 — Geopolitical NLP Overlay (GDELT 2.0 + FinBERT substitute)
+
+#### Objective
+
+Real-time geopolitical-risk scoring pipeline using open-source substitutes for the original proprietary WorldMonitor gRPC spec. Risk score modulates Kelly bet-sizing in S04 and can VETO orders in S05.
+
+**Principle 3 substitute justification**: the v1 spec assumed a paid `WorldMonitorConnector`. The operator has no budget for this. GDELT 2.0 (free, public, event-coded, 15-min cadence, 300 languages) + FinBERT (open-source, ONNX-compilable, CPU-inferable) provides an institutional-grade equivalent at $0/month.
+
+#### Scope
+
+**IN:**
+
+- `services/s01_data_ingestion/connectors/gdelt.py` — new HTTP/CSV connector for GDELT 2.0 events feed (GKG + EVENT). Polls every 15 min. Publishes on `macro.geopolitics.raw` topic.
+- `services/s08_macro_intelligence/nlp/finbert_scorer.py` — FinBERT compiled to ONNX Runtime for CPU inference (no GPU required). Inference in isolated subprocess (no broker-key access). P99 < 50 ms per chunk.
+- `services/s08_macro_intelligence/nlp/model_card_nlp.json` — governance model card documenting bias, inference P99, model size.
+- `GeopoliticalRiskScore [-1.0, 1.0]` persisted to TimescaleDB with point-in-time semantics.
+- `services/s04_fusion_engine/service.py` — Kelly penalty on negative geo_score (asymmetric: `geo_score > 0` does NOT increase Kelly).
+- `services/s05_risk_manager/geopolitical_guard.py` — new guard in the risk chain. `geo_score == -1.0` → VETO all orders. NLP heartbeat absent > 60 s → `SystemRiskState.DEGRADED` (reuses ADR-0006 pattern).
+- New Topics constants: `MACRO_GEOPOLITICS_RAW = "macro.geopolitics.raw"`, `MACRO_GEOPOLITICS_SCORE = "macro.geopolitics.score"`.
+
+**OUT:**
+
+- Custom LLM fine-tuning — Phase 6 (or Phase 11 if budget allows).
+- Satellite imagery — Phase 11.
+- Multi-language NLP — Phase 11 (FinBERT is English-first; GDELT already does cross-language event coding).
+
+#### Module structure
+
+```
+services/s01_data_ingestion/
+├── connectors/
+│   └── gdelt.py                 # NEW — HTTP/CSV GDELT 2.0 feed
+
+services/s08_macro_intelligence/
+├── nlp/
+│   ├── finbert_scorer.py        # NEW — ONNX Runtime wrapper
+│   ├── model_card_nlp.json      # NEW — governance card
+│   └── __init__.py
+
+services/s04_fusion_engine/
+├── service.py                   # MODIFY — Kelly penalty on geo_score
+
+services/s05_risk_manager/
+├── geopolitical_guard.py        # NEW
+
+core/topics.py                   # MODIFY — MACRO_GEOPOLITICS_* constants
+
+tests/unit/services/s01_data_ingestion/test_gdelt_connector.py    (~12)
+tests/unit/services/s08_macro_intelligence/test_finbert_scorer.py  (~16)
+tests/unit/services/s05_risk_manager/test_geopolitical_guard.py   (~12)
+tests/integration/test_geopolitical_pipeline.py                   (~10)
+```
+
+#### Algorithm notes
+
+- **Latency budget**: geopolitical event ingested in S01 → S05 BLOCKED state in < 250 ms end-to-end.
+- **FinBERT ONNX**: compiled via `onnxruntime`; fallback to CPU if GPU unavailable. P99 < 50 ms per text chunk on modern laptop CPU.
+- **Score mapping**: FinBERT logits → softmax → weighted sum into `[-1.0, 1.0]`. Storage: TimescaleDB with point-in-time `score_as_of` column.
+- **Kelly penalty**: `kelly_adj = kelly * max(0, 1 + geo_score)` where `geo_score ∈ [-1, 0]` reduces Kelly linearly; `geo_score > 0` treated as 0 (asymmetric, conservative).
+- **Guard VETO**: `geo_score <= -0.99` → `RiskDecision(approved=False, reason=GEOPOLITICAL_EVENT_BLOCK)`.
+- **Heartbeat**: S08 NLP worker writes to `macro:nlp_heartbeat` every 10 s with TTL 60 s. S05 guard checks this key; missing → `DEGRADED`.
+
+#### Criteria — Definition of Done
+
+1. **Latency test**: event → BLOCKED in < 250 ms.
+2. **Model card** documents bias metrics, inference P99, model size.
+3. **Backtest**: ≥ 15 % MDD reduction on ex-post crisis periods (COVID-03/2020, Ukraine-02/2022).
+4. **Topics registered**; mypy --strict clean; ruff clean; coverage ≥ 88 %.
+5. **$0/month operational cost verified** (GDELT free tier + FinBERT open-source + CPU-only inference).
+
+#### Dependencies
+
+- 5.3 merged (live pipeline for overlay integration).
+- 5.5 merged (drift instrumentation in place).
+
+#### Estimated scope
+
+- LOC: ~800–1,200 (connector + scorer + guard + tests).
+- Tests: ~50.
+- Complexity: **high**.
+- Estimated weeks: **3**.
+- Copilot review cycles: 3.
+
+#### References
+
+- Kelly, B. et al., "Text as Data" (JFE).
+- GDELT Project 2.0 (https://www.gdeltproject.org/).
+- FinBERT (https://github.com/ProsusAI/finBERT).
+- ADR-0006 (fail-closed pattern reuse).
+
+---
+
+### 3.7 Sub-phase 5.10 — Phase 5 Closure Report
+
+#### Objective
+
+Mirror of PR #147 (Phase 4 closure) for Phase 5. Document sub-phase inventory, final benchmarks, Phase 6+ prerequisites, and paper-trading readiness assessment.
+
+#### Scope
+
+- `docs/phase_5_closure_report.md` — new, 10-section closure report.
+- `docs/claude_memory/CONTEXT.md` — refreshed.
+- `docs/claude_memory/PHASE_5_NOTES.md` — new, archival notes.
+- `docs/claude_memory/SESSIONS.md` — final Phase 5 session entry.
+- CHANGELOG.md — entries for 5.2/5.3/5.5/5.4/5.8.
+
+#### Content
+
+- Sub-phase inventory (5.1 / 5.2 / 5.3 / 5.5 / 5.4 / 5.8) with PR numbers, LOC, test counts.
+- Latency + throughput benchmarks (order validation P99, streaming P99, NLP P99).
+- Safety audit: Fail-Closed verification, drift-instrumentation sample events, GeopoliticalGuard unit tests.
+- Phase 7 (paper trading) prerequisites checklist.
+- Deferred-to-Phase-7.5 backlog summary.
+
+#### DoD
+
+1. Closure report committed.
+2. Memory files updated.
+3. All CI jobs green on closure branch.
+4. Paper-trading entry criteria satisfied (capital seeded, producers running, drift baseline captured).
+
+#### Estimated scope
+
+- LOC: N/A (docs only).
+- Complexity: **low**.
+- Estimated weeks: **1**.
+
+---
+
+## 4. Sub-phase tracking table
+
+| Sub-phase | Issue | Branch | Status |
+|---|---|---|---|
+| 5.1 Fail-Closed Pre-Trade Risk | #148 (CLOSED) | `phase-5/fail-closed` (merged) | ✅ DONE |
+| 5.2 Event Sourcing + Producers | #149 (to retitle `[phase-5.2]` in Batch E) | `phase-5/event-sourcing` | NEXT |
+| 5.3 Streaming Inference | #123 (relabeled in Batch E) | `phase-5/streaming-inference` | PENDING |
+| 5.5 Drift Monitoring | #157 | `phase-5/drift-monitoring` | PENDING |
+| 5.4 Short-Side + Regime Fusion | #156 | `phase-5/short-side-regime` | PENDING |
+| 5.8 Geopolitical NLP | #153 (to retitle `[phase-5.8]` in Batch E) | `phase-5/gdelt-finbert` | PENDING |
+| 5.10 Closure Report | #158 | `chore/phase-5-closure` | PENDING |
+
+---
+
+## 5. Cross-cutting concerns
+
+### 5.1 Fail-loud heritage
+
+All sub-phases preserve the fail-loud pattern. No silent fallbacks; explicit fallbacks (correlation matrix identity) are logged on every event.
+
+### 5.2 CI contract
+
+Phase 5 inherits the current CI pipeline:
+
+1. `quality` — ruff + mypy strict + bandit.
+2. `rust` — cargo test + maturin build.
+3. `unit-tests` — pytest, coverage ≥ 85%.
+4. `integration-tests` — full pipeline with Redis.
+5. `backtest-gate` — **MUZZLED pending issue #102** (Batch A Tech Finding 3). Target thresholds to be restored to Sharpe ≥ 0.8, max DD ≤ 8 % after #102 merges.
+
+### 5.3 Security
+
+- S06 execution: 5.1 Fail-Closed guard ensures no orders pass through degraded state.
+- NLP model (5.8): isolated subprocess, no broker-key access.
+- All new producers (5.2): Redis keys scoped by namespace; no cross-service secret exposure.
+
+### 5.4 UTC / Decimal / structlog — non-negotiable
+
+Inherited from CLAUDE.md §2/§10. Every PR grep-audited in CI.
+
+### 5.5 Deferred to Phase 7.5 (explicit acknowledgement)
+
+Phase 5 v2 does **not** ship the following; see [`PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md`](PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md):
+
+- ZMQ Peer-to-Peer bus (former 5.6).
+- SBE / FlatBuffers zero-copy serialization (former 5.7).
+- Rust FFI hot path migration (former 5.9).
+
+The operator explicitly acknowledges this trade-off: live paper trading begins without these; if Phase 8 live-trading benchmarks demonstrate bottlenecks, Phase 7.5 is revisited.
+
+---
+
+## 6. Risks (updated post-audit)
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Orphan-read producers (5.2) introduce new bugs | Fail-closed rejects legitimate orders | Reconciliation loop + staleness timeout + integration test suite. |
+| Correlation-matrix identity fallback masks concentration risk | Position sizing under-conservative | Logged on every risk event; issue tracked for 5.5 or Phase 6 closure. |
+| S05 SRP refactor breaks 5.1 chain semantics | Silent change in fail-closed behavior | Port test suite unchanged; regression tests required before merge. |
+| Streaming adapter P99 > 1 ms budget (5.3) | Bet-size stale by next tick | CI latency gate; calculator-by-calculator benchmarks before live path. |
+| FinBERT hallucination triggers spurious VETO (5.8) | Missed trades during false positives | Score confidence threshold; manual-review panel in S10; VETO requires `geo_score ≤ -0.99`. |
+| Drift monitor false positives (5.5) | Unnecessary Kelly de-risking | Manual reset endpoint; 3-consecutive-window requirement for critical. |
+| Phase 5 scope creep (again) | Delays paper trading | This v2 spec is the scope; any additions require new ADR + PHASE_5_SPEC_v3. |
+
+---
+
+## 7. Phase 6 preview (out of scope, context only)
+
+- **#154 DMA Research** — Dynamic Model Averaging vs Meta-Labeling (pure research).
+- **Automatic retraining pipeline** — orchestrated by `feedback.recalibration.requested` from 5.5.
+- **A/B / champion-challenger** model testing.
+- **Correlation-matrix production writer** (deferred from 5.2).
+- **Multi-asset expansion** preparatory work.
+
+---
+
+## 8. References
+
+### Project
+
+- [`docs/audits/STRATEGIC_AUDIT_2026-04-17_PHASE_5_AND_GLOBAL.md`](../audits/STRATEGIC_AUDIT_2026-04-17_PHASE_5_AND_GLOBAL.md) (strategic basis).
+- [`docs/audits/REDIS_KEYS_WRITER_AUDIT_2026-04-17.md`](../audits/REDIS_KEYS_WRITER_AUDIT_2026-04-17.md) (5.2 prerequisite evidence).
+- [`docs/adr/ADR-0006-fail-closed-risk-controls.md`](../adr/ADR-0006-fail-closed-risk-controls.md).
+- Phase 4 closure: [`docs/phase_4_closure_report.md`](../phase_4_closure_report.md).
+- Phase 3 closure: [`docs/phase_3_closure_report.md`](../phase_3_closure_report.md).
+- CLAUDE.md; MANIFEST.md.
+
+### Academic
+
+- López de Prado, M. (2018), *Advances in Financial Machine Learning*, Wiley.
+- Martin Thompson, "Mechanical Sympathy".
+- LMAX Disruptor.
+- Kelly, B. et al., "Text as Data" (JFE).
+- Tsay, R. (2010), *Analysis of Financial Time Series*, Wiley.
+
+### Industry / tools
+
+- SEC Rule 15c3-5 (Market Access Rule).
+- Knight Capital 2012 post-mortem.
+- GDELT Project 2.0 (https://www.gdeltproject.org/).
+- FinBERT (https://github.com/ProsusAI/finBERT).
+- ONNX Runtime (https://onnxruntime.ai/).
+
+---
+
+**END OF PHASE_5_SPEC_v2.**

--- a/docs/phases/PHASE_5_SPEC_v2.md
+++ b/docs/phases/PHASE_5_SPEC_v2.md
@@ -11,7 +11,7 @@
 
 ## 1. Scope summary
 
-Phase 5 bridges the gap between Phase 4's offline ML pipeline and a paper-trading-ready live system. Five remaining sub-phases on a single strict sequence, one dropped category (infrastructure hardening moved to Phase 7.5).
+Phase 5 bridges the gap between Phase 4's offline ML pipeline and a paper-trading-ready live system. Seven sub-phases on a single strict sequence, one dropped category (infrastructure hardening moved to Phase 7.5).
 
 | Sub-phase | Title | Status |
 |---|---|---|

--- a/docs/phases/PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md
+++ b/docs/phases/PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md
@@ -1,0 +1,348 @@
+# Phase 7.5 — Infrastructure Hardening — Backlog
+
+**Status**: BACKLOG — revisit only if Phase 8 live-trading benchmarks prove bottlenecks.
+**Created**: 2026-04-17
+**Origin**: [`docs/audits/STRATEGIC_AUDIT_2026-04-17_PHASE_5_AND_GLOBAL.md`](../audits/STRATEGIC_AUDIT_2026-04-17_PHASE_5_AND_GLOBAL.md) §4.2.
+**Supersedes scope of**: PHASE_5_SPEC.md v1 §3.6, §3.7, §3.9 (now canonical here).
+**Canonical active spec**: [`PHASE_5_SPEC_v2.md`](PHASE_5_SPEC_v2.md).
+
+---
+
+## 1. Rationale (Principles 1, 3, 7)
+
+These three sub-phases were part of PHASE_5_SPEC v1 but were deferred by the
+[STRATEGIC_AUDIT_2026-04-17](../audits/STRATEGIC_AUDIT_2026-04-17_PHASE_5_AND_GLOBAL.md) for
+the following reasons:
+
+1. **Principle 1 (long-term cash generation).** The operator has no live trading pipeline
+   yet. These three sub-phases collectively represent ~4–10 weeks of work that solves
+   latency / SPOF / serialization problems that are not yet measurable — and some that
+   are structurally irrelevant at the operator's scale. Every week spent here is a week
+   that delays live PnL.
+2. **Principle 3 (acknowledged constraints).** The operator runs ten Docker containers
+   on a single host with personal capital and no colocation / microsecond feeds. There
+   is no meaningful SPOF-isolation win from a P2P bus (when the host is down every
+   service is down regardless). JSON serialization overhead (~1 µs per tick at
+   10 ticks/sec/symbol × 10 symbols) is a rounding error against broker round-trip
+   latency (~50–200 ms). Rust FFI has no current bottleneck to prove.
+3. **Principle 7 (senior-quant tie-breaker).** A senior quant at AQR / Man AHL with a
+   one-person crew would ship alpha first, measure latency empirically from live
+   benchmarks, and only then decide which (if any) of these three to invest in.
+
+## 2. Re-entry criteria
+
+Each sub-phase below is **only** considered for implementation if **both** of the
+following are true:
+
+1. Phase 5 v2 has fully closed (5.1–5.10 all merged + paper trading live).
+2. Live benchmarks from Phase 8 demonstrate a specific bottleneck that the proposed
+   sub-phase would relieve, with quantified evidence (not speculation). Examples of
+   qualifying evidence:
+   - For 5.6 (P2P bus): measured broker-process failure frequency or message-loss rate
+     with containerized-isolation benefit.
+   - For 5.7 (SBE/FlatBuffers): profiler data showing JSON `model_dump_json()` in the
+     top 10 hot-path CPU consumers.
+   - For 5.9 (Rust FFI): P99 order-validation latency exceeding the in-memory-state
+     target of 100 µs with profiler data pinning Python overhead as the cause.
+
+Absent that evidence, these specifications are **kept frozen as historical reference
+only** and do not get scheduled.
+
+## 3. Relationship to existing work
+
+- **ADR-0001 (ZMQ Broker Topology)** remains ACCEPTED indefinitely; the planned
+  supersession in v1 §3.6 is cancelled. If Phase 7.5.1 is ever revived, a fresh ADR
+  records the decision as of that date.
+- The **Rust crates** (`apex_mc`, `apex_risk`) remain in use for Monte Carlo and
+  exposure computation per their existing production role. Phase 7.5.3 would extend
+  them with tick-processing + risk-validation hot paths; it does not replace them.
+- The **pydantic JSON serialization** in `core/bus.py` remains in use. Phase 7.5.2
+  would introduce dual-mode transport (binary + legacy JSON) rather than replacing
+  JSON outright.
+
+---
+
+## 4. Deferred sub-phase specifications
+
+The three sub-specs below are preserved **verbatim** from PHASE_5_SPEC v1 for audit-trail
+purposes. Numbering is retained at `5.6 / 5.7 / 5.9` inside the specs themselves even
+though these now live under Phase 7.5, to avoid breaking cross-references in historical
+documents (ADRs, session logs, PR bodies). When any of these is revived, the implementer
+should re-number as `7.5.1 / 7.5.2 / 7.5.3` at that time.
+
+---
+
+### (Former) 5.6 — ZMQ Peer-to-Peer Bus
+
+## 3.6 Sub-phase 5.6 — ZMQ Peer-to-Peer Bus
+
+### Objective
+Replace the centralized XSUB/XPUB broker (`zmq_broker.py`) with a
+distributed peer-to-peer topology using Redis-based service discovery.
+Eliminate the single point of failure.
+
+### Scope
+- **IN**: Each publisher BINDs its own ephemeral port; service
+  registry in Redis with TTL + heartbeat; subscribers CONNECT
+  directly to publishers; abstract `TransportLayer` interface for
+  future Aeron swap; chaos test proving resilience.
+- **OUT**: Aeron IPC implementation (evaluated, not shipped — Phase 6
+  if benchmarks justify); UDP multicast (network-dependent, deferred).
+
+### Module structure
+```
+core/
+├── bus.py                     # MODIFY — implement P2P topology
+├── transport.py               # NEW — TransportLayer ABC
+├── service_registry.py        # NEW — Redis-based registry
+├── zmq_broker.py              # DEPRECATE (keep for backward compat, flag)
+
+tests/unit/core/
+├── test_transport_layer.py    (~12 tests)
+├── test_service_registry.py   (~14 tests)
+
+tests/integration/
+├── test_zmq_p2p_resilience.py (~10 tests)
+```
+
+### Algorithm notes
+- Service registry: each publisher writes
+  `service:{service_id}:endpoint = "tcp://{ip}:{port}"` to Redis
+  with TTL = 10s. Heartbeat loop refreshes every 5s.
+- Subscriber startup: reads all `service:*:endpoint` keys matching
+  its subscription topics. CONNECTs directly to each publisher.
+- Dynamic discovery: subscriber polls registry every 10s for new
+  publishers (handles service restarts / scaling).
+- `TransportLayer` ABC with methods: `bind()`, `connect()`,
+  `publish()`, `subscribe()`. ZMQ implementation is the default.
+  Aeron implementation is a stub for Phase 6 evaluation.
+- Backward compatibility: services that haven't migrated can still
+  use the broker via a `LegacyBrokerTransport` adapter (transitional,
+  removed in Phase 6).
+
+### Criteria — Definition of Done
+1. Chaos test: kill any single service container → remaining
+   services continue communicating within 2s recovery.
+2. Latency reduction: measured P50/P99 transport latency lower than
+   broker topology (one fewer network hop).
+3. Service registry in Redis with TTL and heartbeat, tested.
+4. `TransportLayer` ABC with ZMQ + stub Aeron implementations.
+5. All tests passing, coverage ≥ 88%.
+6. `mypy --strict` clean, `ruff` clean.
+
+### Dependencies
+- Sub-phase 5.2 merged (event-sourcing defines the ZMQ topic
+  contract that P2P must honor).
+
+### Estimated scope
+- LOC: ~600–850.
+- Tests: ~36.
+- Complexity: **high** (infrastructure, distributed systems).
+- Copilot review cycles: **3**.
+
+### References
+- CME Group infrastructure whitepapers.
+- Real Logic Aeron (https://github.com/real-logic/aeron).
+- CLAUDE.md §2: "ZMQ topics are defined in core/topics.py."
+- ADR-0001 (superseded by this sub-phase).
+- GitHub issue #150.
+
+---
+
+### (Former) 5.7 — SBE / FlatBuffers Serialization
+
+## 3.7 Sub-phase 5.7 — SBE / FlatBuffers Serialization
+
+### Objective
+Migrate the hot-path message serialization from JSON
+(`.model_dump_json()`) to zero-copy binary encoding
+(FlatBuffers or SBE) to eliminate GC pressure from continuous
+string allocation.
+
+### Scope
+- **IN**: Binary schemas for `Tick`, `Signal`, `OrderCandidate`,
+  `RiskDecision`; compiled Python wrappers; `MessageBus` modified
+  to send/receive raw `bytes`; backward-compatible JSON adapter
+  for non-migrated services.
+- **OUT**: Full SBE compliance certification (not required for
+  internal use); Cap'n Proto evaluation (deferred).
+
+### Module structure
+```
+core/
+├── schemas/                   # NEW directory
+│   ├── tick.fbs               # FlatBuffers schema
+│   ├── signal.fbs
+│   ├── order_candidate.fbs
+│   └── risk_decision.fbs
+├── serialization.py           # NEW — encode/decode wrappers
+├── bus.py                     # MODIFY — bytes transport mode
+
+tests/unit/core/
+├── test_serialization.py      (~20 tests)
+├── test_bus_binary_mode.py    (~10 tests)
+
+tests/integration/
+├── test_binary_pipeline.py    (~6 tests)
+```
+
+### Algorithm notes
+- FlatBuffers chosen over SBE for Phase 5: richer tooling, Python
+  code generation, zero-copy access. SBE remains an option for
+  Phase 6 Rust hot path if FlatBuffers overhead is measured.
+- `MessageBus.publish()` accepts both `BaseModel` (legacy JSON path)
+  and `bytes` (new binary path). The bus detects the type and routes
+  accordingly. No service needs to change its consumer code until
+  explicitly migrated.
+- JSON adapter: non-migrated services receive a thin
+  `FlatBufferToJsonAdapter` that deserializes binary → Pydantic
+  model transparently. Performance penalty accepted for backward
+  compatibility during Phase 5.
+- Schema versioning: each `.fbs` file includes a `schema_version`
+  field. Consumers validate version on decode. Unknown versions
+  raise `ValueError` (fail-loud).
+
+### Criteria — Definition of Done
+1. CPU profiling report: > 80% reduction in serialization CPU time
+   for `Tick` messages.
+2. GC stability: stress test (10,000 ticks/s for 60s) shows
+   no GC pause > 10ms.
+3. Schemas versioned and documented.
+4. Backward-compatible: non-migrated services still consume JSON.
+5. All tests passing, coverage ≥ 90%.
+6. `mypy --strict` clean, `ruff` clean.
+
+### Dependencies
+- Sub-phase 5.6 merged (P2P bus defines the transport; binary
+  encoding is layered on top).
+
+### Estimated scope
+- LOC: ~500–700.
+- Tests: ~36.
+- Complexity: **medium** (schema design + dual-mode bus).
+- Copilot review cycles: **2**.
+
+### References
+- FIX Trading Community — SBE specification.
+- Google FlatBuffers (https://google.github.io/flatbuffers/).
+- CLAUDE.md §5: "Hot paths must avoid object allocation in inner
+  loops."
+- GitHub issue #151.
+
+---
+
+### (Former) 5.9 — Rust FFI Hot Path Migration
+
+## 3.9 Sub-phase 5.9 — Rust FFI Hot Path Migration
+
+### Objective
+Rewrite S01 (Market Data ingestion) and S05 (Risk validation) hot
+paths in Rust, connected to the Python ecosystem via FFI (PyO3 or
+shared-memory ring buffer). Achieve > 1M ticks/second/core for
+L2 order book processing.
+
+### Scope
+- **IN**: Rust crates `apex_mc` (market data) and `apex_risk`
+  (risk validation) extended with production-grade tick processing;
+  PyO3 FFI bindings for S02/S08 Python consumers; zero-copy shared
+  memory ring buffer for tick transmission; ADR documenting FFI
+  architecture; benchmark suite.
+- **OUT**: Full Rust monolith consolidation (Phase 6); Aeron
+  transport in Rust (Phase 6); GPU acceleration (Phase 6).
+
+### Module structure
+```
+rust/
+├── apex_mc/
+│   ├── src/
+│   │   ├── ingestion.rs       # EXTEND — production tick parser
+│   │   ├── ring_buffer.rs     # NEW — lock-free ring buffer
+│   │   └── ffi.rs             # NEW — PyO3 bindings
+│   └── Cargo.toml
+├── apex_risk/
+│   ├── src/
+│   │   ├── validator.rs       # EXTEND — order validation logic
+│   │   └── ffi.rs             # NEW — PyO3 bindings
+│   └── Cargo.toml
+
+services/s01_data_ingestion/
+├── rust_bridge.py             # NEW — Python FFI consumer
+
+services/s05_risk_manager/
+├── rust_bridge.py             # NEW — Python FFI consumer
+
+docs/adr/
+├── ADR-0007-rust-ffi-architecture.md  (NEW)
+
+tests/
+├── rust/                      # Rust-side unit tests (cargo test)
+├── unit/services/s01/
+│   └── test_rust_bridge.py    (~10 tests)
+├── unit/services/s05/
+│   └── test_rust_bridge.py    (~10 tests)
+├── integration/
+│   └── test_ffi_pipeline.py   (~8 tests)
+```
+
+### Algorithm notes
+- PyO3 chosen over raw shared memory for Phase 5 MVP: simpler
+  error handling, automatic reference counting, existing CI
+  infrastructure (`maturin build`). Shared-memory ring buffer
+  is a Phase 6 optimization if PyO3 overhead is measured.
+- The Rust tick parser handles L2 order book updates with
+  nanosecond-precision timestamps. Decimal arithmetic via the
+  `rust_decimal` crate (128-bit, matching Python `Decimal`
+  semantics).
+- FFI contract: Python calls `apex_mc.process_tick(raw_bytes) ->
+  NormalizedTick` and `apex_risk.validate_order(candidate, state)
+  -> RiskDecision`. Both functions are GIL-releasing.
+- Benchmark target: > 1M ticks/second/core for `process_tick`.
+  Measured via `criterion` benchmarks in Rust + Python wall-clock
+  in integration tests.
+
+### Criteria — Definition of Done
+1. ADR-0007 committed (FFI architecture: PyO3 vs SHM decision).
+2. Benchmark: > 1M ticks/s/core for `process_tick` (Rust).
+3. Benchmark: Python→Rust→Python round-trip < 5μs per tick.
+4. `cargo test --workspace` all passing.
+5. `maturin build` + `import apex_mc, apex_risk` in Python.
+6. Comparative benchmark: Python vs Rust on hot path (P50/P99/P999).
+7. Integration tests: FFI transparent for S02/S08.
+8. All Python tests passing, coverage ≥ 85%.
+9. `mypy --strict` clean, `ruff` clean.
+
+### Dependencies
+- Sub-phase 5.2 merged (event-sourced state is the Rust validation
+  target).
+- Track B (5.6, 5.7) preferred but not blocking (Rust operates at
+  the transport layer boundary).
+
+### Estimated scope
+- LOC: ~1500–2500 (Rust + Python bindings).
+- Tests: ~28 Python + ~40 Rust.
+- Complexity: **very high** (polyglot, FFI, performance).
+- Copilot review cycles: **4+**.
+
+### References
+- López de Prado (2018), AFML — research vs production separation.
+- PyO3 (https://pyo3.rs/).
+- CLAUDE.md §5: "CPU-bound math goes in Rust (apex_mc, apex_risk
+  crates) — not in Python."
+- GitHub issue #152.
+
+
+---
+
+## 5. Cross-reference map
+
+| Topic | Document |
+|---|---|
+| Strategic deferral rationale | [`STRATEGIC_AUDIT_2026-04-17_PHASE_5_AND_GLOBAL.md §4.2`](../audits/STRATEGIC_AUDIT_2026-04-17_PHASE_5_AND_GLOBAL.md) |
+| v1 original (superseded) | [`PHASE_5_SPEC.md`](PHASE_5_SPEC.md) |
+| v2 canonical active spec | [`PHASE_5_SPEC_v2.md`](PHASE_5_SPEC_v2.md) |
+| Backlog MD issues (DEFERRED banners) | [`docs/issues_backlog/issue_zmq_p2p.md`](../issues_backlog/issue_zmq_p2p.md) · [`issue_sbe_serialization.md`](../issues_backlog/issue_sbe_serialization.md) · [`issue_rust_hotpath.md`](../issues_backlog/issue_rust_hotpath.md) |
+| GitHub issues (to be closed as DEFERRED in Batch E) | #150 (ZMQ P2P), #151 (SBE), #152 (Rust FFI) |
+
+---
+
+**END OF PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.**

--- a/docs/phases/PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md
+++ b/docs/phases/PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md
@@ -144,7 +144,7 @@ tests/integration/
 - CME Group infrastructure whitepapers.
 - Real Logic Aeron (https://github.com/real-logic/aeron).
 - CLAUDE.md §2: "ZMQ topics are defined in core/topics.py."
-- ADR-0001 (superseded by this sub-phase).
+- ADR-0001 (remains ACCEPTED today; would be superseded only if this sub-phase is revived and implemented).
 - GitHub issue #150.
 
 ---


### PR DESCRIPTION
## Summary

Executes **BATCH C** of the [STRATEGIC_AUDIT_2026-04-17](docs/audits/STRATEGIC_AUDIT_2026-04-17_PHASE_5_AND_GLOBAL.md). Docs-only. Publishes **PHASE_5_SPEC v2** (the canonical active spec going forward) and a dedicated **PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md** for the three sub-phases deferred out of Phase 5.

### New files

- **[docs/phases/PHASE_5_SPEC_v2.md](docs/phases/PHASE_5_SPEC_v2.md)** (680 lines) — canonical Phase 5 spec. Five remaining sub-phases in the re-sequenced order: `5.1 (DONE) → 5.2 → 5.3 → 5.5 → 5.4 → 5.8 → 5.10`. Every sub-phase carries Objective / Scope (IN + OUT) / Module structure / Algorithm notes / DoD / Dependencies / Scope estimate / References.
- **[docs/phases/PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md](docs/phases/PHASE_7_5_INFRASTRUCTURE_HARDENING_BACKLOG.md)** (348 lines) — preserves the v1 specs of former sub-phases 5.6 / 5.7 / 5.9 verbatim with an explicit Principles-1/3/7 rationale and re-entry criteria.

### Key design decisions baked into v2

1. **Sub-phase 5.2 expanded** beyond the v1 event-sourcing scope. Per [REDIS_KEYS_WRITER_AUDIT_2026-04-17.md](docs/audits/REDIS_KEYS_WRITER_AUDIT_2026-04-17.md), all 8 S05 context keys are orphan. 5.2 now builds the producers at the same time as the in-memory consumer: `PortfolioTracker` in S06, `PnLTracker` + `PositionAggregator` in S09, session persistence shim in S03, VIX persistence shim in S01. Correlation matrix stays OUT (explicit logged identity fallback, tracked for 5.5 or Phase 6).
2. **5.5 promoted ahead of 5.4** — safety instrumentation before alpha extension (Principle 1).
3. **5.8 substitutes GDELT 2.0 + FinBERT** for the proprietary WorldMonitor gRPC (Principle 3, $0/month).
4. **S05 SRP decomposition** piggybacks onto 5.2 (since 5.2 rewrites context loading anyway).
5. **5.6 / 5.7 / 5.9 preserved verbatim** in the Phase 7.5 backlog — no design detail lost; re-entry gated on live-benchmark evidence.

### Existing files modified

- **[docs/phases/PHASE_5_SPEC.md](docs/phases/PHASE_5_SPEC.md)** — SUPERSEDED banner prepended. The v1 spec is now preserved for history only; all new work references v2.

## Test plan

- [x] `ruff check .` — clean
- [x] No Python touched — no pytest/mypy required
- [x] Cross-reference links verified (every link in v2 resolves to an existing file in the repo)
- [x] Former sub-phase 5.6/5.7/5.9 content extracted from v1 by section marker, not copy-paste — no drift

## Downstream

- BATCH D — SOLID decomposition of S05/S02 (code)
- BATCH E — GitHub issue triage (close #150/#151/#152 as DEFERRED, promote #102, retitle EPICs)
- Then: Phase 5.2 implementation begins against PHASE_5_SPEC_v2.md §3.2.

Refs #102, #123, #148, #149, #150, #151, #152, #153, #154, #156, #157, #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)