### PR TITLE
fix(backtesting): full_report Sharpe bug — sparse-day padding + OU fixture + regression tests (closes #102, progresses #195)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ graphify-out/
 # Phase 4.6 model artefacts — trained weights and cards are not source
 models/meta_labeler/*.joblib
 models/meta_labeler/*.json
+
+# Temporary exports for issue triage
+issues_full.json
+issues_list.txt
+

--- a/backtesting/metrics.py
+++ b/backtesting/metrics.py
@@ -237,8 +237,8 @@ def daily_equity_curve_from_trades(
     The sparse-day semantics (one entry per *active* trading day) are
     available via ``include_empty_days=False`` for callers who need the
     older shape. That mode inflates |Sharpe| as a function of trade
-    density and is not the Sharpe input contract (see
-    ``docs/CONVENTIONS/SHARPE_CONVENTION.md``).
+    density and is not the Sharpe input contract used by
+    :func:`sharpe_ratio`.
 
     Args:
         initial_capital: Starting capital.
@@ -283,8 +283,8 @@ def daily_equity_curve_from_trades(
     last_day = datetime.strptime(day_order[-1], "%Y-%m-%d").replace(tzinfo=UTC).date()
     span_days = (last_day - first_day).days + 1
     for offset in range(span_days):
-        day = first_day + timedelta(days=offset)
-        key = day.strftime("%Y-%m-%d")
+        day_date = first_day + timedelta(days=offset)
+        key = day_date.strftime("%Y-%m-%d")
         if key in daily_pnl:
             equity += daily_pnl[key]
         curve.append(equity)

--- a/backtesting/metrics.py
+++ b/backtesting/metrics.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
@@ -218,25 +218,45 @@ def equity_curve_from_trades(initial_capital: float, trades: list[TradeRecord]) 
 def daily_equity_curve_from_trades(
     initial_capital: float,
     trades: list[TradeRecord],
+    *,
+    include_empty_days: bool = True,
 ) -> list[float]:
     """Build a daily-resampled equity curve from trade records.
 
-    Trades are bucketed by UTC calendar day on their ``exit_timestamp_ms``.
-    The returned series contains one equity value per active day, equal to
-    the running portfolio equity after applying every trade closed on that
-    day. The initial capital is prepended so that ``pct_change`` over the
+    Returns the daily equity curve on a full calendar-day grid between
+    the first and last trade (both by UTC calendar day on
+    ``exit_timestamp_ms``). Days with no trades carry the previous day's
+    equity forward. This is the annualisation-safe representation: the
+    resulting series has one entry per calendar day in the active span,
+    so applying √252 annualisation in :func:`sharpe_ratio` yields a
+    density-invariant statistic (issue #102).
+
+    The initial capital is prepended so that ``pct_change`` over the
     series captures the first day's PnL.
 
-    This is the standard input for an annualised (√252) Sharpe ratio
-    (Lopez de Prado, 2018, Ch. 14): per-trade returns are not iid in time
-    and produce arbitrarily biased Sharpe values for HFT-style strategies.
+    The sparse-day semantics (one entry per *active* trading day) are
+    available via ``include_empty_days=False`` for callers who need the
+    older shape. That mode inflates |Sharpe| as a function of trade
+    density and is not the Sharpe input contract (see
+    ``docs/CONVENTIONS/SHARPE_CONVENTION.md``).
 
     Args:
         initial_capital: Starting capital.
         trades: Trade records (any order).
+        include_empty_days: When True (default), pad the curve to a full
+            calendar-day grid with carry-forward equity on silent days.
+            When False, emit one entry per active trading day
+            (pre-fix shape).
 
     Returns:
-        List of daily equity values, length = 1 + number of active days.
+        List of daily equity values. Length with ``include_empty_days``
+        is ``1 + (last_day - first_day + 1)`` calendar days; with
+        ``include_empty_days=False`` it is ``1 + n_active_days``.
+
+    Reference:
+        Lopez de Prado (2018). Advances in Financial Machine Learning,
+        Ch. 14.5 — annualised Sharpe is defined on an evenly-spaced
+        return series.
     """
     if not trades:
         return [initial_capital]
@@ -248,10 +268,25 @@ def daily_equity_curve_from_trades(
         if day not in daily_pnl:
             day_order.append(day)
         daily_pnl[day] += _to_float(trade.net_pnl)
+
     equity = initial_capital
     curve = [equity]
-    for day in day_order:
-        equity += daily_pnl[day]
+    if not include_empty_days:
+        for day in day_order:
+            equity += daily_pnl[day]
+            curve.append(equity)
+        return curve
+
+    # Dense calendar-day grid: iterate every day from first to last
+    # active day (inclusive). Silent days carry equity forward.
+    first_day = datetime.strptime(day_order[0], "%Y-%m-%d").replace(tzinfo=UTC).date()
+    last_day = datetime.strptime(day_order[-1], "%Y-%m-%d").replace(tzinfo=UTC).date()
+    span_days = (last_day - first_day).days + 1
+    for offset in range(span_days):
+        day = first_day + timedelta(days=offset)
+        key = day.strftime("%Y-%m-%d")
+        if key in daily_pnl:
+            equity += daily_pnl[key]
         curve.append(equity)
     return curve
 

--- a/scripts/generate_test_fixtures.py
+++ b/scripts/generate_test_fixtures.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
 # Ornstein-Uhlenbeck parameters. Tuned so that (a) the process stays
@@ -47,7 +48,7 @@ _OU_SIGMA: float = 15.0  # diffusion term per sqrt(minute)
 _SEED: int = 42  # fixed for byte-deterministic fixture output
 
 
-def _generate_ou_price_path(n: int, rng: np.random.Generator) -> np.ndarray:
+def _generate_ou_price_path(n: int, rng: np.random.Generator) -> npt.NDArray[np.float64]:
     """Simulate n minutes of a discrete OU process starting at mu.
 
     Uses the Euler-Maruyama discretisation with dt=1 (minute). Clamps the

--- a/scripts/generate_test_fixtures.py
+++ b/scripts/generate_test_fixtures.py
@@ -10,25 +10,26 @@ Schema is aligned with backtesting.data_loader.load_parquet():
     bid / ask    : float64
     spread_bps   : float64
     session      : str        ("after_hours")
-"""
 
-# ── KNOWN ISSUE: APEX-METRICS-V2 ──────────────────────────────────────
-# This fixture intentionally generates a CONSTANT price series so that
-# the backtest engine produces zero trades, exercising the data-loader
-# contract end-to-end without triggering a structural bug in
-# backtesting/metrics.full_report().
-#
-# The bug: full_report() computes Sharpe on per-trade returns minus an
-# annualised 5% risk-free rate (~2bps per period). For HFT-style tiny
-# per-trade returns (1e-5 magnitude), the -rf term dominates entirely,
-# producing arbitrarily negative Sharpe even with winrate >90% and
-# positive net PnL (verified empirically: PF=15.84, WR=93% -> Sharpe=-3709).
-#
-# Until APEX-METRICS-V2 reworks Sharpe to use the equity-curve returns,
-# the backtest-gate job is marked `continue-on-error: true` in CI and
-# this fixture stays constant. DO NOT add price variation here without
-# first fixing full_report().
-# ──────────────────────────────────────────────────────────────────────
+The price path is a discrete Ornstein-Uhlenbeck process:
+
+    X_{t+1} = X_t + theta * (mu - X_t) * dt + sigma * sqrt(dt) * Z_t
+
+with ``Z_t ~ N(0, 1)``, ``dt = 1`` minute. Parameters (see
+``_OU_THETA``, ``_OU_MU``, ``_OU_SIGMA``) produce a price that oscillates
+inside a plausible band around ``mu`` with a half-life of ~11.5 hours,
+creating mean-reversion opportunities the Phase 3/4 signal suite can
+exercise. The RNG seed is fixed so the fixture is byte-deterministic
+across runs (tests/unit/scripts/test_fixture_determinism.py enforces).
+
+Why this fixture replaced the previous constant-price one: the old
+generator emitted ``np.full(43_200, 45_000.0)`` so the BacktestEngine
+produced zero trades and ``scripts/backtest_regression.py`` short-
+circuited with exit 0 without ever running ``full_report()``. That made
+the CI backtest-gate structurally vacuous — passing regardless of
+Sharpe/DD correctness. See issue #102 + STRATEGIC_AUDIT_2026-04-17
+Tech Finding 3.
+"""
 
 from __future__ import annotations
 
@@ -37,22 +38,38 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+# Ornstein-Uhlenbeck parameters. Tuned so that (a) the process stays
+# inside a realistic ~1% band around mu, (b) minute-scale volatility is
+# large enough to trigger the microstructure signal suite.
+_OU_THETA: float = 0.001  # mean-reversion speed per minute (half-life ~11.5h)
+_OU_MU: float = 45_000.0  # long-term mean in USD
+_OU_SIGMA: float = 15.0  # diffusion term per sqrt(minute)
+_SEED: int = 42  # fixed for byte-deterministic fixture output
+
+
+def _generate_ou_price_path(n: int, rng: np.random.Generator) -> np.ndarray:
+    """Simulate n minutes of a discrete OU process starting at mu.
+
+    Uses the Euler-Maruyama discretisation with dt=1 (minute). Clamps the
+    output at a 1.0 floor as a defensive guard — with the chosen params
+    the steady-state std is ~335, so the floor never activates in
+    practice but we want to fail loudly if the params are ever retuned
+    to something unrealistic.
+    """
+    price = np.empty(n, dtype=np.float64)
+    price[0] = _OU_MU
+    noise = rng.standard_normal(n)
+    for i in range(1, n):
+        drift = _OU_THETA * (_OU_MU - price[i - 1])
+        price[i] = price[i - 1] + drift + _OU_SIGMA * noise[i]
+    return np.maximum(price, 1.0)
+
 
 def main() -> None:
-    rng = np.random.default_rng(42)
-    n = 43_200  # 30 days x 24h x 60min
+    rng = np.random.default_rng(_SEED)
+    n = 43_200  # 30 days × 24h × 60min
 
-    # Strong trending bull market with small mean-reverting noise: produces
-    # a clean positive-EV regime for scalping/trend strategies.
-    # Constant-price fixture: no signal triggers in the BacktestEngine, so
-    # zero trades are generated and scripts/backtest_regression.py exits 0
-    # via its no-trades short-circuit. The full_report Sharpe formula is
-    # computed against a 5% annualised risk-free rate which structurally
-    # produces large negative ratios on the engine's tiny default position
-    # sizes; until that calculation is reworked (separate issue), this
-    # fixture is intentionally non-tradeable so the regression gate runs
-    # the data-loader contract end-to-end without false-failing on Sharpe.
-    price = np.full(n, 45_000.0, dtype=np.float64)
+    price = _generate_ou_price_path(n, rng)
 
     start_ms = int(pd.Timestamp("2024-01-01", tz="UTC").timestamp() * 1000)
     timestamp_ms = start_ms + np.arange(n, dtype=np.int64) * 60_000  # 1-min cadence
@@ -75,7 +92,8 @@ def main() -> None:
     out.parent.mkdir(parents=True, exist_ok=True)
     df.to_parquet(out, index=False)
     print(f"Generated {n} candles -> {out}")
-    print(f"  Price range: ${price.min():.0f} - ${price.max():.0f}")
+    print(f"  Price range: ${price.min():.2f} - ${price.max():.2f}")
+    print(f"  Price mean / std: ${price.mean():.2f} / ${price.std():.2f}")
     print(f"  Time range:  {timestamp_ms[0]} -> {timestamp_ms[-1]} (ms epoch)")
 
 

--- a/tests/unit/backtesting/test_full_report_sharpe.py
+++ b/tests/unit/backtesting/test_full_report_sharpe.py
@@ -1,0 +1,298 @@
+"""Known-answer Sharpe regression tests for backtesting.metrics.
+
+Exposes the sparse-day annualisation bias in
+:func:`backtesting.metrics.daily_equity_curve_from_trades` (issue #102).
+
+The broken implementation skips calendar days with no trades, so a
+strategy firing on N << 252 days has its N daily returns annualised by
+sqrt(252) as if each represented a full trading day. This structurally
+inflates |Sharpe| as a function of trade density rather than of
+risk-adjusted performance.
+
+These tests must FAIL against the pre-fix implementation. The failure
+output in the commit message of commit 2 is the SD-8 audit trail.
+"""
+
+from __future__ import annotations
+
+import math
+from decimal import Decimal
+
+import pytest
+
+from backtesting.metrics import (
+    _ANNUAL_FACTOR_DAILY,
+    daily_equity_curve_from_trades,
+    daily_returns_from_equity,
+    full_report,
+    sharpe_ratio,
+)
+from core.models.order import TradeRecord
+from core.models.signal import Direction
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# 2024-01-01 00:00:00 UTC in epoch seconds (a Monday).
+_BASE_TS_S = 1_704_067_200
+_DAY_MS = 86_400 * 1000
+
+
+def _make_trade(net_pnl: float, day_offset: int) -> TradeRecord:
+    """Construct a TradeRecord that closes at UTC midday on day `day_offset`."""
+    pnl = Decimal(str(round(net_pnl, 4)))
+    entry = Decimal("50000")
+    size = Decimal("0.01")
+    # Avoid division-by-zero when net_pnl == 0 by clamping size delta to 0.
+    delta = pnl / size if pnl != 0 else Decimal("0")
+    exit_p = entry + delta
+    exit_ts_ms = (_BASE_TS_S + day_offset * 86_400 + 43_200) * 1000  # midday
+    return TradeRecord(
+        trade_id=f"t-{day_offset}-{net_pnl}",
+        symbol="BTC/USDT",
+        direction=Direction.LONG,
+        entry_timestamp_ms=exit_ts_ms - 1000,
+        exit_timestamp_ms=exit_ts_ms,
+        entry_price=entry,
+        exit_price=exit_p,
+        size=size,
+        gross_pnl=pnl,
+        net_pnl=pnl,
+        commission=Decimal("0"),
+        slippage_cost=Decimal("0"),
+        signal_type="OFI",
+        regime_at_entry="TRENDING",
+        session_at_entry="us_normal",
+    )
+
+
+# ---------------------------------------------------------------------------
+# SD-1 — Analytically known Sharpe on sharpe_ratio() directly
+# ---------------------------------------------------------------------------
+
+
+class TestSharpeKnownAnswer:
+    """Three analytically-known Sharpe scenarios on the bare helper."""
+
+    def test_a_constant_positive_returns_infinite_sharpe(self) -> None:
+        """Zero-variance positive series returns sign-aware +inf.
+
+        The implementation documents this as the correct convention for a
+        zero-variance series: consistent gains -> +inf, consistent losses
+        -> -inf, flat -> 0.0.
+        """
+        returns = [0.001] * 100
+        assert sharpe_ratio(returns, risk_free_rate=0.0) == float("inf")
+
+    def test_b_mean_001_std_01_daily_gives_expected_annualised_sharpe(self) -> None:
+        """252 daily returns with mean=0.001 and pop_std=0.01.
+
+        Analytical Sharpe (rf=0) = (mean / sample_std) * sqrt(252)
+        where sample_std = pop_std * sqrt(n / (n-1)).
+        For n=252, sample_std = 0.01 * sqrt(252/251) ~ 0.01002.
+        Expected annualised Sharpe ~ (0.001 / 0.01002) * sqrt(252) ~ 1.584.
+        """
+        mu, sigma = 0.001, 0.01
+        returns = [mu + sigma if i % 2 == 0 else mu - sigma for i in range(252)]
+        computed = sharpe_ratio(returns, risk_free_rate=0.0)
+        sample_std = sigma * math.sqrt(252 / 251)
+        expected = (mu / sample_std) * math.sqrt(252)
+        assert abs(computed - expected) < 0.01, (
+            f"Sharpe {computed:.4f} diverged from analytical {expected:.4f} beyond 0.01 tolerance"
+        )
+
+    def test_c_negative_mean_gives_negative_annualised_sharpe(self) -> None:
+        """252 daily returns with mean=-0.0005 and pop_std=0.01.
+
+        Expected annualised Sharpe (rf=0) ~ -0.792.
+        """
+        mu, sigma = -0.0005, 0.01
+        returns = [mu + sigma if i % 2 == 0 else mu - sigma for i in range(252)]
+        computed = sharpe_ratio(returns, risk_free_rate=0.0)
+        sample_std = sigma * math.sqrt(252 / 251)
+        expected = (mu / sample_std) * math.sqrt(252)
+        assert computed < 0, f"expected negative Sharpe, got {computed}"
+        assert abs(computed - expected) < 0.01, (
+            f"Sharpe {computed:.4f} diverged from analytical {expected:.4f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# SD-8 — Tests that MUST FAIL against the pre-fix implementation
+# ---------------------------------------------------------------------------
+
+
+class TestDenseGridContract:
+    """Tests that pin down the dense calendar-day grid contract."""
+
+    def test_full_report_calendar_day_grid_contract(self) -> None:
+        """daily_equity_curve must span the full [first_day, last_day] grid.
+
+        Ten-day span with trades only on days 0, 2, 6. The returned curve
+        must have 11 entries (one seed + 10 calendar days), not 4
+        (one seed + 3 active days) as the sparse-day impl returns.
+        """
+        trades = [
+            _make_trade(+1000.0, 0),
+            _make_trade(+1000.0, 2),
+            _make_trade(+1000.0, 6),
+        ]
+        curve = daily_equity_curve_from_trades(100_000.0, trades)
+        # Expected: initial_capital + 7 calendar days (day 0 through day 6).
+        assert len(curve) == 8, (
+            f"daily_equity_curve has {len(curve)} entries; expected 8 "
+            f"(1 seed + 7 days from day 0 through day 6). Sparse-day "
+            f"impl returns 4. Curve: {curve}"
+        )
+
+    def test_full_report_empty_days_carry_forward(self) -> None:
+        """Silent days must carry the previous equity forward."""
+        trades = [_make_trade(+1000.0, 0), _make_trade(+1000.0, 6)]
+        curve = daily_equity_curve_from_trades(100_000.0, trades)
+        # Grid: [seed, day0, day1, day2, day3, day4, day5, day6].
+        # day0 closes at 101_000; days 1-5 are silent and carry forward;
+        # day 6 closes at 102_000.
+        assert curve[0] == pytest.approx(100_000.0)
+        assert curve[1] == pytest.approx(101_000.0)
+        for i in range(2, 7):
+            assert curve[i] == pytest.approx(101_000.0), (
+                f"day {i - 1} silent-day equity {curve[i]} did not carry "
+                f"forward from day 0 equity 101000"
+            )
+        assert curve[7] == pytest.approx(102_000.0)
+
+    def test_daily_returns_zero_on_silent_days(self) -> None:
+        """daily_returns_from_equity must emit 0.0 for silent (flat) days."""
+        trades = [_make_trade(+1000.0, 0), _make_trade(+1000.0, 6)]
+        curve = daily_equity_curve_from_trades(100_000.0, trades)
+        returns = daily_returns_from_equity(curve)
+        # 8-entry curve -> 7 returns, one per calendar day in the span.
+        assert len(returns) == 7, f"expected 7 daily returns, got {len(returns)}"
+        # days 2..6 in the return list (indices 1..5) are silent carry-forward days.
+        for i in range(1, 6):
+            assert returns[i] == pytest.approx(0.0, abs=1e-12), (
+                f"silent day {i + 1} return {returns[i]} != 0.0"
+            )
+
+
+class TestSharpeInvariantToTradeDensity:
+    """A strategy's Sharpe must not be inflated by sparse firing alone."""
+
+    def test_sparse_sharpe_not_inflated_vs_dense(self) -> None:
+        """Same total PnL, sparser firing -> Sharpe must not explode.
+
+        Under the BROKEN sparse-day impl, a 3-trade strategy over 30 days
+        has 3 daily returns annualised by sqrt(252), producing a Sharpe
+        that is inflated by roughly sqrt(252/N_active) relative to a
+        dense strategy with the same total return. Under the FIX both are
+        annualised on the full 30-day calendar grid.
+        """
+        dense = [_make_trade(+100.0, d) for d in range(30)]
+        sparse = [_make_trade(+1000.0, d) for d in (0, 14, 29)]
+
+        dense_total = sum(float(t.net_pnl) for t in dense)
+        sparse_total = sum(float(t.net_pnl) for t in sparse)
+        assert dense_total == pytest.approx(sparse_total, rel=1e-9), (
+            "test setup: dense and sparse must have identical total PnL"
+        )
+
+        r_dense = full_report(dense, initial_capital=100_000.0, risk_free_rate=0.0)
+        r_sparse = full_report(sparse, initial_capital=100_000.0, risk_free_rate=0.0)
+
+        assert math.isfinite(r_sparse["sharpe"]), (
+            f"sparse Sharpe is non-finite: {r_sparse['sharpe']}"
+        )
+        # Under the broken impl sparse Sharpe is several hundred due to
+        # std collapsing on 3 nearly-identical returns. Under the fix it
+        # is bounded by a small multiple of the dense Sharpe.
+        assert r_sparse["sharpe"] < 50.0, (
+            f"sparse Sharpe ({r_sparse['sharpe']:.2f}) is implausibly high; "
+            f"indicates sparse-day annualisation bias. "
+            f"Dense Sharpe for the same total PnL was {r_dense['sharpe']:.2f}."
+        )
+
+    def test_sparse_sharpe_bounded_by_dense_for_same_total_return(self) -> None:
+        """Lumpier PnL (same total) must not produce higher Sharpe.
+
+        Sharpe penalises lumpiness via the denominator; a sparser strategy
+        with the same total return must have a Sharpe <= the dense one.
+        """
+        dense = [_make_trade(+100.0, d) for d in range(30)]
+        sparse = [_make_trade(+1000.0, d) for d in (0, 14, 29)]
+
+        r_dense = full_report(dense, initial_capital=100_000.0, risk_free_rate=0.0)
+        r_sparse = full_report(sparse, initial_capital=100_000.0, risk_free_rate=0.0)
+
+        if math.isfinite(r_dense["sharpe"]):
+            assert r_sparse["sharpe"] <= r_dense["sharpe"] + 1e-6, (
+                f"sparse Sharpe ({r_sparse['sharpe']:.4f}) > dense Sharpe "
+                f"({r_dense['sharpe']:.4f}) for same total return "
+                f"— sparse-day annualisation bias suspected"
+            )
+
+
+class TestKnownAnalyticalSharpeOnFullReport:
+    """Direct analytical Sharpe on a full_report() pipeline."""
+
+    def test_full_report_sharpe_matches_analytical_on_30_day_fixture(self) -> None:
+        """Build a deterministic 30-day series, check Sharpe end-to-end.
+
+        30 daily trades with alternating PnL that yields deterministic
+        mean and std on the daily return series. The bare-helper Sharpe
+        (computed on the same daily_returns) is the ground truth; full
+        report must match that ground truth exactly (rel=1e-6).
+        """
+        # Alternating +500 / +100 PnL over 30 consecutive days.
+        trades: list[TradeRecord] = []
+        for d in range(30):
+            pnl = 500.0 if d % 2 == 0 else 100.0
+            trades.append(_make_trade(pnl, d))
+
+        report = full_report(trades, initial_capital=100_000.0, risk_free_rate=0.05)
+
+        curve = daily_equity_curve_from_trades(100_000.0, trades)
+        returns = daily_returns_from_equity(curve)
+        expected_sharpe = sharpe_ratio(
+            returns,
+            risk_free_rate=0.05,
+            annual_factor=_ANNUAL_FACTOR_DAILY,
+        )
+
+        assert report["sharpe"] == pytest.approx(expected_sharpe, rel=1e-6), (
+            f"full_report sharpe ({report['sharpe']:.6f}) diverged from "
+            f"bare-helper ground truth ({expected_sharpe:.6f})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# SD-4 — Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge-case coverage: empty, singleton, all losers."""
+
+    def test_empty_trade_list_returns_error(self) -> None:
+        report = full_report([], initial_capital=100_000.0)
+        assert report == {"error": "no trades"}
+
+    def test_single_trade_sharpe_is_zero_or_sentinel(self) -> None:
+        """A single trade -> single daily return -> len(returns) == 1.
+
+        sharpe_ratio() guards len(returns) < 2 by returning 0.0. The
+        fixed daily_equity_curve still emits only a 2-entry curve for a
+        single-day fixture (first == last), so the guard fires and the
+        report surfaces a Sharpe of 0.0.
+        """
+        trades = [_make_trade(+1000.0, 0)]
+        report = full_report(trades, initial_capital=100_000.0)
+        assert report["sharpe"] == pytest.approx(0.0)
+
+    def test_all_losers_produce_negative_sharpe(self) -> None:
+        """30 losing trades -> mean daily return < 0 -> Sharpe < 0."""
+        trades = [_make_trade(-50.0, d) for d in range(30)]
+        report = full_report(trades, initial_capital=100_000.0, risk_free_rate=0.0)
+        assert report["sharpe"] < 0.0, (
+            f"30 losing trades should yield negative Sharpe, got {report['sharpe']}"
+        )

--- a/tests/unit/backtesting/test_full_report_sharpe.py
+++ b/tests/unit/backtesting/test_full_report_sharpe.py
@@ -129,9 +129,10 @@ class TestDenseGridContract:
     def test_full_report_calendar_day_grid_contract(self) -> None:
         """daily_equity_curve must span the full [first_day, last_day] grid.
 
-        Ten-day span with trades only on days 0, 2, 6. The returned curve
-        must have 11 entries (one seed + 10 calendar days), not 4
-        (one seed + 3 active days) as the sparse-day impl returns.
+        Seven calendar days are covered here: trades occur on days 0, 2,
+        and 6, so the returned curve must have 8 entries (one seed + days
+        0 through 6), not 4 (one seed + 3 active days) as the sparse-day
+        impl returns.
         """
         trades = [
             _make_trade(+1000.0, 0),

--- a/tests/unit/scripts/test_fixture_determinism.py
+++ b/tests/unit/scripts/test_fixture_determinism.py
@@ -1,0 +1,100 @@
+"""Byte-determinism regression for the backtest-gate fixture generator.
+
+The CI backtest-gate relies on ``scripts/generate_test_fixtures.py`` producing
+an identical parquet file on every run — otherwise Sharpe/DD thresholds would
+drift between CI runs and could silently pass or fail for reasons unrelated
+to code changes.
+
+Fail-fast: any non-determinism in the OU process (missing seed, non-fixed RNG,
+non-deterministic pandas operation) is caught here instead of on the nightly
+CI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from scripts.generate_test_fixtures import (
+    _OU_MU,
+    _OU_SIGMA,
+    _OU_THETA,
+    _SEED,
+    _generate_ou_price_path,
+)
+
+
+def _path_hash(p: Path) -> str:
+    return hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+def test_price_path_is_deterministic_across_runs() -> None:
+    """Two runs with the fixed seed yield bit-identical price arrays."""
+    rng1 = np.random.default_rng(_SEED)
+    rng2 = np.random.default_rng(_SEED)
+    path1 = _generate_ou_price_path(1_000, rng1)
+    path2 = _generate_ou_price_path(1_000, rng2)
+    assert np.array_equal(path1, path2), (
+        "OU price path diverged across two runs with the same seed — "
+        "fixture is not byte-deterministic"
+    )
+
+
+def test_price_path_parameters_are_within_realistic_band() -> None:
+    """Steady-state std implied by OU params stays within a realistic 1% band.
+
+    Protects against future retuning that would silently expand or
+    collapse the price band and invalidate the backtest thresholds.
+    """
+    rng = np.random.default_rng(_SEED)
+    path = _generate_ou_price_path(43_200, rng)
+    # With theta=0.001, sigma=15, steady-state std = sigma / sqrt(2*theta) ~ 335.
+    # Observed std over 30 days should be O(hundreds), not O(thousands).
+    observed_std = float(np.std(path))
+    assert 100.0 < observed_std < 1_000.0, (
+        f"OU steady-state std = {observed_std:.2f}; outside [100, 1000] "
+        f"realistic band. Params may have drifted from "
+        f"(theta={_OU_THETA}, mu={_OU_MU}, sigma={_OU_SIGMA})."
+    )
+
+
+def test_parquet_output_is_byte_deterministic(tmp_path: Path) -> None:
+    """Writing the fixture twice with the fixed seed yields identical bytes."""
+    rng_a = np.random.default_rng(_SEED)
+    rng_b = np.random.default_rng(_SEED)
+    n = 1_000
+    price_a = _generate_ou_price_path(n, rng_a)
+    price_b = _generate_ou_price_path(n, rng_b)
+
+    start_ms = int(pd.Timestamp("2024-01-01", tz="UTC").timestamp() * 1000)
+    timestamp_ms = start_ms + np.arange(n, dtype=np.int64) * 60_000
+
+    def _write(path: Path, price: np.ndarray, rng: np.random.Generator) -> None:
+        df = pd.DataFrame(
+            {
+                "symbol": "BTCUSDT",
+                "market": "crypto",
+                "timestamp_ms": timestamp_ms,
+                "price": price,
+                "volume": rng.uniform(0.5, 5.0, n),
+                "side": "unknown",
+                "bid": price * 0.9999,
+                "ask": price * 1.0001,
+                "spread_bps": np.full(n, 1.0, dtype=np.float64),
+                "session": "after_hours",
+            }
+        )
+        df.to_parquet(path, index=False)
+
+    a = tmp_path / "a.parquet"
+    b = tmp_path / "b.parquet"
+    _write(a, price_a, np.random.default_rng(_SEED + 1))
+    _write(b, price_b, np.random.default_rng(_SEED + 1))
+
+    assert _path_hash(a) == _path_hash(b), (
+        "Two parquet writes with identical inputs produced different bytes — "
+        "pandas / pyarrow is introducing non-determinism"
+    )


### PR DESCRIPTION
## Summary

Cherry-picked from abandoned branch `fix/ci-backtest-gate-sharpe` (had doc regressions); this branch contains only the 3 clean code commits.

Fixes the `full_report()` Sharpe calculation bug by:

1. **Sparse-day annualisation bias**: the equity curve was annualised on observed-day count rather than calendar-day count, inflating Sharpe when trades cluster in a subset of days. Fix: pad the equity curve to a full calendar-day grid before annualisation.

2. **Dead constant-price fixture**: the test fixture emitted `np.full(43_200, 45_000.0)` which produced zero trades and short-circuited the no-trades branch in `backtest_regression.py`. Replaced with an Ornstein-Uhlenbeck mean-reverting synthetic that exercises the signal suite (mu=45_000, theta=0.001/min, sigma=15/sqrt(min), seed=42, range ~1% band).

3. **Known-answer regression tests**: 298 lines of new tests in `tests/unit/backtesting/test_full_report_sharpe.py` exposing the sparse-day bias and verifying the fix on fixed fixtures.

## Changes

| File | Lines | Change |
|---|---|---|
| `backtesting/metrics.py` | +57 | Calendar-day padding in full_report |
| `scripts/generate_test_fixtures.py` | +84 | OU fixture replacing constant-price |
| `tests/unit/backtesting/test_full_report_sharpe.py` | +298 (new) | Regression tests |
| `tests/unit/scripts/test_fixture_determinism.py` | +100 (new) | Fixture determinism tests |

**Total: 495 insertions, 44 deletions.**

## Context within Phase A

This PR closes the oldest half of `#195 [phase-A.5] Fix full_report backtest-gate: Sharpe/DD/PSR excess-return consistency`. After this merges, `#195` is reduced to the PSR/DSR excess-return consistency work (easier scope).

Also unblocks `#196 [phase-A.6] Un-muzzle CI backtest-gate` which depends on the Sharpe fix landing first.

## Commits

- `d2bf93f` test(backtesting): add known-answer Sharpe regression tests exposing sparse-day bias (#102)
- `2297430` fix(backtesting): pad equity curve to full calendar-day grid to eliminate sparse-day annualisation bias (#102)
- `ba9a7e3` test(backtesting): replace dead constant-price fixture with Ornstein-Uhlenbeck mean-reverting synthetic (#102)

## Test plan

- [ ] CI unit-tests green (runs both new test files automatically)
- [ ] CI backtest-gate: still muzzled via `|| true` until #196; this PR does NOT un-muzzle (that's #196's scope)
- [ ] No regression on existing backtesting tests
- [ ] Copilot review

Closes #102.
Progresses #195.
Unblocks #196.