### PR TITLE
feat(core): Signal.strategy_id (phase-A.1, closes #191)

### DIFF
--- a/core/models/signal.py
+++ b/core/models/signal.py
@@ -117,6 +117,14 @@ class Signal(BaseModel):
     signal_id: str = Field(..., description="Unique signal identifier")
     symbol: str = Field(..., description="Uppercase trading symbol")
     timestamp_ms: int = Field(..., gt=0, description="Signal generation time UTC ms")
+    strategy_id: str = Field(
+        default="default",
+        description=(
+            "Per-strategy identifier (Charter §5.5, ADR-0007 §D6). "
+            "Default 'default' preserves the legacy single-strategy path "
+            "until Phase B wraps it as LegacyConfluenceStrategy."
+        ),
+    )
 
     # Direction and strength
     direction: Direction = Field(..., description="Trade direction")
@@ -167,6 +175,31 @@ class Signal(BaseModel):
     def symbol_uppercase(cls, v: str) -> str:
         """Ensure symbol is uppercase."""
         return v.upper()
+
+    @field_validator("strategy_id")
+    @classmethod
+    def validate_strategy_id(cls, v: str) -> str:
+        """Reject strategy_ids that break ZMQ topics, Redis keys, or filesystem paths.
+
+        Empty strings, whitespace, forward/backslashes and quote characters are
+        rejected because strategy_id is interpolated into ZMQ topics
+        (`signal.technical.{strategy_id}.{symbol}` per Charter §5.5), Redis keys
+        (`kelly:{strategy_id}:{symbol}` et al. per ADR-0007 §D6) and filesystem
+        paths (`services/strategies/{strategy_id}/` per ADR-0007 §D2). Length is
+        capped at 64 to keep Redis key lengths bounded.
+        """
+        if not v:
+            raise ValueError("strategy_id must be non-empty")
+        if len(v) > 64:
+            raise ValueError(f"strategy_id length {len(v)} exceeds max 64 characters")
+        forbidden = set(" \t\n\r\v\f/\\'\"")
+        bad = sorted(set(v) & forbidden)
+        if bad:
+            raise ValueError(
+                f"strategy_id contains forbidden characters {bad!r}; "
+                "whitespace, slashes and quotes are not permitted"
+            )
+        return v
 
     @model_validator(mode="after")
     def validate_price_levels(self) -> Signal:

--- a/core/models/signal.py
+++ b/core/models/signal.py
@@ -181,12 +181,23 @@ class Signal(BaseModel):
     def validate_strategy_id(cls, v: str) -> str:
         """Reject strategy_ids that break ZMQ topics, Redis keys, or filesystem paths.
 
-        Empty strings, whitespace, forward/backslashes and quote characters are
-        rejected because strategy_id is interpolated into ZMQ topics
-        (`signal.technical.{strategy_id}.{symbol}` per Charter §5.5), Redis keys
-        (`kelly:{strategy_id}:{symbol}` et al. per ADR-0007 §D6) and filesystem
-        paths (`services/strategies/{strategy_id}/` per ADR-0007 §D2). Length is
-        capped at 64 to keep Redis key lengths bounded.
+        At Phase A.1, ``strategy_id`` is carried as metadata on the Signal
+        contract but the downstream consumers still use the legacy single-
+        strategy form: ZMQ publishes on ``signal.technical.{SYMBOL}``
+        (``core.topics.Topics.signal``) and Kelly stats live at
+        ``kelly:{symbol}`` / ``feedback:kelly_stats:{strategy_key}``
+        (``services/s04_fusion_engine/kelly_sizer.py``). Phase A.4 introduces
+        ``Topics.signal_for(strategy_id, symbol)`` →
+        ``signal.technical.{strategy_id}.{symbol}`` and Phase A.5+ rewrites
+        the Redis keys to ``kelly:{strategy_id}:{symbol}`` per Charter §5.5
+        and ADR-0007 §D6/D7; filesystem paths follow
+        ``services/strategies/{strategy_id}/`` per ADR-0007 §D2.
+
+        The validator enforces the structural constraints required by those
+        future consumers **now**, so no invalid identifier can enter the
+        pipeline before the downstream code flips over. Empty strings,
+        whitespace, forward/backslashes and quote characters are rejected,
+        and length is capped at 64 to keep Redis key lengths bounded.
         """
         if not v:
             raise ValueError("strategy_id must be non-empty")

--- a/tests/unit/core/models/test_signal_strategy_id.py
+++ b/tests/unit/core/models/test_signal_strategy_id.py
@@ -1,0 +1,209 @@
+"""Unit tests for the `strategy_id` field on the `Signal` Pydantic model.
+
+Covers Phase A §2.2.1 / Charter §5.5 / ADR-0007 §D6:
+
+- default value is `"default"` (backward compatibility with the legacy
+  single-strategy codebase);
+- custom values are preserved verbatim;
+- the model stays `frozen=True` so mutation is rejected;
+- structurally unsafe identifiers (whitespace, slashes, quotes, empty,
+  length > 64) are rejected for ZMQ/Redis/filesystem compatibility;
+- JSON round-trip preserves any valid ASCII snake_case identifier.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from core.models.signal import Direction, Signal
+
+
+def _make_signal(**overrides: object) -> Signal:
+    """Build a minimally valid long-direction Signal, with optional overrides."""
+    defaults: dict[str, object] = {
+        "signal_id": "sig-001",
+        "symbol": "BTCUSDT",
+        "timestamp_ms": 1_700_000_000_000,
+        "direction": Direction.LONG,
+        "strength": 0.5,
+        "entry": Decimal("100"),
+        "stop_loss": Decimal("95"),
+        "take_profit": [Decimal("105"), Decimal("110")],
+    }
+    defaults.update(overrides)
+    return Signal(**defaults)  # type: ignore[arg-type]
+
+
+# ── Defaults and preservation ────────────────────────────────────────────────
+
+
+class TestStrategyIdDefault:
+    def test_default_value_is_default(self) -> None:
+        sig = _make_signal()
+        assert sig.strategy_id == "default"
+
+    def test_custom_value_preserved(self) -> None:
+        sig = _make_signal(strategy_id="crypto_momentum")
+        assert sig.strategy_id == "crypto_momentum"
+
+    def test_non_default_snake_case_preserved(self) -> None:
+        for sid in (
+            "trend_following",
+            "mean_rev_equities",
+            "volatility_risk_premium",
+            "macro_carry",
+            "news_driven",
+        ):
+            assert _make_signal(strategy_id=sid).strategy_id == sid
+
+
+# ── Frozen / immutability ────────────────────────────────────────────────────
+
+
+class TestStrategyIdFrozen:
+    def test_mutation_raises(self) -> None:
+        sig = _make_signal(strategy_id="crypto_momentum")
+        with pytest.raises(ValidationError):
+            sig.strategy_id = "trend_following"  # type: ignore[misc]
+
+
+# ── Validator rejection cases ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        " leading",
+        "trailing ",
+        "has space",
+        "has\ttab",
+        "has\nnewline",
+        "has/slash",
+        "has\\backslash",
+        "has'quote",
+        'has"dq',
+        "a" * 65,
+    ],
+)
+def test_invalid_strategy_id_rejected(bad: str) -> None:
+    with pytest.raises(ValidationError):
+        _make_signal(strategy_id=bad)
+
+
+def test_max_length_boundary_accepted() -> None:
+    """Length 64 is the max allowed (>64 is rejected)."""
+    sid = "a" * 64
+    sig = _make_signal(strategy_id=sid)
+    assert sig.strategy_id == sid
+
+
+# ── Hypothesis round-trip property ───────────────────────────────────────────
+
+
+_ALLOWED_ALPHABET = st.characters(
+    whitelist_categories=(),
+    whitelist_characters="abcdefghijklmnopqrstuvwxyz0123456789_",
+)
+
+_valid_strategy_ids = st.text(
+    alphabet=_ALLOWED_ALPHABET,
+    min_size=1,
+    max_size=64,
+)
+
+
+@given(strategy_id=_valid_strategy_ids)
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_json_roundtrip_preserves_strategy_id(strategy_id: str) -> None:
+    """For any valid ASCII snake_case id, JSON round-trip is lossless."""
+    sig = _make_signal(strategy_id=strategy_id)
+    restored = Signal.model_validate_json(sig.model_dump_json())
+    assert restored.strategy_id == strategy_id
+    assert restored == sig
+
+
+# ── Pre-existing invariant coverage ──────────────────────────────────────────
+# Exercise the Signal model_validator and risk_reward property so that adding
+# the strategy_id field does not regress overall coverage on signal.py below
+# the 90% gate required by Roadmap §2.2.1 acceptance.
+
+
+class TestPriceLevelValidator:
+    def test_long_stop_above_entry_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_signal(
+                direction=Direction.LONG,
+                entry=Decimal("100"),
+                stop_loss=Decimal("105"),
+                take_profit=[Decimal("110"), Decimal("120")],
+            )
+
+    def test_long_tp_below_entry_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_signal(
+                direction=Direction.LONG,
+                entry=Decimal("100"),
+                stop_loss=Decimal("95"),
+                take_profit=[Decimal("99"), Decimal("98")],
+            )
+
+    def test_short_happy_path(self) -> None:
+        sig = _make_signal(
+            direction=Direction.SHORT,
+            strength=-0.5,
+            entry=Decimal("100"),
+            stop_loss=Decimal("105"),
+            take_profit=[Decimal("95"), Decimal("90")],
+        )
+        assert sig.direction == Direction.SHORT
+
+    def test_short_stop_below_entry_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_signal(
+                direction=Direction.SHORT,
+                strength=-0.5,
+                entry=Decimal("100"),
+                stop_loss=Decimal("95"),
+                take_profit=[Decimal("90"), Decimal("85")],
+            )
+
+    def test_short_tp_above_entry_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_signal(
+                direction=Direction.SHORT,
+                strength=-0.5,
+                entry=Decimal("100"),
+                stop_loss=Decimal("105"),
+                take_profit=[Decimal("101"), Decimal("102")],
+            )
+
+
+class TestRiskReward:
+    def test_risk_reward_long(self) -> None:
+        sig = _make_signal(
+            entry=Decimal("100"),
+            stop_loss=Decimal("95"),
+            take_profit=[Decimal("110"), Decimal("120")],
+        )
+        assert sig.risk_reward == Decimal("2")
+
+    def test_risk_reward_zero_risk_returns_none(self) -> None:
+        # Direction.FLAT bypasses the price-level validator, allowing entry==stop.
+        sig = _make_signal(
+            direction=Direction.FLAT,
+            strength=0.0,
+            entry=Decimal("100"),
+            stop_loss=Decimal("100"),
+            take_profit=[Decimal("110"), Decimal("120")],
+        )
+        assert sig.risk_reward is None

--- a/tests/unit/core/models/test_signal_strategy_id.py
+++ b/tests/unit/core/models/test_signal_strategy_id.py
@@ -14,6 +14,7 @@ Covers Phase A §2.2.1 / Charter §5.5 / ADR-0007 §D6:
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import Any
 
 import pytest
 from hypothesis import HealthCheck, given, settings
@@ -25,7 +26,7 @@ from core.models.signal import Direction, Signal
 
 def _make_signal(**overrides: object) -> Signal:
     """Build a minimally valid long-direction Signal, with optional overrides."""
-    defaults: dict[str, object] = {
+    defaults: dict[str, Any] = {
         "signal_id": "sig-001",
         "symbol": "BTCUSDT",
         "timestamp_ms": 1_700_000_000_000,
@@ -36,7 +37,7 @@ def _make_signal(**overrides: object) -> Signal:
         "take_profit": [Decimal("105"), Decimal("110")],
     }
     defaults.update(overrides)
-    return Signal(**defaults)  # type: ignore[arg-type]
+    return Signal(**defaults)
 
 
 # ── Defaults and preservation ────────────────────────────────────────────────
@@ -69,7 +70,7 @@ class TestStrategyIdFrozen:
     def test_mutation_raises(self) -> None:
         sig = _make_signal(strategy_id="crypto_momentum")
         with pytest.raises(ValidationError):
-            sig.strategy_id = "trend_following"  # type: ignore[misc]
+            sig.__setattr__("strategy_id", "trend_following")
 
 
 # ── Validator rejection cases ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Phase A.1 foundational contract: adds a frozen `strategy_id: str = "default"` field to the `Signal` Pydantic model per Charter §5.5, ADR-0007 §D6, and Roadmap v3.0 §2.2.1.

- **Default `"default"`** preserves backward compatibility with the legacy single-strategy codebase until Phase B wraps it as `LegacyConfluenceStrategy`.
- **Frozen** per CLAUDE.md §2 (all order-path contracts immutable).
- **Format validator** rejects empty strings, length > 64, whitespace (space/tab/newline/etc.), forward/back slashes, and single/double quotes — because `strategy_id` is interpolated into ZMQ topics (`signal.technical.{strategy_id}.{symbol}`), Redis keys (`kelly:{strategy_id}:{symbol}` et al.), and filesystem paths (`services/strategies/{strategy_id}/`). This is a structural/safety validator, not a membership/allowlist one — Charter §11 extensibility is preserved.

Scope strictly limited to `core/models/signal.py` + one new test file, per A.1 parallelization contract. `OrderCandidate`, `ApprovedOrder`, `ExecutedOrder`, `TradeRecord`, `Topics.signal_for`, and backtest/CI changes remain with #192 / #193 / #194 / #195.

## Test plan

- [x] `pytest tests/unit/core/models/test_signal_strategy_id.py -v` → **24 passed** (17 strategy_id cases + 7 pre-existing-invariant cases to keep overall file coverage ≥ 90%).
- [x] Coverage on `core/models/signal.py`: **100%** (target was ≥ 90%).
- [x] `mypy --strict core/models/signal.py tests/unit/core/models/test_signal_strategy_id.py` → clean.
- [x] `ruff check` + `ruff format --check` → clean.
- [x] Hypothesis property test (`max_examples=100`) confirms JSON round-trip is lossless for any valid ASCII snake_case id of length 1–64.
- [x] Frozen-ness test confirms mutation of `strategy_id` raises `ValidationError`.
- [ ] CI: `quality`, `unit-tests`, `integration-tests`, `rust` — awaiting run.

## References

- [Roadmap v3.0 §2.2.1 — strategy_id field on five Pydantic models](docs/phases/PHASE_5_v3_MULTI_STRAT_ALIGNED_ROADMAP.md)
- [Charter §5.5 — per-strategy identity](docs/strategy/ALPHA_THESIS_AND_MULTI_STRAT_CHARTER.md)
- [ADR-0007 §D6 — strategy_id as first-class Pydantic field](docs/adr/ADR-0007-strategy-as-microservice.md)

Closes #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)