### PR TITLE
fix(s04): Kelly sizer Redis dual-read (phase-A.11, closes #201)

### DIFF
--- a/services/s04_fusion_engine/kelly_sizer.py
+++ b/services/s04_fusion_engine/kelly_sizer.py
@@ -21,9 +21,14 @@ _logger = structlog.get_logger(__name__)
 class KellySizer:
     """Compute Kelly-optimal position sizes from live trade statistics.
 
-    Statistics are stored in Redis under the key ``kelly:{symbol}`` as a
-    JSON object with fields ``win_rate`` and ``avg_rr``.  If the key is
-    absent the safe defaults ``win_rate=0.5``, ``avg_rr=1.5`` are used.
+    Statistics are stored in Redis under the per-strategy key
+    ``kelly:{strategy_id}:{symbol}`` (primary) with a fallback read from the
+    legacy single-strategy key ``kelly:{symbol}`` during the Phase A migration
+    window (Roadmap v3.0 §2.2.5, ADR-0007 §D9). If neither key is present the
+    safe defaults ``win_rate=0.5``, ``avg_rr=1.5`` are used.
+
+    The writer-side migration (s09 FeedbackLoop) lands in a follow-up ticket;
+    this class is reader-side only.
     """
 
     # ── Statistics ────────────────────────────────────────────────────────────
@@ -72,19 +77,45 @@ class KellySizer:
         self,
         state: StateStore,
         symbol: str,
+        strategy_id: str = "default",
     ) -> tuple[float, float]:
         """Read win-rate and average risk/reward for ``symbol`` from Redis.
 
+        Dual-read during Phase A migration (Roadmap v3.0 §2.2.5, ADR-0007 §D9):
+        the per-strategy key ``kelly:{strategy_id}:{symbol}`` is tried first,
+        and on miss a fallback read against the legacy ``kelly:{symbol}`` key
+        is performed. Every legacy-path hit emits a structlog WARNING so the
+        residual dependency on the legacy key is observable. When the s09
+        writer migration lands and all legacy stats have aged out, the
+        fallback branch (and this parameter) can be removed.
+
         Args:
-            state:  Connected :class:`~core.state.StateStore` instance.
-            symbol: Uppercase trading symbol.
+            state:       Connected :class:`~core.state.StateStore` instance.
+            symbol:      Uppercase trading symbol.
+            strategy_id: Per-strategy namespace; defaults to ``"default"`` to
+                         preserve pre-migration behavior for existing callers.
 
         Returns:
             ``(win_rate, avg_rr)`` tuple.  Defaults: ``(0.5, 1.5)``.
         """
-        raw: dict[str, Any] | None = await state.get(f"kelly:{symbol}")
+        new_key = f"kelly:{strategy_id}:{symbol}"
+        legacy_key = f"kelly:{symbol}"
+
+        raw: dict[str, Any] | None = await state.get(new_key)
+
         if not isinstance(raw, dict):
-            return 0.5, 1.5
+            legacy_raw: dict[str, Any] | None = await state.get(legacy_key)
+            if not isinstance(legacy_raw, dict):
+                return 0.5, 1.5
+            _logger.warning(
+                "kelly_sizer.legacy_key_fallback",
+                strategy_id=strategy_id,
+                symbol=symbol,
+                legacy_key=legacy_key,
+                new_key=new_key,
+            )
+            raw = legacy_raw
+
         win_rate = float(raw.get("win_rate", 0.5))
         avg_rr = float(raw.get("avg_rr", 1.5))
         # Clamp to sensible ranges.

--- a/services/s04_fusion_engine/kelly_sizer.py
+++ b/services/s04_fusion_engine/kelly_sizer.py
@@ -21,14 +21,21 @@ _logger = structlog.get_logger(__name__)
 class KellySizer:
     """Compute Kelly-optimal position sizes from live trade statistics.
 
-    Statistics are stored in Redis under the per-strategy key
+    Statistics are stored in Redis as HASHES (written by S09 FeedbackLoop
+    via :meth:`StateStore.hset`) under the per-strategy key
     ``kelly:{strategy_id}:{symbol}`` (primary) with a fallback read from the
     legacy single-strategy key ``kelly:{symbol}`` during the Phase A migration
     window (Roadmap v3.0 §2.2.5, ADR-0007 §D9). If neither key is present the
     safe defaults ``win_rate=0.5``, ``avg_rr=1.5`` are used.
 
-    The writer-side migration (s09 FeedbackLoop) lands in a follow-up ticket;
-    this class is reader-side only.
+    Storage shape: each key is a Redis HASH with fields ``win_rate`` and
+    ``avg_rr`` (see ``services/s09_feedback_loop/service.py`` _fast_analysis).
+    The reader therefore issues ``hgetall`` — issuing a plain ``GET`` against
+    the same key would raise ``WRONGTYPE`` at runtime.
+
+    The writer-side migration (S09 FeedbackLoop cutting over to the
+    per-strategy primary key) lands in a follow-up ticket; this class is
+    reader-side only.
     """
 
     # ── Statistics ────────────────────────────────────────────────────────────
@@ -83,11 +90,23 @@ class KellySizer:
 
         Dual-read during Phase A migration (Roadmap v3.0 §2.2.5, ADR-0007 §D9):
         the per-strategy key ``kelly:{strategy_id}:{symbol}`` is tried first,
-        and on miss a fallback read against the legacy ``kelly:{symbol}`` key
-        is performed. Every legacy-path hit emits a structlog WARNING so the
-        residual dependency on the legacy key is observable. When the s09
+        and on empty-miss a fallback read against the legacy ``kelly:{symbol}``
+        key is performed. Every legacy-path hit emits a structlog WARNING so
+        the residual dependency on the legacy key is observable. When the S09
         writer migration lands and all legacy stats have aged out, the
         fallback branch (and this parameter) can be removed.
+
+        Storage contract: S09 writes each key as a Redis HASH via
+        :meth:`StateStore.hset`; the reader therefore uses
+        :meth:`StateStore.hgetall` (which returns ``{}`` for a missing key),
+        not ``get`` — the latter would raise ``WRONGTYPE`` against a hash.
+
+        Fallback semantics: the legacy path is gated strictly on the primary
+        HASH being empty (cache miss). A non-empty primary hash missing
+        ``win_rate`` / ``avg_rr`` fields does **not** trigger fallback; the
+        reader uses the in-dict values (or defaults) directly. Invalid
+        values (non-numeric ``win_rate`` etc.) surface as ``ValueError`` via
+        :func:`float` — fail-loud, mirroring :mod:`portfolio_tracker`.
 
         Args:
             state:       Connected :class:`~core.state.StateStore` instance.
@@ -101,11 +120,11 @@ class KellySizer:
         new_key = f"kelly:{strategy_id}:{symbol}"
         legacy_key = f"kelly:{symbol}"
 
-        raw: dict[str, Any] | None = await state.get(new_key)
+        primary: dict[str, Any] = await state.hgetall(new_key)
 
-        if not isinstance(raw, dict):
-            legacy_raw: dict[str, Any] | None = await state.get(legacy_key)
-            if not isinstance(legacy_raw, dict):
+        if not primary:
+            legacy: dict[str, Any] = await state.hgetall(legacy_key)
+            if not legacy:
                 return 0.5, 1.5
             _logger.warning(
                 "kelly_sizer.legacy_key_fallback",
@@ -114,7 +133,9 @@ class KellySizer:
                 legacy_key=legacy_key,
                 new_key=new_key,
             )
-            raw = legacy_raw
+            raw: dict[str, Any] = legacy
+        else:
+            raw = primary
 
         win_rate = float(raw.get("win_rate", 0.5))
         avg_rr = float(raw.get("avg_rr", 1.5))

--- a/tests/unit/s04/test_kelly_redis.py
+++ b/tests/unit/s04/test_kelly_redis.py
@@ -1,8 +1,9 @@
-"""Tests for KellySizer.get_rolling_stats_from_redis."""
+"""Tests for KellySizer.get_rolling_stats_from_redis and dual-read get_stats."""
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -114,3 +115,96 @@ class TestKellyGetStats:
         state.get.return_value = None
         await self.sizer().get_stats(state, "AAPL")
         state.get.assert_called_with("kelly:AAPL")
+
+
+class TestKellyDualRead:
+    """Dual-read migration (Roadmap v3.0 section 2.2.5, ADR-0007 section D9).
+
+    get_stats reads kelly:{strategy_id}:{symbol} first, falls back to the
+    legacy kelly:{symbol} key on miss, and emits a structlog WARNING whenever
+    the legacy path is hit so residual dependency is observable.
+    """
+
+    def sizer(self) -> KellySizer:
+        return KellySizer()
+
+    @staticmethod
+    def _keyed_state(store: dict[str, Any]) -> AsyncMock:
+        """Build an AsyncMock StateStore backed by an in-memory dict."""
+        state = AsyncMock()
+
+        async def _get(key: str) -> Any | None:
+            return store.get(key)
+
+        state.get.side_effect = _get
+        return state
+
+    @pytest.mark.asyncio
+    async def test_new_key_hit_no_fallback(self) -> None:
+        store = {"kelly:default:BTCUSDT": {"win_rate": 0.60, "avg_rr": 2.0}}
+        state = self._keyed_state(store)
+        with patch("services.s04_fusion_engine.kelly_sizer._logger") as mock_log:
+            win_rate, avg_rr = await self.sizer().get_stats(state, "BTCUSDT")
+        assert win_rate == pytest.approx(0.60)
+        assert avg_rr == pytest.approx(2.0)
+        state.get.assert_awaited_once_with("kelly:default:BTCUSDT")
+        mock_log.warning.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_legacy_key_fallback_warns(self) -> None:
+        store = {"kelly:BTCUSDT": {"win_rate": 0.55, "avg_rr": 1.8}}
+        state = self._keyed_state(store)
+        with patch("services.s04_fusion_engine.kelly_sizer._logger") as mock_log:
+            win_rate, avg_rr = await self.sizer().get_stats(state, "BTCUSDT")
+        assert win_rate == pytest.approx(0.55)
+        assert avg_rr == pytest.approx(1.8)
+        assert state.get.await_count == 2
+        state.get.assert_any_await("kelly:default:BTCUSDT")
+        state.get.assert_any_await("kelly:BTCUSDT")
+        mock_log.warning.assert_called_once()
+        call_args = mock_log.warning.call_args
+        assert call_args.args[0] == "kelly_sizer.legacy_key_fallback"
+        assert call_args.kwargs["strategy_id"] == "default"
+        assert call_args.kwargs["symbol"] == "BTCUSDT"
+        assert call_args.kwargs["legacy_key"] == "kelly:BTCUSDT"
+        assert call_args.kwargs["new_key"] == "kelly:default:BTCUSDT"
+
+    @pytest.mark.asyncio
+    async def test_new_key_wins_when_both_present(self) -> None:
+        store = {
+            "kelly:default:BTCUSDT": {"win_rate": 0.65, "avg_rr": 2.5},
+            "kelly:BTCUSDT": {"win_rate": 0.40, "avg_rr": 1.2},
+        }
+        state = self._keyed_state(store)
+        with patch("services.s04_fusion_engine.kelly_sizer._logger") as mock_log:
+            win_rate, avg_rr = await self.sizer().get_stats(state, "BTCUSDT")
+        assert win_rate == pytest.approx(0.65)
+        assert avg_rr == pytest.approx(2.5)
+        state.get.assert_awaited_once_with("kelly:default:BTCUSDT")
+        mock_log.warning.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_both_missing_returns_defaults(self) -> None:
+        state = self._keyed_state({})
+        with patch("services.s04_fusion_engine.kelly_sizer._logger") as mock_log:
+            win_rate, avg_rr = await self.sizer().get_stats(state, "BTCUSDT")
+        assert win_rate == 0.5
+        assert avg_rr == 1.5
+        assert state.get.await_count == 2
+        mock_log.warning.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_default_strategy_id_fallback(self) -> None:
+        store = {"kelly:BTCUSDT": {"win_rate": 0.58, "avg_rr": 1.9}}
+        state = self._keyed_state(store)
+        with patch("services.s04_fusion_engine.kelly_sizer._logger") as mock_log:
+            win_rate, avg_rr = await self.sizer().get_stats(
+                state, "BTCUSDT", strategy_id="crypto_momentum"
+            )
+        assert win_rate == pytest.approx(0.58)
+        assert avg_rr == pytest.approx(1.9)
+        state.get.assert_any_await("kelly:crypto_momentum:BTCUSDT")
+        state.get.assert_any_await("kelly:BTCUSDT")
+        mock_log.warning.assert_called_once()
+        assert mock_log.warning.call_args.kwargs["strategy_id"] == "crypto_momentum"
+        assert mock_log.warning.call_args.kwargs["new_key"] == "kelly:crypto_momentum:BTCUSDT"

--- a/tests/unit/s04/test_kelly_redis.py
+++ b/tests/unit/s04/test_kelly_redis.py
@@ -1,9 +1,19 @@
-"""Tests for KellySizer.get_rolling_stats_from_redis and dual-read get_stats."""
+"""Tests for KellySizer.get_rolling_stats_from_redis and dual-read get_stats.
+
+Storage contract:
+- ``get_rolling_stats_from_redis`` reads ``feedback:kelly_stats:{key}`` which
+  is a JSON-serialized STRING value written by S09 slow analysis — tests mock
+  ``state.get``.
+- ``get_stats`` reads ``kelly:{strategy_id}:{symbol}`` / ``kelly:{symbol}``
+  which are Redis HASHES written by S09 ``_fast_analysis`` via
+  :meth:`StateStore.hset` — tests mock ``state.hgetall``. (Using ``state.get``
+  here would raise ``WRONGTYPE`` at runtime against a hash.)
+"""
 
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
@@ -68,21 +78,25 @@ class TestKellyRollingStats:
 
 
 class TestKellyGetStats:
+    """Single-key behavior of ``get_stats`` against the Redis HASH backend."""
+
     def sizer(self) -> KellySizer:
         return KellySizer()
 
     @pytest.mark.asyncio
     async def test_defaults_when_no_key(self) -> None:
+        """Both hashes empty → defaults."""
         state = AsyncMock()
-        state.get.return_value = None
+        state.hgetall.return_value = {}
         win_rate, avg_rr = await self.sizer().get_stats(state, "BTCUSDT")
         assert win_rate == 0.5
         assert avg_rr == 1.5
 
     @pytest.mark.asyncio
     async def test_reads_live_data(self) -> None:
+        """Non-empty primary hash → values read directly, no fallback."""
         state = AsyncMock()
-        state.get.return_value = {"win_rate": 0.62, "avg_rr": 2.1}
+        state.hgetall.return_value = {"win_rate": 0.62, "avg_rr": 2.1}
         win_rate, avg_rr = await self.sizer().get_stats(state, "BTCUSDT")
         assert win_rate == pytest.approx(0.62)
         assert avg_rr == pytest.approx(2.1)
@@ -90,53 +104,58 @@ class TestKellyGetStats:
     @pytest.mark.asyncio
     async def test_win_rate_clamped_to_zero_one(self) -> None:
         state = AsyncMock()
-        state.get.return_value = {"win_rate": 1.5, "avg_rr": 2.0}
+        state.hgetall.return_value = {"win_rate": 1.5, "avg_rr": 2.0}
         win_rate, _ = await self.sizer().get_stats(state, "BTCUSDT")
         assert win_rate <= 1.0
 
     @pytest.mark.asyncio
     async def test_avg_rr_clamped_above_zero(self) -> None:
         state = AsyncMock()
-        state.get.return_value = {"win_rate": 0.5, "avg_rr": -5.0}
+        state.hgetall.return_value = {"win_rate": 0.5, "avg_rr": -5.0}
         _, avg_rr = await self.sizer().get_stats(state, "BTCUSDT")
         assert avg_rr >= 0.01
 
     @pytest.mark.asyncio
-    async def test_uses_defaults_when_keys_missing(self) -> None:
-        state = AsyncMock()
-        state.get.return_value = {}  # dict but empty
-        win_rate, avg_rr = await self.sizer().get_stats(state, "ETHUSDT")
-        assert win_rate == pytest.approx(0.5)
-        assert avg_rr == pytest.approx(1.5)
-
-    @pytest.mark.asyncio
     async def test_redis_key_contains_symbol(self) -> None:
+        """Primary key is attempted first; legacy key is the fallback on miss.
+
+        Ensures future refactors cannot silently break the per-strategy
+        primary lookup (addresses #209 Copilot thread 3).
+        """
         state = AsyncMock()
-        state.get.return_value = None
+        state.hgetall.return_value = {}
         await self.sizer().get_stats(state, "AAPL")
-        state.get.assert_called_with("kelly:AAPL")
+        assert state.hgetall.await_args_list == [
+            call("kelly:default:AAPL"),
+            call("kelly:AAPL"),
+        ]
 
 
 class TestKellyDualRead:
     """Dual-read migration (Roadmap v3.0 section 2.2.5, ADR-0007 section D9).
 
-    get_stats reads kelly:{strategy_id}:{symbol} first, falls back to the
-    legacy kelly:{symbol} key on miss, and emits a structlog WARNING whenever
-    the legacy path is hit so residual dependency is observable.
+    ``get_stats`` issues ``hgetall`` against ``kelly:{strategy_id}:{symbol}``
+    first, falls back to the legacy ``kelly:{symbol}`` hash on empty-miss, and
+    emits a structlog WARNING whenever the legacy path is hit so residual
+    dependency is observable.
     """
 
     def sizer(self) -> KellySizer:
         return KellySizer()
 
     @staticmethod
-    def _keyed_state(store: dict[str, Any]) -> AsyncMock:
-        """Build an AsyncMock StateStore backed by an in-memory dict."""
+    def _keyed_state(store: dict[str, dict[str, Any]]) -> AsyncMock:
+        """Build an AsyncMock StateStore backed by an in-memory hash-dict.
+
+        Mirrors ``StateStore.hgetall`` semantics: missing keys resolve to
+        an empty dict (never ``None``).
+        """
         state = AsyncMock()
 
-        async def _get(key: str) -> Any | None:
-            return store.get(key)
+        async def _hgetall(key: str) -> dict[str, Any]:
+            return store.get(key, {})
 
-        state.get.side_effect = _get
+        state.hgetall.side_effect = _hgetall
         return state
 
     @pytest.mark.asyncio
@@ -147,7 +166,7 @@ class TestKellyDualRead:
             win_rate, avg_rr = await self.sizer().get_stats(state, "BTCUSDT")
         assert win_rate == pytest.approx(0.60)
         assert avg_rr == pytest.approx(2.0)
-        state.get.assert_awaited_once_with("kelly:default:BTCUSDT")
+        state.hgetall.assert_awaited_once_with("kelly:default:BTCUSDT")
         mock_log.warning.assert_not_called()
 
     @pytest.mark.asyncio
@@ -158,9 +177,11 @@ class TestKellyDualRead:
             win_rate, avg_rr = await self.sizer().get_stats(state, "BTCUSDT")
         assert win_rate == pytest.approx(0.55)
         assert avg_rr == pytest.approx(1.8)
-        assert state.get.await_count == 2
-        state.get.assert_any_await("kelly:default:BTCUSDT")
-        state.get.assert_any_await("kelly:BTCUSDT")
+        # Primary tried first, then legacy — ordered assertion.
+        assert state.hgetall.await_args_list == [
+            call("kelly:default:BTCUSDT"),
+            call("kelly:BTCUSDT"),
+        ]
         mock_log.warning.assert_called_once()
         call_args = mock_log.warning.call_args
         assert call_args.args[0] == "kelly_sizer.legacy_key_fallback"
@@ -180,7 +201,7 @@ class TestKellyDualRead:
             win_rate, avg_rr = await self.sizer().get_stats(state, "BTCUSDT")
         assert win_rate == pytest.approx(0.65)
         assert avg_rr == pytest.approx(2.5)
-        state.get.assert_awaited_once_with("kelly:default:BTCUSDT")
+        state.hgetall.assert_awaited_once_with("kelly:default:BTCUSDT")
         mock_log.warning.assert_not_called()
 
     @pytest.mark.asyncio
@@ -190,7 +211,10 @@ class TestKellyDualRead:
             win_rate, avg_rr = await self.sizer().get_stats(state, "BTCUSDT")
         assert win_rate == 0.5
         assert avg_rr == 1.5
-        assert state.get.await_count == 2
+        assert state.hgetall.await_args_list == [
+            call("kelly:default:BTCUSDT"),
+            call("kelly:BTCUSDT"),
+        ]
         mock_log.warning.assert_not_called()
 
     @pytest.mark.asyncio
@@ -203,8 +227,33 @@ class TestKellyDualRead:
             )
         assert win_rate == pytest.approx(0.58)
         assert avg_rr == pytest.approx(1.9)
-        state.get.assert_any_await("kelly:crypto_momentum:BTCUSDT")
-        state.get.assert_any_await("kelly:BTCUSDT")
+        assert state.hgetall.await_args_list == [
+            call("kelly:crypto_momentum:BTCUSDT"),
+            call("kelly:BTCUSDT"),
+        ]
         mock_log.warning.assert_called_once()
         assert mock_log.warning.call_args.kwargs["strategy_id"] == "crypto_momentum"
         assert mock_log.warning.call_args.kwargs["new_key"] == "kelly:crypto_momentum:BTCUSDT"
+
+    @pytest.mark.asyncio
+    async def test_malformed_primary_value_raises(self) -> None:
+        """Non-numeric value in a populated primary hash → fail-loud (ValueError).
+
+        The legacy fallback is gated strictly on the primary hash being
+        *empty* (cache miss). A populated primary hash with a corrupted
+        ``win_rate`` value does not silently fall back to the legacy key;
+        it surfaces as a ``ValueError`` via ``float(...)`` — matching the
+        fail-loud contract used by :mod:`portfolio_tracker` (addresses
+        #209 Copilot thread 2).
+        """
+        store = {
+            "kelly:default:BTCUSDT": {"win_rate": "not_a_number", "avg_rr": 1.8},
+            "kelly:BTCUSDT": {"win_rate": 0.99, "avg_rr": 3.0},
+        }
+        state = self._keyed_state(store)
+        with patch("services.s04_fusion_engine.kelly_sizer._logger") as mock_log:
+            with pytest.raises(ValueError, match="could not convert"):
+                await self.sizer().get_stats(state, "BTCUSDT")
+        # Crucially: fallback was NOT triggered — only the primary key was read.
+        state.hgetall.assert_awaited_once_with("kelly:default:BTCUSDT")
+        mock_log.warning.assert_not_called()


### PR DESCRIPTION
## Summary

Per-strategy **read-side** migration for the Kelly sizer, per Roadmap v3.0 §2.2.5 and ADR-0007 §D9.

### Audit finding (scope pivot vs. original ticket wording)

Ticket #201 was originally framed as a **dual-write**. The audit showed `services/s04_fusion_engine/kelly_sizer.py` performs **no Redis writes** — it is a pure compute class that only reads `kelly:{symbol}`. The actual writer of that key is `services/s09_feedback_loop/service.py` (lines 94–103, `hset(f"kelly:{symbol}", ...)`), which is out of scope for this ticket and HARD-STOPPED for this agent.

Scope was therefore retargeted (in agreement with the user) to a **dual-read**: the reader is now per-strategy-aware and falls back to the legacy key during the Phase A migration window. The writer-side migration lands in a separate follow-up ticket; once it ships and legacy stats age out, the fallback branch here can be removed.

### Changes

**`services/s04_fusion_engine/kelly_sizer.py`**
- `get_stats` accepts `strategy_id: str = "default"` (preserves back-compat for every existing caller).
- Primary read: `kelly:{strategy_id}:{symbol}`.
- On miss, fallback read against legacy `kelly:{symbol}`.
- Every legacy-path hit emits `structlog` WARNING `kelly_sizer.legacy_key_fallback` with audit fields (`strategy_id`, `symbol`, `legacy_key`, `new_key`) — residual legacy-key dependency is observable.
- Both miss → existing safe defaults `(0.5, 1.5)` unchanged.
- Class docstring updated with migration rationale and references.

### Test plan

- [x] `python -m pytest tests/unit/s04/test_kelly_redis.py -v` — **18/18 passing** (13 pre-existing + 5 new `TestKellyDualRead`)
- [x] `python -m mypy --strict services/s04_fusion_engine/kelly_sizer.py` — clean
- [x] `python -m ruff check services/s04_fusion_engine/kelly_sizer.py tests/unit/s04/test_kelly_redis.py` — clean
- [x] `python -m ruff format --check` — clean
- [x] Coverage on `kelly_sizer.py`: **100 %** across the full s04 suite (`pytest tests/unit/s04/ tests/unit/test_kelly_sizer.py`, 82 tests)

### New test cases (TestKellyDualRead)

| # | Case | Assertion |
|---|---|---|
| a | `test_new_key_hit_no_fallback` | new key populated, single await, no WARNING |
| b | `test_legacy_key_fallback_warns` | only legacy populated, both awaits observed, WARNING with full audit kwargs |
| c | `test_new_key_wins_when_both_present` | both keys populated, new-key value returned, no WARNING |
| d | `test_both_missing_returns_defaults` | neither key populated, returns `(0.5, 1.5)` |
| e | `test_non_default_strategy_id_fallback` | `strategy_id="crypto_momentum"` miss → legacy fallback, WARNING logs `new_key=kelly:crypto_momentum:BTCUSDT` |

### Follow-ups (out of scope here)

- Writer-side migration in `services/s09_feedback_loop/service.py` to dual-write `kelly:{strategy_id}:{symbol}` (separate ticket).
- Once writer lands and legacy entries have aged out of Redis TTL, drop the fallback branch + `strategy_id` parameter.

### References

- Roadmap §2.2.5 — dual-read/dual-write scope and rationale
- ADR-0007 §D9 — per-strategy Redis key topology
- CLAUDE.md §10 — structlog / Decimal / UTC rules

Closes #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)