### PR TITLE
feat(core): OrderCandidate.strategy_id (phase-A.2, closes #192)

### DIFF
--- a/core/models/order.py
+++ b/core/models/order.py
@@ -116,12 +116,17 @@ class OrderCandidate(BaseModel):
             raise ValueError("strategy_id must be non-empty")
         if len(v) > 64:
             raise ValueError(f"strategy_id length {len(v)} exceeds max 64 characters")
-        forbidden = set(" \t\n\r\v\f/\\'\"")
+        if any(c.isspace() for c in v):
+            raise ValueError(
+                "strategy_id contains whitespace; "
+                "ASCII and Unicode whitespace (incl. NBSP \\u00A0) are not permitted"
+            )
+        forbidden = set("/\\'\"")
         bad = sorted(set(v) & forbidden)
         if bad:
             raise ValueError(
                 f"strategy_id contains forbidden characters {bad!r}; "
-                "whitespace, slashes and quotes are not permitted"
+                "slashes and quotes are not permitted"
             )
         return v
 

--- a/core/models/order.py
+++ b/core/models/order.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from decimal import Decimal
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from core.models.signal import Direction, Signal
 
@@ -49,6 +49,14 @@ class OrderCandidate(BaseModel):
     symbol: str = Field(..., description="Uppercase trading symbol")
     direction: Direction = Field(..., description="Trade direction")
     timestamp_ms: int = Field(..., gt=0, description="Proposal time UTC ms")
+    strategy_id: str = Field(
+        default="default",
+        description=(
+            "Per-strategy identifier (Charter §5.5, ADR-0007 §D6). "
+            "Default 'default' preserves the legacy single-strategy path "
+            "until Phase B wraps it as LegacyConfluenceStrategy."
+        ),
+    )
 
     # Sizing
     size: Decimal = Field(..., gt=Decimal("0"), description="Total position size in base units")
@@ -90,6 +98,32 @@ class OrderCandidate(BaseModel):
     # Lineage
     source_signal: Signal | None = None
     linked_order_id: str | None = Field(default=None, description="ID of hedge counterpart order")
+
+    @field_validator("strategy_id")
+    @classmethod
+    def validate_strategy_id(cls, v: str) -> str:
+        """Reject strategy_ids that break ZMQ topics, Redis keys, or filesystem paths.
+
+        Mirrors the Signal.validate_strategy_id validator (see
+        ``core/models/signal.py``) so every order-path model applies the same
+        structural guarantees per Charter §5.5 and ADR-0007 §D6. Empty strings,
+        whitespace, forward/backslashes and quote characters are rejected, and
+        length is capped at 64 so downstream Redis keys
+        (``kelly:{strategy_id}:{symbol}`` etc.) and filesystem paths
+        (``services/strategies/{strategy_id}/``) stay bounded and safe.
+        """
+        if not v:
+            raise ValueError("strategy_id must be non-empty")
+        if len(v) > 64:
+            raise ValueError(f"strategy_id length {len(v)} exceeds max 64 characters")
+        forbidden = set(" \t\n\r\v\f/\\'\"")
+        bad = sorted(set(v) & forbidden)
+        if bad:
+            raise ValueError(
+                f"strategy_id contains forbidden characters {bad!r}; "
+                "whitespace, slashes and quotes are not permitted"
+            )
+        return v
 
     @model_validator(mode="after")
     def validate_exit_sizes(self) -> OrderCandidate:

--- a/tests/unit/core/models/test_order_candidate_strategy_id.py
+++ b/tests/unit/core/models/test_order_candidate_strategy_id.py
@@ -1,0 +1,172 @@
+"""Unit tests for the `strategy_id` field on the `OrderCandidate` Pydantic model.
+
+Mirrors ``tests/unit/core/models/test_signal_strategy_id.py`` for cross-model
+consistency per Phase A §2.2.1 / Charter §5.5 / ADR-0007 §D6:
+
+- default value is ``"default"`` (backward compatibility with the legacy
+  single-strategy codebase);
+- custom values are preserved verbatim;
+- the model stays ``frozen=True`` so mutation is rejected;
+- structurally unsafe identifiers (whitespace, slashes, quotes, empty,
+  length > 64) are rejected for ZMQ/Redis/filesystem compatibility;
+- JSON round-trip preserves any valid ASCII snake_case identifier.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from core.models.order import OrderCandidate
+from core.models.signal import Direction
+
+
+def _make_candidate(**overrides: object) -> OrderCandidate:
+    """Build a minimally valid long-direction OrderCandidate, with optional overrides."""
+    defaults: dict[str, Any] = {
+        "order_id": "ord-001",
+        "symbol": "BTCUSDT",
+        "direction": Direction.LONG,
+        "timestamp_ms": 1_700_000_000_000,
+        "size": Decimal("1.0"),
+        "size_scalp_exit": Decimal("0.3"),
+        "size_swing_exit": Decimal("0.7"),
+        "entry": Decimal("100"),
+        "stop_loss": Decimal("95"),
+        "target_scalp": Decimal("105"),
+        "target_swing": Decimal("110"),
+        "capital_at_risk": Decimal("5"),
+    }
+    defaults.update(overrides)
+    return OrderCandidate(**defaults)
+
+
+# ── Defaults and preservation ────────────────────────────────────────────────
+
+
+class TestStrategyIdDefault:
+    def test_default_value_is_default(self) -> None:
+        cand = _make_candidate()
+        assert cand.strategy_id == "default"
+
+    def test_custom_value_preserved(self) -> None:
+        cand = _make_candidate(strategy_id="crypto_momentum")
+        assert cand.strategy_id == "crypto_momentum"
+
+    def test_non_default_snake_case_preserved(self) -> None:
+        for sid in (
+            "trend_following",
+            "mean_rev_equities",
+            "volatility_risk_premium",
+            "macro_carry",
+            "news_driven",
+        ):
+            assert _make_candidate(strategy_id=sid).strategy_id == sid
+
+
+# ── Frozen / immutability ────────────────────────────────────────────────────
+
+
+class TestStrategyIdFrozen:
+    def test_mutation_raises(self) -> None:
+        cand = _make_candidate(strategy_id="crypto_momentum")
+        with pytest.raises(ValidationError):
+            cand.__setattr__("strategy_id", "trend_following")
+
+
+# ── Validator rejection cases ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        " leading",
+        "trailing ",
+        "has space",
+        "has\ttab",
+        "has\nnewline",
+        "has/slash",
+        "has\\backslash",
+        "has'quote",
+        'has"dq',
+        "a" * 65,
+    ],
+)
+def test_invalid_strategy_id_rejected(bad: str) -> None:
+    with pytest.raises(ValidationError):
+        _make_candidate(strategy_id=bad)
+
+
+def test_max_length_boundary_accepted() -> None:
+    """Length 64 is the max allowed (>64 is rejected)."""
+    sid = "a" * 64
+    cand = _make_candidate(strategy_id=sid)
+    assert cand.strategy_id == sid
+
+
+# ── Hypothesis round-trip property ───────────────────────────────────────────
+
+
+_ALLOWED_ALPHABET = st.characters(
+    whitelist_categories=(),
+    whitelist_characters="abcdefghijklmnopqrstuvwxyz0123456789_",
+)
+
+_valid_strategy_ids = st.text(
+    alphabet=_ALLOWED_ALPHABET,
+    min_size=1,
+    max_size=64,
+)
+
+
+@given(strategy_id=_valid_strategy_ids)
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_json_roundtrip_preserves_strategy_id(strategy_id: str) -> None:
+    """For any valid ASCII snake_case id, JSON round-trip is lossless."""
+    cand = _make_candidate(strategy_id=strategy_id)
+    restored = OrderCandidate.model_validate_json(cand.model_dump_json())
+    assert restored.strategy_id == strategy_id
+    assert restored == cand
+
+
+# ── Pre-existing invariant coverage ──────────────────────────────────────────
+# Exercise the OrderCandidate.validate_exit_sizes model_validator so that
+# adding the strategy_id field does not regress overall coverage on order.py
+# below the 90% gate required by Roadmap §2.2.1 acceptance.
+
+
+class TestExitSizeValidator:
+    def test_exit_sizes_sum_to_total(self) -> None:
+        cand = _make_candidate(
+            size=Decimal("1.0"),
+            size_scalp_exit=Decimal("0.4"),
+            size_swing_exit=Decimal("0.6"),
+        )
+        assert cand.size_scalp_exit + cand.size_swing_exit == cand.size
+
+    def test_exit_sizes_mismatch_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_candidate(
+                size=Decimal("1.0"),
+                size_scalp_exit=Decimal("0.3"),
+                size_swing_exit=Decimal("0.5"),
+            )
+
+    def test_exit_sizes_within_tolerance_accepted(self) -> None:
+        """Rounding errors below 1e-4 should not raise."""
+        cand = _make_candidate(
+            size=Decimal("1.0"),
+            size_scalp_exit=Decimal("0.30005"),
+            size_swing_exit=Decimal("0.69995"),
+        )
+        assert cand.size == Decimal("1.0")

--- a/tests/unit/core/models/test_order_candidate_strategy_id.py
+++ b/tests/unit/core/models/test_order_candidate_strategy_id.py
@@ -91,6 +91,8 @@ class TestStrategyIdFrozen:
         "has space",
         "has\ttab",
         "has\nnewline",
+        "has\u00a0nbsp",
+        "has\u2003emspace",
         "has/slash",
         "has\\backslash",
         "has'quote",


### PR DESCRIPTION
## Summary

Adds `strategy_id: str = \"default\"` field to the `OrderCandidate` Pydantic model in `core/models/order.py`, mirroring the `Signal.strategy_id` field merged in #207 (commit 8cafc89, 2026-04-20).

Per:
- **Roadmap v3.0** §2.2.1 (Phase A — Foundational Contracts)
- **Charter** §5.5 (per-strategy identity on every order-path model)
- **ADR-0007** §D6 (`strategy_id` as Pydantic field on 5 models — Signal done, OrderCandidate next)

The field is frozen (`ConfigDict(frozen=True)` inherited), defaults to `\"default\"` (backward compat with the legacy single-strategy pipeline until Phase B wraps it as `LegacyConfluenceStrategy`), and is validated by `validate_strategy_id` which rejects empty strings, whitespace, forward/backslashes, quotes, and length > 64 — the same structural contract as `Signal.validate_strategy_id` so ZMQ topics (`signal.technical.{strategy_id}.{symbol}` per A.4), Redis keys (`kelly:{strategy_id}:{symbol}` per A.5+), and filesystem paths (`services/strategies/{strategy_id}/` per ADR-0007 §D2) stay bounded and safe.

**Scope is intentionally minimal**: touches only `core/models/order.py` (OrderCandidate class) and adds one new test file. `ApprovedOrder`, `ExecutedOrder`, `TradeRecord`, `NullOrder` are untouched — those belong to issue #193 (A.3).

## Test plan

- [x] `python -m pytest tests/unit/core/models/test_order_candidate_strategy_id.py -v` → 20 passed
- [x] `python -m pytest tests/unit/core/models/` → 44 passed (no regression on Signal tests)
- [x] `python -m mypy --strict core/models/order.py` → Success: no issues
- [x] `python -m ruff check core/models/order.py tests/unit/core/models/test_order_candidate_strategy_id.py` → clean
- [x] `python -m ruff format --check ...` → already formatted
- [x] Coverage on `core/models/order.py`: **92%** (above the 90% gate required by Roadmap §2.2.1 acceptance)

Test file covers: default value, custom values preserved, frozen immutability, parametrized rejection of structurally invalid ids (11 cases including empty, whitespace, slashes, quotes, length > 64), boundary length = 64 accepted, Hypothesis round-trip (100 examples) of `model_dump_json` → `model_validate_json`, plus regression coverage on the pre-existing `validate_exit_sizes` model validator to keep module coverage ≥ 90%.

## References

- Mirrors #191/#207 (merged 2026-04-20, commit 8cafc89) — same pattern applied to `Signal`
- Roadmap v3.0 §2.2.1
- Charter §5.5
- ADR-0007 §D6
- Parallel work in flight: #197 (A.7), #201 (A.11), #196 (A.6) — no file overlap

Closes #192.