### PR TITLE
feat(risk_manager): pre-trade PnLTracker with dual-key Redis read (phase-A.8, closes #198)

### DIFF
--- a/services/risk_manager/pnl_tracker.py
+++ b/services/risk_manager/pnl_tracker.py
@@ -1,0 +1,252 @@
+"""Pre-trade PnL reader with per-strategy dual-key Redis fallback.
+
+Phase A.8 (issue #198, Roadmap v3.0 §2.2.4, ADR-0007 §D9).
+
+Design rationale
+----------------
+This is the **pre-trade** PnL reader, consumed by the S05 Risk Manager
+gate chain. It is strictly separate from
+:mod:`services.command_center.pnl_tracker` (reporting tracker feeding the
+dashboard). Separation follows the Millennium / Citadel pod pattern:
+pre-trade risk paths never share code with reporting paths so a bug in
+one cannot block or corrupt the other.
+
+**SLA distinction**
+
+- Pre-trade path (this module): millisecond-scale reads, **fail-loud**
+  on malformed data (ADR-0006 §D4). A corrupted payload MUST surface as
+  :class:`RuntimeError` so the fail-closed guard rejects the order
+  rather than sizing on garbage.
+- Reporting path (``command_center.pnl_tracker``): seconds-scale SLA,
+  eventual consistency tolerated, aggregates from ``trades:all`` list.
+
+Audit finding (2026-04-20)
+--------------------------
+Grep of the repo for ``pnl:daily`` / ``pnl:24h``:
+
+- **Writer of ``pnl:daily``**: **no production writer exists yet**.
+  The key is an "orphan read" consumed by
+  :class:`services.risk_manager.context_loader.ContextLoader` (line 74)
+  and seeded only by test fixtures
+  (``tests/unit/risk_manager/test_service_no_fallbacks.py:82`` and
+  ``tests/unit/risk_manager/test_risk_chain.py:95``) which use
+  ``redis.set("pnl:daily", "0")``. The S05 Fail-Closed guard
+  (ADR-0006 §D1) currently shields production from the missing writer;
+  the real writer lands in Phase B (S09 FeedbackLoop aggregation).
+- **Writer of ``pnl:24h``**: **does not exist anywhere in the codebase
+  today**. Introduced here as a reserved key so the Phase B writer can
+  target the per-strategy primary directly.
+- **Storage API**: :meth:`core.state.StateStore.set` is the only write
+  primitive on the pre-trade path. It encodes the payload via
+  ``json.dumps(value, default=str)`` under a Redis ``STRING`` (not a
+  ``HASH``). :meth:`core.state.StateStore.get` mirrors it with
+  ``json.loads`` on the raw value. See ``core/state.py:121`` +
+  ``core/state.py:136``.
+- **Payload shape**: unlike ``portfolio:capital`` (which is a dict
+  ``{"available": <amount>}``), the PnL keys are encoded as **scalars**
+  — a JSON number or numeric string. ``ContextLoader`` consumes them as
+  ``Decimal(str(results[1]))`` directly (line 74), confirming the
+  scalar contract.
+
+Reader API decision
+-------------------
+Given the writer uses ``state.set(...)`` (STRING-with-JSON), this
+tracker reads via ``state.get(key)`` and expects a **scalar numeric**
+payload (JSON number, numeric string, or any value accepted by
+``Decimal(str(...))``). Malformed payloads surface as
+:class:`RuntimeError` with the resolved key + ``strategy_id`` embedded,
+so post-Phase-B audits can locate the offending producer.
+
+Fix
+---
+Dual-key read mirrors :class:`services.risk_manager.portfolio_tracker.PortfolioTracker`
+(PR #210, ``92cf12a`` + fix ``e5eba7c``):
+
+1. **Primary**  -- ``pnl:{strategy_id}:daily`` (or ``:24h``).
+2. **Fallback** -- ``pnl:daily`` (or ``pnl:24h``) -- legacy unscoped.
+
+On fallback the tracker emits a :mod:`structlog` WARNING
+(``pnl_tracker.legacy_key_fallback``) carrying both keys and
+``strategy_id`` so operators can audit the Phase-A → Phase-B cutover.
+Once the Phase B writer populates the per-strategy key, fallback hits
+drop to zero and the legacy branch dies naturally.
+
+Wiring
+------
+This module is **new** and not wired into any consumer. ContextLoader
+still reads ``pnl:daily`` directly; swapping it to this tracker is a
+Phase B follow-up tracked alongside the S09 writer introduction.
+
+Shared helper
+-------------
+A grep across ``core/`` and ``services/`` confirms no reusable dual-read
+helper exists today (``portfolio_tracker`` and ``kelly_sizer`` each
+open-code the pattern). Extraction is intentionally deferred: with a
+third inline instance, a refactor to ``core/redis_dual_read.py`` becomes
+economically justified, but this sprint preserves the proven pattern.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any, Protocol
+
+from core.logger import get_logger
+
+logger = get_logger("risk_manager.pnl_tracker")
+
+LEGACY_DAILY_KEY = "pnl:daily"
+"""Legacy unscoped Redis key for daily PnL. Written by pre-Phase-B producers only."""
+
+LEGACY_24H_KEY = "pnl:24h"
+"""Legacy unscoped Redis key for trailing 24h PnL. Written by pre-Phase-B producers only."""
+
+DEFAULT_STRATEGY_ID = "default"
+"""Strategy scope used when callers haven't migrated to per-strategy calls."""
+
+
+class _StateReader(Protocol):
+    """Duck-type for the subset of :class:`core.state.StateStore` used here."""
+
+    async def get(self, key: str) -> Any | None: ...  # noqa: ANN401
+
+
+class PnLTracker:
+    """Dual-key Redis reader for pre-trade PnL (daily + trailing 24h).
+
+    Args:
+        state: Any object exposing an awaitable ``get(key: str)`` method
+            that returns the JSON-deserialized scalar payload or
+            ``None`` on miss. :class:`core.state.StateStore` satisfies
+            this protocol in production; a ``fakeredis``-backed adapter
+            satisfies it in unit tests.
+    """
+
+    def __init__(self, state: _StateReader) -> None:
+        self._state = state
+
+    @staticmethod
+    def primary_daily_key(strategy_id: str) -> str:
+        """Return the per-strategy primary key for daily PnL.
+
+        Exposed so callers (and tests) can write the same key the
+        tracker will read back -- single source of truth for the key
+        format.
+        """
+        return f"pnl:{strategy_id}:daily"
+
+    @staticmethod
+    def primary_24h_key(strategy_id: str) -> str:
+        """Return the per-strategy primary key for trailing 24h PnL."""
+        return f"pnl:{strategy_id}:24h"
+
+    async def _resolve(
+        self,
+        *,
+        primary_key: str,
+        legacy_key: str,
+        strategy_id: str,
+    ) -> tuple[str | None, Any | None]:
+        """Perform the dual-key read and report which key produced the payload.
+
+        Returns:
+            ``(resolved_key, payload)``. ``resolved_key`` is the primary
+            key on a primary hit, the legacy key on fallback, and
+            ``None`` when both keys miss (``payload`` is also ``None``).
+        """
+        primary_value = await self._state.get(primary_key)
+        if primary_value is not None:
+            return primary_key, primary_value
+
+        legacy_value = await self._state.get(legacy_key)
+        if legacy_value is not None:
+            logger.warning(
+                "pnl_tracker.legacy_key_fallback",
+                strategy_id=strategy_id,
+                legacy_key=legacy_key,
+                new_key=primary_key,
+            )
+            return legacy_key, legacy_value
+
+        return None, None
+
+    async def get_daily_pnl(
+        self,
+        *,
+        strategy_id: str = DEFAULT_STRATEGY_ID,
+    ) -> Decimal | None:
+        """Return current daily PnL as :class:`Decimal` (never float).
+
+        Dual-key read: primary ``pnl:{strategy_id}:daily`` then legacy
+        ``pnl:daily`` fallback with structlog WARNING on fallback.
+
+        Args:
+            strategy_id: Per-strategy scope. Defaults to ``"default"``
+                to preserve Phase A call-site behavior.
+
+        Returns:
+            Daily PnL as :class:`Decimal`, or ``None`` if neither key
+            resolved.
+
+        Raises:
+            RuntimeError: If a payload was returned but cannot be
+                converted to :class:`Decimal` (fail-loud per
+                ADR-0006 §D4). The message embeds the resolved key
+                (primary vs legacy) and ``strategy_id`` so post-Phase-B
+                audits can locate the offending producer.
+        """
+        return await self._read_scalar(
+            primary_key=self.primary_daily_key(strategy_id),
+            legacy_key=LEGACY_DAILY_KEY,
+            strategy_id=strategy_id,
+            field="daily",
+        )
+
+    async def get_24h_pnl(
+        self,
+        *,
+        strategy_id: str = DEFAULT_STRATEGY_ID,
+    ) -> Decimal | None:
+        """Return trailing 24h PnL as :class:`Decimal` (never float).
+
+        Same dual-read + fail-loud contract as :meth:`get_daily_pnl`
+        but for the ``:24h`` key family.
+        """
+        return await self._read_scalar(
+            primary_key=self.primary_24h_key(strategy_id),
+            legacy_key=LEGACY_24H_KEY,
+            strategy_id=strategy_id,
+            field="24h",
+        )
+
+    async def _read_scalar(
+        self,
+        *,
+        primary_key: str,
+        legacy_key: str,
+        strategy_id: str,
+        field: str,
+    ) -> Decimal | None:
+        """Shared scalar-Decimal conversion used by the daily + 24h getters."""
+        resolved_key, payload = await self._resolve(
+            primary_key=primary_key,
+            legacy_key=legacy_key,
+            strategy_id=strategy_id,
+        )
+        if payload is None:
+            return None
+        if isinstance(payload, bool):
+            # Guard against ``True``/``False`` being silently coerced to
+            # ``Decimal("1")`` / ``Decimal("0")``: booleans are never a
+            # valid PnL payload; fail loud.
+            raise RuntimeError(
+                f"pnl {field} payload non-numeric at key={resolved_key!r} "
+                f"strategy_id={strategy_id!r}: {payload!r}"
+            )
+        try:
+            return Decimal(str(payload))
+        except (InvalidOperation, ValueError) as exc:
+            raise RuntimeError(
+                f"pnl {field} payload non-numeric at key={resolved_key!r} "
+                f"strategy_id={strategy_id!r}: {payload!r}"
+            ) from exc

--- a/services/risk_manager/pnl_tracker.py
+++ b/services/risk_manager/pnl_tracker.py
@@ -122,6 +122,11 @@ class PnLTracker:
             satisfies it in unit tests.
     """
 
+    # TODO(Phase B): Add staleness check once the S09 FeedbackLoop writer
+    # defines its cadence. The reader will verify Redis TTL or a sidecar
+    # timestamp key (pnl:{strategy_id}:daily:ts) and raise PnLStale if
+    # data is older than the writer's expected refresh interval.
+
     def __init__(self, state: _StateReader) -> None:
         self._state = state
 

--- a/tests/unit/risk_manager/test_pnl_tracker.py
+++ b/tests/unit/risk_manager/test_pnl_tracker.py
@@ -1,0 +1,386 @@
+"""Unit tests for :class:`services.risk_manager.pnl_tracker.PnLTracker`.
+
+Phase A.8 (issue #198). Validates the dual-key Redis read pattern:
+primary ``pnl:{strategy_id}:daily`` (and ``:24h``) with fallback to
+legacy ``pnl:daily`` (and ``pnl:24h``) and a structlog audit-trail
+WARNING on fallback.
+
+Test patterns follow CLAUDE.md Section 2 (fakeredis only, no real
+Redis) and Section 7 (happy path + edge cases + error cases + property
+test). The adapter mirrors the Phase-A writer API
+(:meth:`core.state.StateStore.set`) which stores JSON-encoded scalars
+under Redis ``STRING`` keys.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from decimal import Decimal
+from typing import Any
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+from hypothesis import given
+from hypothesis import settings as hyp_settings
+from hypothesis import strategies as st
+
+from services.risk_manager.pnl_tracker import (
+    DEFAULT_STRATEGY_ID,
+    LEGACY_24H_KEY,
+    LEGACY_DAILY_KEY,
+    PnLTracker,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _JsonStateAdapter:
+    """Minimal JSON-aware adapter around a fakeredis client.
+
+    Mirrors :class:`core.state.StateStore.get` semantics: raw bytes/str
+    values are JSON-decoded before being returned to the caller.
+    """
+
+    def __init__(self, redis: fakeredis.aioredis.FakeRedis) -> None:
+        self._redis = redis
+
+    async def get(self, key: str) -> Any | None:
+        raw = await self._redis.get(key)
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return json.loads(raw)
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> AsyncIterator[fakeredis.aioredis.FakeRedis]:
+    """Fresh fakeredis per test."""
+    client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    try:
+        yield client
+    finally:
+        await client.flushall()
+        await client.aclose()
+
+
+@pytest_asyncio.fixture
+async def tracker(
+    redis_client: fakeredis.aioredis.FakeRedis,
+) -> PnLTracker:
+    return PnLTracker(_JsonStateAdapter(redis_client))
+
+
+async def _seed(
+    redis: fakeredis.aioredis.FakeRedis,
+    key: str,
+    payload: Any,
+) -> None:
+    """Mirror :meth:`core.state.StateStore.set` — JSON-encode under STRING."""
+    await redis.set(key, json.dumps(payload))
+
+
+# ---------------------------------------------------------------------------
+# (a) Primary-key hit: no fallback, no warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_primary_daily_hit_returns_decimal_no_warning(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PnLTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Primary daily hit returns Decimal immediately, no fallback warning."""
+    await _seed(redis_client, PnLTracker.primary_daily_key("default"), "1234.56")
+
+    with caplog.at_level("WARNING"):
+        pnl = await tracker.get_daily_pnl()
+
+    assert pnl == Decimal("1234.56")
+    assert "pnl_tracker.legacy_key_fallback" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_primary_24h_hit_returns_decimal_no_warning(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PnLTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Primary 24h hit returns Decimal immediately, no fallback warning."""
+    await _seed(redis_client, PnLTracker.primary_24h_key("default"), "5678.90")
+
+    with caplog.at_level("WARNING"):
+        pnl = await tracker.get_24h_pnl()
+
+    assert pnl == Decimal("5678.90")
+    assert "pnl_tracker.legacy_key_fallback" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# (b) Legacy fallback (default strategy_id): value returned + WARNING
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_daily_fallback_with_default_strategy_warns(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PnLTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Only legacy populated + default strategy_id -> fallback + WARNING."""
+    await _seed(redis_client, LEGACY_DAILY_KEY, "42.00")
+
+    with caplog.at_level("WARNING"):
+        pnl = await tracker.get_daily_pnl()
+
+    assert pnl == Decimal("42.00")
+    assert "pnl_tracker.legacy_key_fallback" in caplog.text
+    assert LEGACY_DAILY_KEY in caplog.text
+    assert "pnl:default:daily" in caplog.text
+    assert DEFAULT_STRATEGY_ID in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_legacy_24h_fallback_with_default_strategy_warns(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PnLTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Only legacy 24h populated + default strategy_id -> fallback + WARNING."""
+    await _seed(redis_client, LEGACY_24H_KEY, "-100.25")
+
+    with caplog.at_level("WARNING"):
+        pnl = await tracker.get_24h_pnl()
+
+    assert pnl == Decimal("-100.25")
+    assert "pnl_tracker.legacy_key_fallback" in caplog.text
+    assert LEGACY_24H_KEY in caplog.text
+    assert "pnl:default:24h" in caplog.text
+    assert DEFAULT_STRATEGY_ID in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# (c) Double-write: new key wins, no warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_double_write_primary_daily_wins_no_warning(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PnLTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Both daily keys populated -> primary takes precedence, no warning."""
+    await _seed(redis_client, PnLTracker.primary_daily_key("default"), "999")
+    await _seed(redis_client, LEGACY_DAILY_KEY, "1")
+
+    with caplog.at_level("WARNING"):
+        pnl = await tracker.get_daily_pnl()
+
+    assert pnl == Decimal("999")
+    assert "pnl_tracker.legacy_key_fallback" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_double_write_primary_24h_wins_no_warning(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PnLTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Both 24h keys populated -> primary takes precedence, no warning."""
+    await _seed(redis_client, PnLTracker.primary_24h_key("default"), "7777")
+    await _seed(redis_client, LEGACY_24H_KEY, "2")
+
+    with caplog.at_level("WARNING"):
+        pnl = await tracker.get_24h_pnl()
+
+    assert pnl == Decimal("7777")
+    assert "pnl_tracker.legacy_key_fallback" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# (d) Both keys empty: tracker returns None (caller's fail-loud decides)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_both_keys_empty_daily_returns_none(
+    tracker: PnLTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Neither daily key populated -> None, no WARNING."""
+    with caplog.at_level("WARNING"):
+        pnl = await tracker.get_daily_pnl()
+
+    assert pnl is None
+    assert "pnl_tracker.legacy_key_fallback" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_both_keys_empty_24h_returns_none(
+    tracker: PnLTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Neither 24h key populated -> None, no WARNING."""
+    with caplog.at_level("WARNING"):
+        pnl = await tracker.get_24h_pnl()
+
+    assert pnl is None
+    assert "pnl_tracker.legacy_key_fallback" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# (e) Non-default strategy_id isolation + fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_default_strategy_primary_isolated_from_legacy_daily(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PnLTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Per-strategy primary for X -> reads X, ignores default and legacy."""
+    await _seed(redis_client, PnLTracker.primary_daily_key("crypto_momentum"), "333")
+    await _seed(redis_client, PnLTracker.primary_daily_key("default"), "1")
+    await _seed(redis_client, LEGACY_DAILY_KEY, "2")
+
+    with caplog.at_level("WARNING"):
+        pnl = await tracker.get_daily_pnl(strategy_id="crypto_momentum")
+
+    assert pnl == Decimal("333")
+    assert "pnl_tracker.legacy_key_fallback" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_non_default_strategy_fallback_to_legacy_daily_warns(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PnLTracker,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Phase-B caller with real strategy_id + only legacy populated ->
+    fallback + WARNING records the strategy_id (cross-strategy audit)."""
+    await _seed(redis_client, LEGACY_DAILY_KEY, "55.5")
+
+    with caplog.at_level("WARNING"):
+        pnl = await tracker.get_daily_pnl(strategy_id="crypto_momentum")
+
+    assert pnl == Decimal("55.5")
+    assert "pnl_tracker.legacy_key_fallback" in caplog.text
+    assert "crypto_momentum" in caplog.text
+    assert "pnl:crypto_momentum:daily" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Malformed-payload / fail-loud contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_malformed_primary_payload_daily_raises_with_context(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PnLTracker,
+) -> None:
+    """Non-numeric primary payload -> RuntimeError with resolved key + strategy_id."""
+    await _seed(
+        redis_client,
+        PnLTracker.primary_daily_key("default"),
+        "not_a_number",
+    )
+    with pytest.raises(RuntimeError, match="non-numeric") as excinfo:
+        await tracker.get_daily_pnl()
+    msg = str(excinfo.value)
+    assert "pnl:default:daily" in msg
+    assert "default" in msg
+
+
+@pytest.mark.asyncio
+async def test_malformed_legacy_payload_reports_legacy_key_daily(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PnLTracker,
+) -> None:
+    """Malformed payload under legacy key -> error cites LEGACY key, not primary.
+
+    Ensures post-Phase-B audits can distinguish a corrupted legacy
+    producer from a corrupted per-strategy producer (same contract as
+    PortfolioTracker -- addresses PR #210 Copilot thread 1).
+    """
+    await _seed(redis_client, LEGACY_DAILY_KEY, ["not", "a", "scalar"])
+    with pytest.raises(RuntimeError, match="non-numeric") as excinfo:
+        await tracker.get_daily_pnl(strategy_id="crypto_momentum")
+    msg = str(excinfo.value)
+    assert LEGACY_DAILY_KEY in msg
+    assert "crypto_momentum" in msg
+    assert "pnl:crypto_momentum:daily" not in msg
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_rejects_bool(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    tracker: PnLTracker,
+) -> None:
+    """Boolean payload -> RuntimeError (never silently Decimal(True)=1)."""
+    await _seed(redis_client, PnLTracker.primary_daily_key("default"), True)
+    with pytest.raises(RuntimeError, match="non-numeric"):
+        await tracker.get_daily_pnl()
+
+
+# ---------------------------------------------------------------------------
+# Property test: any non-negative numeric payload round-trips through Decimal
+# ---------------------------------------------------------------------------
+
+
+@hyp_settings(max_examples=50, deadline=None)
+@given(
+    st.decimals(
+        min_value=Decimal("0"),
+        max_value=Decimal("1e12"),
+        places=8,
+        allow_nan=False,
+        allow_infinity=False,
+    )
+)
+def test_property_numeric_daily_pnl_round_trips(value: Decimal) -> None:
+    """Non-negative, finite 8-decimal value round-trips through Decimal."""
+    import asyncio
+
+    async def _run() -> Decimal | None:
+        client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+        try:
+            await client.set(
+                PnLTracker.primary_daily_key("default"),
+                json.dumps(str(value)),
+            )
+            tr = PnLTracker(_JsonStateAdapter(client))
+            return await tr.get_daily_pnl()
+        finally:
+            await client.flushall()
+            await client.aclose()
+
+    result = asyncio.run(_run())
+    assert result == value
+
+
+# ---------------------------------------------------------------------------
+# Static helpers
+# ---------------------------------------------------------------------------
+
+
+def test_primary_key_format() -> None:
+    """Sanity-check the key-builder helpers (contract with future writers)."""
+    assert PnLTracker.primary_daily_key("default") == "pnl:default:daily"
+    assert PnLTracker.primary_daily_key("crypto_momentum") == "pnl:crypto_momentum:daily"
+    assert PnLTracker.primary_24h_key("default") == "pnl:default:24h"
+    assert PnLTracker.primary_24h_key("crypto_momentum") == "pnl:crypto_momentum:24h"
+
+
+def test_module_constants_are_stable_contracts() -> None:
+    """Constants exposed by the module are stable contracts."""
+    assert LEGACY_DAILY_KEY == "pnl:daily"
+    assert LEGACY_24H_KEY == "pnl:24h"
+    assert DEFAULT_STRATEGY_ID == "default"


### PR DESCRIPTION
## Summary

- New **pre-trade** PnL reader at `services/risk_manager/pnl_tracker.py`, strictly separate from the **reporting** tracker at `services/command_center/pnl_tracker.py`. Separation follows the Millennium / Citadel pod pattern — pre-trade paths never share code with reporting paths.
- Dual-key Redis read: primary `pnl:{strategy_id}:daily` (and `:24h`), fallback to legacy `pnl:daily` (and `pnl:24h`) with `structlog` WARNING on fallback for migration audit trail.
- Fail-loud per ADR-0006 §D4: malformed payloads raise `RuntimeError` embedding the resolved key + `strategy_id` so post-Phase-B audits can locate the offending producer.

Refs: Roadmap v3.0 §2.2.4 · ADR-0007 §D9 · issue #198.

## Design rationale (why two trackers)

| Path | SLA | Failure mode | Data source |
|---|---|---|---|
| `services/risk_manager/pnl_tracker.py` (this PR) | ms-scale | **fail-loud** | Redis `pnl:{strategy_id}:daily` / `:24h` |
| `services/command_center/pnl_tracker.py` (untouched) | seconds OK, eventual consistency | soft | aggregates from `trades:all` list |

A bug in the reporting tracker cannot block trading; a bug in the pre-trade tracker cannot corrupt the dashboard.

## Audit findings (embedded in module docstring)

- **Writer of `pnl:daily`**: **no production writer exists yet**. Consumed by `services/risk_manager/context_loader.py:74` and seeded only by test fixtures (`tests/unit/risk_manager/test_service_no_fallbacks.py:82`, `tests/unit/risk_manager/test_risk_chain.py:95`) via `redis.set("pnl:daily", "0")`. The S05 Fail-Closed guard currently shields production from the missing writer; the real writer lands in Phase B (S09 FeedbackLoop aggregation).
- **Writer of `pnl:24h`**: does not exist anywhere today. Introduced here as a reserved key so the Phase B writer can target the per-strategy primary directly.
- **Writer API**: `core.state.StateStore.set` — `json.dumps` under Redis `STRING`. Reader uses `StateStore.get` + `json.loads` (`core/state.py:121` + `core/state.py:136`).
- **Payload shape**: JSON scalar (number or numeric string), NOT a dict — confirmed by `ContextLoader`: `Decimal(str(results[1]))` at line 74. Differs from `portfolio:capital` which is `{"available": <amount>}`.
- **command_center/pnl_tracker.py** does NOT write these keys (aggregates from `trades:all`). Intentional separation preserved; not modified.
- **No reusable dual-read helper** exists today (grep across `core/` + `services/` confirms). `portfolio_tracker` and `kelly_sizer` open-code the pattern inline; this PR adds a third inline instance. A fourth will justify extraction to `core/redis_dual_read.py` — intentionally deferred out of this sprint per mission guardrail.

## Pattern alignment

Mirrors `PortfolioTracker` (PR #210 / 92cf12a + fix e5eba7c):

- `_resolve` helper returns `(resolved_key, payload)` so error messages cite the correct key (primary vs legacy), addressing PR #210 Copilot thread 1.
- `primary_*_key()` static methods expose the key format as a stable contract for future writers.
- Booleans explicitly rejected so `Decimal(True) == Decimal("1")` cannot silently sneak through.

## Test plan

- [x] 16 unit tests, 100% line + branch coverage on the new module (target was ≥90%).
- [x] Regression: 159/159 pass in `tests/unit/risk_manager/` (143 prior + 16 new).
- [x] `mypy --strict services/risk_manager/pnl_tracker.py` — clean.
- [x] `ruff check` + `ruff format --check` — clean.
- [ ] CI pipeline green end-to-end.

Test coverage breakdown:
1. Primary-key hit (daily + 24h) — no warning
2. Legacy fallback (daily + 24h) with default `strategy_id` — warns
3. Double-write: primary wins (daily + 24h) — no warning
4. Both keys empty (daily + 24h) — returns `None`
5. Non-default `strategy_id` isolation (primary takes precedence over default + legacy)
6. Non-default `strategy_id` fallback — warns, records correct strategy_id
7. Malformed primary — `RuntimeError` with resolved_key + strategy_id
8. Malformed legacy — error cites LEGACY key (not primary)
9. Boolean payload explicitly rejected
10. Hypothesis property test — Decimal round-trip for any non-negative value
11. Static key-builder + module-constant contracts

## Hard stops respected

- [x] `services/command_center/pnl_tracker.py` — **untouched**
- [x] `core/models/` — untouched (Terminal 2)
- [x] `db/` — untouched (Terminal 5)
- [x] `services/fusion_engine/`, `feedback_loop/`, `execution/` — untouched (Terminal 4)
- [x] `services/risk_manager/portfolio_tracker.py` — untouched
- [x] `services/risk_manager/context_loader.py` — untouched (wiring deferred to Phase B)
- [x] No consumer wiring — Phase B scope

## Wiring (deferred)

Not wired into any consumer. `ContextLoader.load` still reads `pnl:daily` directly at line 74; swapping it to this tracker is a Phase B follow-up tracked alongside the S09 writer introduction.

Closes #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)