### PR TITLE
fix(s05): PortfolioTracker Redis orphan-read fix (phase-A.7, closes #197)

### DIFF
--- a/services/s05_risk_manager/portfolio_tracker.py
+++ b/services/s05_risk_manager/portfolio_tracker.py
@@ -121,10 +121,25 @@ class PortfolioTracker:
             The JSON-deserialized payload (typically a ``dict`` with an
             ``available`` key) or ``None`` if neither key resolves.
         """
+        _, payload = await self._resolve(strategy_id=strategy_id)
+        return payload
+
+    async def _resolve(
+        self,
+        *,
+        strategy_id: str,
+    ) -> tuple[str | None, Any | None]:
+        """Perform the dual-key read and report which key produced the payload.
+
+        Returns:
+            ``(resolved_key, payload)``. ``resolved_key`` is the primary key
+            on a primary hit, the legacy key on fallback, and ``None`` when
+            both keys miss (``payload`` is also ``None`` in that case).
+        """
         primary = self.primary_key(strategy_id)
         primary_value = await self._state.get(primary)
         if primary_value is not None:
-            return primary_value
+            return primary, primary_value
 
         legacy_value = await self._state.get(LEGACY_CAPITAL_KEY)
         if legacy_value is not None:
@@ -134,7 +149,9 @@ class PortfolioTracker:
                 legacy_key=LEGACY_CAPITAL_KEY,
                 new_key=primary,
             )
-        return legacy_value
+            return LEGACY_CAPITAL_KEY, legacy_value
+
+        return None, None
 
     async def get_capital(
         self,
@@ -158,16 +175,23 @@ class PortfolioTracker:
         Raises:
             RuntimeError: If a payload was returned but is malformed
                 (not a ``dict`` / missing ``available`` / non-numeric).
-                Fail-loud per ADR-0006 D4.
+                Fail-loud per ADR-0006 D4. The error message includes the
+                resolved key (primary vs legacy) and ``strategy_id`` so
+                post-Phase-B audits can locate the offending producer.
         """
-        payload = await self.read_raw(strategy_id=strategy_id)
+        resolved_key, payload = await self._resolve(strategy_id=strategy_id)
         if payload is None:
             return None
         if not isinstance(payload, dict) or "available" not in payload:
-            raise RuntimeError(f"portfolio:capital malformed: {payload!r}")
+            raise RuntimeError(
+                f"portfolio capital malformed at key={resolved_key!r} "
+                f"strategy_id={strategy_id!r}: {payload!r}"
+            )
         try:
             return Decimal(str(payload["available"]))
         except (InvalidOperation, ValueError) as exc:
             raise RuntimeError(
-                f"portfolio:capital.available not numeric: {payload['available']!r}"
+                f"portfolio capital 'available' not numeric at "
+                f"key={resolved_key!r} strategy_id={strategy_id!r}: "
+                f"{payload['available']!r}"
             ) from exc

--- a/services/s05_risk_manager/portfolio_tracker.py
+++ b/services/s05_risk_manager/portfolio_tracker.py
@@ -1,0 +1,173 @@
+"""Portfolio-capital reader with per-strategy dual-key Redis fallback.
+
+Phase A.7 (issue #197, Roadmap v3.0 §2.2.4, ADR-0007 §D9).
+
+Audit finding (2026-04-20)
+--------------------------
+Prior to this module, the S05 pre-trade context loader
+(:mod:`services.s05_risk_manager.context_loader`) reads the
+``portfolio:capital`` Redis key directly and **unscoped**. Per ADR-0007 §D9
+the Phase B topology migrates every order-path writer to a per-strategy
+key (``portfolio:{strategy_id}:capital``). Once Phase B writers cut over,
+the legacy unscoped key stops being updated -- a reader that keeps
+consulting it silently returns **stale data** (an "orphan read").
+
+Fix
+---
+:class:`PortfolioTracker` performs a dual-key read:
+
+1. **Primary**  -- ``portfolio:{strategy_id}:capital`` (Phase B target).
+2. **Fallback** -- ``portfolio:capital`` (legacy, Phase A).
+
+On fallback the tracker emits a :mod:`structlog` WARNING
+(``portfolio_tracker.legacy_key_fallback``) to give operators an audit
+trail of legacy hits throughout the Phase A -> Phase B migration. Once
+Phase B writers populate the per-strategy key, fallback hits drop to zero
+and the legacy branch dies naturally.
+
+During Phase A, callers that omit ``strategy_id`` transparently keep
+their current behavior (``strategy_id="default"``) because the fallback
+preserves the pre-fix payload. No existing call site is broken by
+wiring this tracker in (follow-up PR).
+
+Compliance notes
+----------------
+- CLAUDE.md Section 2: :class:`Decimal` (never float) for money;
+  :mod:`structlog` only; no ``threading.Thread`` / ``print`` /
+  ``datetime.now()`` without UTC.
+- CLAUDE.md Section 10: deserialization errors surface as
+  :class:`RuntimeError` (fail-loud per ADR-0006 D4), not silently
+  swallowed.
+
+Wiring
+------
+This module is **new** and not yet consumed. The follow-up that replaces
+the raw ``portfolio:capital`` read in
+:class:`services.s05_risk_manager.context_loader.ContextLoader.load` with
+a :class:`PortfolioTracker` call is tracked as a dedicated micro-PR -- or
+naturally bundled into the Phase B ``LegacyConfluenceStrategy`` wrap.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any, Protocol
+
+from core.logger import get_logger
+
+logger = get_logger("s05_risk_manager.portfolio_tracker")
+
+LEGACY_CAPITAL_KEY = "portfolio:capital"
+"""Legacy unscoped Redis key. Written by pre-Phase-B producers only."""
+
+DEFAULT_STRATEGY_ID = "default"
+"""Strategy scope used when callers haven't migrated to per-strategy calls."""
+
+
+class _StateReader(Protocol):
+    """Duck-type for the subset of :class:`core.state.StateStore` used here."""
+
+    async def get(self, key: str) -> Any | None: ...  # noqa: ANN401
+
+
+class PortfolioTracker:
+    """Dual-key Redis reader for the ``portfolio:capital`` snapshot.
+
+    Args:
+        state: Any object exposing an awaitable ``get(key: str)`` method
+            that returns the JSON-deserialized payload or ``None`` on
+            miss. :class:`core.state.StateStore` satisfies this protocol
+            in production; a ``fakeredis``-backed adapter satisfies it
+            in unit tests (see ``tests/unit/s05/test_portfolio_tracker.py``).
+    """
+
+    def __init__(self, state: _StateReader) -> None:
+        self._state = state
+
+    @staticmethod
+    def primary_key(strategy_id: str) -> str:
+        """Return the per-strategy primary key for ``strategy_id``.
+
+        Exposed so callers (and tests) can write the same key the tracker
+        will read back -- single source of truth for the key format.
+        """
+        return f"portfolio:{strategy_id}:capital"
+
+    async def read_raw(
+        self,
+        *,
+        strategy_id: str = DEFAULT_STRATEGY_ID,
+    ) -> Any | None:  # noqa: ANN401
+        """Read the raw capital payload with dual-key fallback.
+
+        Algorithm:
+            1. Attempt the primary per-strategy key
+               (``portfolio:{strategy_id}:capital``). On hit, return the
+               payload immediately -- no fallback, no warning.
+            2. On miss, attempt the legacy unscoped key
+               (``portfolio:capital``). On hit, emit a structlog WARNING
+               (``portfolio_tracker.legacy_key_fallback``) with both keys
+               and ``strategy_id`` for the audit trail, then return the
+               legacy payload.
+            3. If both keys miss, return ``None`` so the caller's
+               fail-loud contract (ADR-0006 D4) decides whether to
+               raise.
+
+        Args:
+            strategy_id: Per-strategy scope. Defaults to ``"default"`` to
+                preserve Phase A call-site behavior.
+
+        Returns:
+            The JSON-deserialized payload (typically a ``dict`` with an
+            ``available`` key) or ``None`` if neither key resolves.
+        """
+        primary = self.primary_key(strategy_id)
+        primary_value = await self._state.get(primary)
+        if primary_value is not None:
+            return primary_value
+
+        legacy_value = await self._state.get(LEGACY_CAPITAL_KEY)
+        if legacy_value is not None:
+            logger.warning(
+                "portfolio_tracker.legacy_key_fallback",
+                strategy_id=strategy_id,
+                legacy_key=LEGACY_CAPITAL_KEY,
+                new_key=primary,
+            )
+        return legacy_value
+
+    async def get_capital(
+        self,
+        *,
+        strategy_id: str = DEFAULT_STRATEGY_ID,
+    ) -> Decimal | None:
+        """Return the available capital as :class:`Decimal` (never float).
+
+        Thin convenience wrapper around :meth:`read_raw`. Validates that
+        the payload is a ``dict`` carrying an ``available`` entry and
+        converts that entry to :class:`Decimal` via ``str(...)`` to avoid
+        binary-float rounding, per CLAUDE.md Section 2.
+
+        Args:
+            strategy_id: Per-strategy scope (see :meth:`read_raw`).
+
+        Returns:
+            Available capital as :class:`Decimal`, or ``None`` if neither
+            key resolved.
+
+        Raises:
+            RuntimeError: If a payload was returned but is malformed
+                (not a ``dict`` / missing ``available`` / non-numeric).
+                Fail-loud per ADR-0006 D4.
+        """
+        payload = await self.read_raw(strategy_id=strategy_id)
+        if payload is None:
+            return None
+        if not isinstance(payload, dict) or "available" not in payload:
+            raise RuntimeError(f"portfolio:capital malformed: {payload!r}")
+        try:
+            return Decimal(str(payload["available"]))
+        except (InvalidOperation, ValueError) as exc:
+            raise RuntimeError(
+                f"portfolio:capital.available not numeric: {payload['available']!r}"
+            ) from exc

--- a/tests/unit/s05/test_portfolio_tracker.py
+++ b/tests/unit/s05/test_portfolio_tracker.py
@@ -1,0 +1,334 @@
+"""Unit tests for :class:`services.s05_risk_manager.portfolio_tracker.PortfolioTracker`.
+
+Phase A.7 (issue #197). Validates the dual-key Redis read pattern:
+primary ``portfolio:{strategy_id}:capital`` with fallback to legacy
+``portfolio:capital`` and a structlog audit-trail WARNING on fallback.
+
+Test patterns follow CLAUDE.md Section 2 (fakeredis only, no real Redis)
+and Section 7 (happy path + edge cases + error cases + property test).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from decimal import Decimal
+from typing import Any
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+from hypothesis import given
+from hypothesis import settings as hyp_settings
+from hypothesis import strategies as st
+
+from services.s05_risk_manager.portfolio_tracker import (
+    DEFAULT_STRATEGY_ID,
+    LEGACY_CAPITAL_KEY,
+    PortfolioTracker,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _JsonStateAdapter:
+    """Minimal JSON-aware adapter around a fakeredis client.
+
+    Mirrors :class:`core.state.StateStore.get` semantics: raw bytes/str
+    values are JSON-decoded before being returned to the caller.
+    """
+
+    def __init__(self, redis: fakeredis.aioredis.FakeRedis) -> None:
+        self._redis = redis
+
+    async def get(self, key: str) -> Any | None:
+        raw = await self._redis.get(key)
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return json.loads(raw)
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> AsyncIterator[fakeredis.aioredis.FakeRedis]:
+    """Fresh fakeredis per test."""
+    client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    try:
+        yield client
+    finally:
+        await client.flushall()
+        await client.aclose()
+
+
+@pytest_asyncio.fixture
+async def tracker(
+    redis_client: fakeredis.aioredis.FakeRedis,
+) -> PortfolioTracker:
+    return PortfolioTracker(_JsonStateAdapter(redis_client))
+
+
+async def _seed(
+    redis: fakeredis.aioredis.FakeRedis,
+    key: str,
+    payload: Any,
+) -> None:
+    await redis.set(key, json.dumps(payload))
+
+
+# ---------------------------------------------------------------------------
+# (a) Primary-key hit: no fallback, no warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_primary_key_hit_returns_value_no_warning(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PortfolioTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Primary hit returns Decimal immediately, no fallback warning."""
+    await _seed(
+        redis_client,
+        PortfolioTracker.primary_key("default"),
+        {"available": "123456.78"},
+    )
+
+    with caplog.at_level("WARNING"):
+        capital = await tracker.get_capital()
+
+    assert capital == Decimal("123456.78")
+    assert "portfolio_tracker.legacy_key_fallback" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_primary_key_hit_read_raw_returns_payload(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PortfolioTracker,
+) -> None:
+    """``read_raw`` returns the deserialized dict, not a Decimal."""
+    await _seed(
+        redis_client,
+        PortfolioTracker.primary_key("default"),
+        {"available": 100_000, "currency": "USD"},
+    )
+    payload = await tracker.read_raw()
+    assert payload == {"available": 100_000, "currency": "USD"}
+
+
+# ---------------------------------------------------------------------------
+# (b) Legacy fallback (default strategy_id): value returned + WARNING
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_fallback_default_strategy_id(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PortfolioTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Only legacy populated + default strategy_id -> fallback + WARNING."""
+    await _seed(redis_client, LEGACY_CAPITAL_KEY, {"available": "50000"})
+
+    with caplog.at_level("WARNING"):
+        capital = await tracker.get_capital()
+
+    assert capital == Decimal("50000")
+    assert "portfolio_tracker.legacy_key_fallback" in caplog.text
+    assert LEGACY_CAPITAL_KEY in caplog.text
+    assert "portfolio:default:capital" in caplog.text
+    assert DEFAULT_STRATEGY_ID in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# (c) Double-write: new key wins, no warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_double_write_primary_wins_no_warning(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PortfolioTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Both keys populated -> primary takes precedence, no warning."""
+    await _seed(
+        redis_client,
+        PortfolioTracker.primary_key("default"),
+        {"available": "99999"},
+    )
+    await _seed(redis_client, LEGACY_CAPITAL_KEY, {"available": "1"})
+
+    with caplog.at_level("WARNING"):
+        capital = await tracker.get_capital()
+
+    assert capital == Decimal("99999")
+    assert "portfolio_tracker.legacy_key_fallback" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# (d) Both keys empty: tracker returns None (caller's fail-loud decides)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_both_keys_empty_returns_none(
+    tracker: PortfolioTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Neither key populated -> both methods return None, no WARNING."""
+    with caplog.at_level("WARNING"):
+        capital = await tracker.get_capital()
+        payload = await tracker.read_raw()
+
+    assert capital is None
+    assert payload is None
+    assert "portfolio_tracker.legacy_key_fallback" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# (e) Non-default strategy_id fallback still works
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_default_strategy_id_falls_back_to_legacy(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PortfolioTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Phase-B caller with real strategy_id + only legacy populated ->
+    fallback + WARNING records the strategy_id (cross-strategy audit)."""
+    await _seed(redis_client, LEGACY_CAPITAL_KEY, {"available": "42"})
+
+    with caplog.at_level("WARNING"):
+        capital = await tracker.get_capital(strategy_id="crypto_momentum")
+
+    assert capital == Decimal("42")
+    assert "portfolio_tracker.legacy_key_fallback" in caplog.text
+    assert "crypto_momentum" in caplog.text
+    assert "portfolio:crypto_momentum:capital" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_non_default_strategy_id_primary_hit_isolates_from_legacy(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PortfolioTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Per-strategy primary populated for X -> reads X, ignores default
+    and legacy. Proves per-strategy isolation post-Phase-B."""
+    await _seed(
+        redis_client,
+        PortfolioTracker.primary_key("crypto_momentum"),
+        {"available": "7777"},
+    )
+    await _seed(
+        redis_client,
+        PortfolioTracker.primary_key("default"),
+        {"available": "1"},
+    )
+    await _seed(redis_client, LEGACY_CAPITAL_KEY, {"available": "2"})
+
+    with caplog.at_level("WARNING"):
+        capital = await tracker.get_capital(strategy_id="crypto_momentum")
+
+    assert capital == Decimal("7777")
+    assert "portfolio_tracker.legacy_key_fallback" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Malformed-payload / fail-loud contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_not_dict_raises(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PortfolioTracker,
+) -> None:
+    """Non-dict payload -> RuntimeError (ADR-0006 D4 fail-loud)."""
+    await _seed(redis_client, PortfolioTracker.primary_key("default"), ["not", "a", "dict"])
+    with pytest.raises(RuntimeError, match="malformed"):
+        await tracker.get_capital()
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_missing_available_raises(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PortfolioTracker,
+) -> None:
+    """Dict missing ``available`` -> RuntimeError."""
+    await _seed(redis_client, PortfolioTracker.primary_key("default"), {"currency": "USD"})
+    with pytest.raises(RuntimeError, match="malformed"):
+        await tracker.get_capital()
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_non_numeric_available_raises(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PortfolioTracker,
+) -> None:
+    """Non-numeric ``available`` -> RuntimeError with specific message."""
+    await _seed(
+        redis_client,
+        PortfolioTracker.primary_key("default"),
+        {"available": "not_a_number"},
+    )
+    with pytest.raises(RuntimeError, match="not numeric"):
+        await tracker.get_capital()
+
+
+# ---------------------------------------------------------------------------
+# Property test: any numeric-like payload round-trips through Decimal
+# ---------------------------------------------------------------------------
+
+
+@hyp_settings(max_examples=50, deadline=None)
+@given(
+    st.decimals(
+        min_value=Decimal("0"),
+        max_value=Decimal("1e12"),
+        places=8,
+        allow_nan=False,
+        allow_infinity=False,
+    )
+)
+def test_property_numeric_available_round_trips(value: Decimal) -> None:
+    """Non-negative, finite 8-decimal value round-trips through Decimal."""
+    import asyncio
+
+    async def _run() -> Decimal | None:
+        client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+        try:
+            await client.set(
+                PortfolioTracker.primary_key("default"),
+                json.dumps({"available": str(value)}),
+            )
+            tr = PortfolioTracker(_JsonStateAdapter(client))
+            return await tr.get_capital()
+        finally:
+            await client.flushall()
+            await client.aclose()
+
+    result = asyncio.run(_run())
+    assert result == value
+
+
+# ---------------------------------------------------------------------------
+# Static helpers
+# ---------------------------------------------------------------------------
+
+
+def test_primary_key_format() -> None:
+    """Sanity-check the key-builder helper (contract with future writers)."""
+    assert PortfolioTracker.primary_key("default") == "portfolio:default:capital"
+    assert PortfolioTracker.primary_key("crypto_momentum") == "portfolio:crypto_momentum:capital"
+
+
+def test_module_constants_are_stable_contracts() -> None:
+    """Constants exposed by the module are stable contracts."""
+    assert LEGACY_CAPITAL_KEY == "portfolio:capital"
+    assert DEFAULT_STRATEGY_ID == "default"

--- a/tests/unit/s05/test_portfolio_tracker.py
+++ b/tests/unit/s05/test_portfolio_tracker.py
@@ -249,10 +249,13 @@ async def test_malformed_payload_not_dict_raises(
     redis_client: fakeredis.aioredis.FakeRedis,
     tracker: PortfolioTracker,
 ) -> None:
-    """Non-dict payload -> RuntimeError (ADR-0006 D4 fail-loud)."""
+    """Non-dict payload -> RuntimeError with resolved key + strategy_id context."""
     await _seed(redis_client, PortfolioTracker.primary_key("default"), ["not", "a", "dict"])
-    with pytest.raises(RuntimeError, match="malformed"):
+    with pytest.raises(RuntimeError, match="malformed") as excinfo:
         await tracker.get_capital()
+    msg = str(excinfo.value)
+    assert "portfolio:default:capital" in msg
+    assert "default" in msg
 
 
 @pytest.mark.asyncio
@@ -260,10 +263,13 @@ async def test_malformed_payload_missing_available_raises(
     redis_client: fakeredis.aioredis.FakeRedis,
     tracker: PortfolioTracker,
 ) -> None:
-    """Dict missing ``available`` -> RuntimeError."""
+    """Dict missing ``available`` -> RuntimeError with resolved key + strategy_id."""
     await _seed(redis_client, PortfolioTracker.primary_key("default"), {"currency": "USD"})
-    with pytest.raises(RuntimeError, match="malformed"):
+    with pytest.raises(RuntimeError, match="malformed") as excinfo:
         await tracker.get_capital()
+    msg = str(excinfo.value)
+    assert "portfolio:default:capital" in msg
+    assert "default" in msg
 
 
 @pytest.mark.asyncio
@@ -271,14 +277,36 @@ async def test_malformed_payload_non_numeric_available_raises(
     redis_client: fakeredis.aioredis.FakeRedis,
     tracker: PortfolioTracker,
 ) -> None:
-    """Non-numeric ``available`` -> RuntimeError with specific message."""
+    """Non-numeric ``available`` -> RuntimeError with resolved key + strategy_id."""
     await _seed(
         redis_client,
         PortfolioTracker.primary_key("default"),
         {"available": "not_a_number"},
     )
-    with pytest.raises(RuntimeError, match="not numeric"):
+    with pytest.raises(RuntimeError, match="not numeric") as excinfo:
         await tracker.get_capital()
+    msg = str(excinfo.value)
+    assert "portfolio:default:capital" in msg
+    assert "default" in msg
+
+
+@pytest.mark.asyncio
+async def test_malformed_legacy_payload_reports_legacy_key(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PortfolioTracker,
+) -> None:
+    """Malformed payload under legacy key -> error cites the LEGACY key, not primary.
+
+    Ensures post-Phase-B audits can distinguish a corrupted legacy producer
+    from a corrupted per-strategy producer (addresses #210 Copilot thread 1).
+    """
+    await _seed(redis_client, LEGACY_CAPITAL_KEY, {"currency": "USD"})
+    with pytest.raises(RuntimeError, match="malformed") as excinfo:
+        await tracker.get_capital(strategy_id="crypto_momentum")
+    msg = str(excinfo.value)
+    assert LEGACY_CAPITAL_KEY in msg
+    assert "crypto_momentum" in msg
+    assert "portfolio:crypto_momentum:capital" not in msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase A.7 resolution of the `portfolio:capital` orphan-read risk identified in [`docs/audits/REDIS_KEYS_WRITER_AUDIT_2026-04-17.md`](../docs/audits/REDIS_KEYS_WRITER_AUDIT_2026-04-17.md) and scheduled in Roadmap v3.0 §2.2.4 (cf. ADR-0007 §D9).

Introduces a new reader module `services/s05_risk_manager/portfolio_tracker.py` that performs a **dual-key** Redis lookup:

1. **Primary**  `portfolio:{strategy_id}:capital` (Phase B target per ADR-0007 §D9).
2. **Fallback** `portfolio:capital` (legacy unscoped key, Phase A).

On fallback the tracker emits a structlog WARNING (`portfolio_tracker.legacy_key_fallback`) carrying both keys and the `strategy_id`, providing an audit trail across the Phase A → Phase B migration. Once Phase B writers populate the per-strategy key, fallback hits drop to zero and the legacy branch dies naturally.

## Audit findings (pre-fix)

- **Current reader**: `services/s05_risk_manager/context_loader.py::ContextLoader.load()` reads `portfolio:capital` **unscoped** (single key, no strategy dimension).
- **Writer status**: orphan — no production writer verified (per the 2026-04-17 Redis-keys audit). Phase B strategy microservices will write to the per-strategy key `portfolio:{strategy_id}:capital` per ADR-0007 §D9.
- **Orphan-read risk**: after Phase B cutover, the legacy unscoped key stops being updated. A reader that keeps consulting it silently returns **stale data** — the "orphan read".
- **File topology divergence from Roadmap §2.2.4**: the Roadmap names `services/s06_execution/portfolio_tracker.py` as the writer file. This PR implements the **reader** side in S05 (matching the mission’s orphan-read scope). The module is self-contained and can be consumed from either S05 or S06 follow-ups.

## Design

- `PortfolioTracker(state)` — accepts any object exposing `async get(key)` (duck-typed; `core.state.StateStore` and fakeredis adapters both satisfy the protocol).
- `read_raw(*, strategy_id="default")` — returns the raw JSON payload (dict) or `None`.
- `get_capital(*, strategy_id="default")` — returns `Decimal | None` (per CLAUDE.md §2 — no float for money). Raises `RuntimeError` on malformed payloads (ADR-0006 §D4 fail-loud).
- `DEFAULT_STRATEGY_ID = "default"` preserves current caller behaviour during Phase A.

## Files changed

| File | Change | LOC |
|---|---|---|
| `services/s05_risk_manager/portfolio_tracker.py` | **new** | ~165 |
| `tests/unit/s05/test_portfolio_tracker.py` | **new** | ~310 |

No other file touched. Hard stops honoured: `core/models/*`, `services/s04_*/kelly_sizer.py`, `services/s05_*/context_loader.py`, `backtesting/*`, `core/topics.py`, `.github/workflows/ci.yml`, `docs/adr/*` all untouched.

## Test plan

13 tests, all green locally, 100% branch + line coverage on the new module.

- [x] **(a)** Primary hit returns `Decimal`, no fallback warning.
- [x] **(a)** Primary hit: `read_raw` returns dict payload.
- [x] **(b)** Legacy-only + default `strategy_id` → value returned + WARNING logged.
- [x] **(c)** Both keys populated → primary wins, no warning (double-write precedence).
- [x] **(d)** Both empty → `None` returned, no warning (fail-loud handled by caller).
- [x] **(e)** Legacy-only + non-default `strategy_id="crypto_momentum"` → fallback + WARNING records the real strategy_id.
- [x] **(e')** Per-strategy primary populated for `crypto_momentum` → returns its value, ignores default and legacy (Phase-B isolation).
- [x] Malformed: non-dict payload → `RuntimeError` match `"malformed"`.
- [x] Malformed: dict missing `available` → `RuntimeError`.
- [x] Malformed: non-numeric `available` → `RuntimeError` match `"not numeric"`.
- [x] Hypothesis property test: any non-negative finite 8-decimal value round-trips through Decimal without float lossiness.
- [x] `primary_key` helper format is `portfolio:{strategy_id}:capital`.
- [x] Module constants (`LEGACY_CAPITAL_KEY`, `DEFAULT_STRATEGY_ID`) are stable contracts.

### Gates run locally

```
ruff check services/s05_risk_manager/portfolio_tracker.py tests/unit/s05/test_portfolio_tracker.py   # All checks passed!
ruff format --check   # 2 files already formatted
mypy --strict services/s05_risk_manager/portfolio_tracker.py tests/unit/s05/test_portfolio_tracker.py   # Success: no issues found in 2 source files
pytest tests/unit/s05/test_portfolio_tracker.py -v   # 13 passed
pytest tests/unit/s05/   # 142 passed (13 new + 129 existing, no regression)
pytest --cov=services.s05_risk_manager.portfolio_tracker   # 100% (35/35 stmts, 8/8 branches)
```

## Follow-up

Wiring `PortfolioTracker` into `ContextLoader.load()` (replacing the raw `portfolio:capital` read in `context_loader.py`) is intentionally out of scope for this PR — tracked as a dedicated micro-PR, or naturally bundled into the Phase B `LegacyConfluenceStrategy` wrap.

## References

- Issue: #197
- Roadmap: [`PHASE_5_v3_MULTI_STRAT_ALIGNED_ROADMAP.md`](../docs/phases/PHASE_5_v3_MULTI_STRAT_ALIGNED_ROADMAP.md) §2.2.4
- ADR: [`ADR-0007-strategy-as-microservice.md`](../docs/adr/ADR-0007-strategy-as-microservice.md) §D9
- Audit: [`REDIS_KEYS_WRITER_AUDIT_2026-04-17.md`](../docs/audits/REDIS_KEYS_WRITER_AUDIT_2026-04-17.md)
- Charter: [`ALPHA_THESIS_AND_MULTI_STRAT_CHARTER.md`](../docs/strategy/ALPHA_THESIS_AND_MULTI_STRAT_CHARTER.md) §5.5

Closes #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)