### PR TITLE
docs(adr): ADR-0013 capital allocation trajectory

### DIFF
--- a/config/strategies.example.yaml
+++ b/config/strategies.example.yaml
@@ -1,0 +1,284 @@
+# =========================================================================
+# config/strategies.example.yaml  --  TEMPLATE (NOT wired into any loader)
+# -------------------------------------------------------------------------
+# Canonical example of the Tier 1 static-allocation schema defined in
+# ADR-0013 (Capital Allocation Trajectory).
+#
+# Real deployment copies this file to config/strategies.yaml and populates
+# it with the strategies that have passed Gate 2. The loader (planned at
+# core/config/strategies.py, Phase B) reads the live file, validates the
+# schema, and exposes per-strategy capital envelopes to each strategy's
+# sub-book (ADR-0012).
+#
+# All comments explain field purpose and valid ranges. Every weight/price
+# value uses YAML numerics that map to Python Decimal in the loader --
+# never float -- per CLAUDE.md Section 2.
+#
+# Reference: docs/adr/ADR-0013-capital-allocation-trajectory.md
+# Companion: docs/research/CAPITAL_ALLOCATION_TRAJECTORY.md
+# =========================================================================
+
+
+# -------------------------------------------------------------------------
+# 1. Top-level allocator selection
+# -------------------------------------------------------------------------
+
+allocation_tier: static
+  # Which allocation algorithm the allocator service runs.
+  # Valid: "static" | "risk_parity" | "hrp"
+  # -- static      (Tier 1): weights below are authoritative; no runtime compute.
+  # -- risk_parity (Tier 2): allocator computes 1/sigma weights weekly.
+  # -- hrp         (Tier 3): allocator computes HRP weights monthly.
+  # See ADR-0013 sections 3.1 / 3.2 / 3.3.
+
+
+cash_buffer: 0.20
+  # Fraction of portfolio capital held as USD, not allocated to any strategy.
+  # Valid: 0.0 <= cash_buffer <= 1.0
+  # Recommended range: 0.10 -- 0.30.
+  # Rationale: margin-call protection + emergency liquidity for hard-CB halt
+  # redemption. A cash_buffer of 0.20 means all enabled strategies together
+  # receive at most 80% of portfolio capital.
+
+
+portfolio_capital_usd: 250000.00
+  # Total USD capital under APEX management. Reference value only -- the
+  # allocator uses this to translate `weight` into `capital_usd` when
+  # emitting envelopes to the per-strategy sub-books (ADR-0012).
+  # The operator should keep this in sync with the actual broker balance
+  # via a daily reconciliation (manual or automated). If it drifts, the
+  # per-strategy `capital_usd` becomes stale but is still harmless because
+  # sub-books enforce their own position caps.
+
+
+# -------------------------------------------------------------------------
+# 2. Per-strategy entries
+# -------------------------------------------------------------------------
+# Each entry defines one strategy's participation in the allocation.
+# Order does not matter. Every `id` must be unique across both `strategies`
+# and `blacklist`.
+#
+# Schema contract (enforced by Pydantic loader at startup):
+#   - sum(strategies[enabled].weight) + cash_buffer <= 1.0  (strict)
+#   - 0.0 <= weight <= 1.0
+#   - 0.0 <= min_weight <= weight <= max_weight <= 1.0
+#   - burn_in_days >= 0
+#   - capital_usd > 0 (when enabled=true)
+# -------------------------------------------------------------------------
+
+strategies:
+
+  # -----------------------------------------------------------------------
+  # Strategy #1 -- established, passed Gate 4, full allocation.
+  # -----------------------------------------------------------------------
+  - id: legacy_confluence
+      # Canonical strategy_id. Matches `strategy_id="default"` once the
+      # pre-multi-strat signal engine is wrapped as LegacyConfluenceStrategy
+      # in Phase B per Roadmap sec 3.2. Keep this id stable across PRs --
+      # renaming breaks `apex_strategy_metrics` history and Redis keys.
+
+    enabled: true
+      # Whether the strategy participates in allocation.
+      # Valid: true | false
+      # Setting enabled=false excludes the strategy from the rebalance;
+      # its share redistributes pro-rata to other enabled strategies.
+      # Use this for operational pauses (e.g., broker maintenance). For
+      # permanent decommissioning, use the `blacklist:` list instead.
+
+    weight: 0.50
+      # Fraction of portfolio capital allocated to this strategy.
+      # Valid: 0.0 -- 1.0 (further bounded by min_weight/max_weight).
+      # At Tier 1, this is the authoritative weight.
+      # At Tier 2/3, this is the seed weight for the first rebalance and
+      # the fallback if the compute job fails.
+
+    min_weight: 0.30
+      # Lower bound enforced during Tier 2/3 clip-then-renormalise.
+      # Valid: 0.0 -- weight.
+      # If Tier 2 would compute a weight below this, it is clipped up.
+
+    max_weight: 0.60
+      # Upper bound enforced during Tier 2/3 clip-then-renormalise.
+      # Valid: weight -- 1.0 (typically <= 0.60 per Charter sec 6.1.2).
+      # Guards against runaway concentration when a strategy's vol drops.
+
+    burn_in_days: 0
+      # Days after enabling during which the strategy is excluded from
+      # adaptive compute (its weight stays pinned at min_weight).
+      # Valid: 0 -- 90 typically.
+      # legacy_confluence has no burn-in: it has multi-year history.
+      # A newly-Gate-2'd strategy uses burn_in_days: 30 (see #2 below).
+
+    capital_usd: 125000.00
+      # Absolute USD envelope for the strategy's sub-book (ADR-0012).
+      # Computed field: weight * portfolio_capital_usd = 0.50 * 250000 = 125000.
+      # The loader may re-derive this; specifying it here makes the YAML
+      # self-documenting for grep/audit.
+
+  # -----------------------------------------------------------------------
+  # Strategy #2 -- new, just passed Gate 2, in 30-day burn-in.
+  # -----------------------------------------------------------------------
+  - id: har_rv_momentum
+      # HAR-RV (Heterogeneous Autoregressive model of Realised Volatility,
+      # Corsi 2009) applied to crypto cross-sectional momentum. Fresh
+      # Gate 2 PR; no live history.
+
+    enabled: true
+    weight: 0.20
+    min_weight: 0.10
+    max_weight: 0.40
+      # Lower max_weight than legacy_confluence while building a track
+      # record. Can be raised to 0.40--0.50 after 6 months of Gate 4
+      # live-micro via a CIO-ratified config edit.
+
+    burn_in_days: 30
+      # First 30 days on paper: excluded from adaptive compute. Weight
+      # stays pinned at min_weight (0.10) while `apex_strategy_metrics`
+      # fills out. After day 30, adaptive compute starts using partial
+      # history; at day 60, full 60-day sigma window is available and
+      # the strategy participates normally.
+
+    capital_usd: 50000.00
+      # 0.20 * 250000 = 50000
+
+  # -----------------------------------------------------------------------
+  # Strategy #3 -- mature, targeting volatility arbitrage.
+  # -----------------------------------------------------------------------
+  - id: vol_arb
+      # Systematic variance-swap vs straddle dispersion across majors
+      # (BTC, ETH). Higher realised Sharpe but also higher volatility.
+
+    enabled: true
+    weight: 0.10
+    min_weight: 0.05
+    max_weight: 0.25
+      # Tighter cap than legacy_confluence because vol_arb has higher
+      # realised vol; Risk Parity would otherwise push its weight down
+      # naturally, but the floor/ceiling bounds keep Tier 1 consistent.
+
+    burn_in_days: 0
+      # Established strategy; ported from a prior live book.
+
+    capital_usd: 25000.00
+      # 0.10 * 250000 = 25000
+
+
+# -------------------------------------------------------------------------
+# 3. Rebalance policy
+# -------------------------------------------------------------------------
+
+rebalance:
+
+  policy: static
+    # How often the allocator recomputes and writes envelopes.
+    # Valid: "static" | "weekly" | "monthly"
+    # -- static  -> Tier 1: change requires config edit + service restart.
+    # -- weekly  -> Tier 2: compute runs at weekly_day / weekly_time_utc.
+    # -- monthly -> Tier 3: compute runs at monthly_day 00:00 UTC.
+    # Must be consistent with allocation_tier (the loader enforces).
+
+  weekly_day: sun
+    # Day of week for weekly rebalance (Tier 2).
+    # Valid: mon | tue | wed | thu | fri | sat | sun.
+    # Charter sec 6.1.2 + ADR-0008 sec D2 specify Sunday before Asia open.
+
+  weekly_time_utc: "23:00"
+    # Time of day (HH:MM, UTC) for weekly rebalance.
+    # Aligned to ADR-0008 sec D2 (Sunday 23:00 UTC).
+
+  monthly_day: 1
+    # Day of month for monthly rebalance (Tier 3).
+    # Valid: 1 -- 28 (avoid 29/30/31 to side-step month-length edge cases).
+    # Default: 1 (first calendar day). The allocator falls forward to the
+    # first trading day of the month if the 1st is a weekend/holiday.
+
+  trigger_threshold_pct: 0.5
+    # Minimum per-strategy weight delta (in percentage points of portfolio
+    # value) before the allocator emits OrderCandidates to rebalance.
+    # Valid: > 0.0, typically 0.1 -- 2.0.
+    # Example: with trigger_threshold_pct=0.5 and portfolio_capital=250k,
+    # a weight change of less than 1250 USD per strategy is ignored.
+    # Rationale: below-threshold deltas are indistinguishable from sigma
+    # estimation noise; acting on them churns the book for no alpha.
+
+  transition_cost_cap_pct: 0.20
+    # If the summed transition cost for a rebalance exceeds this fraction
+    # of the expected incremental Sharpe contribution, the rebalance is
+    # deferred to the next cycle. See ADR-0013 sec 5.3 + Almgren-Chriss 2000.
+    # Default: 0.20 (20% of incremental Sharpe).
+
+
+# -------------------------------------------------------------------------
+# 4. Tier 2/3 compute parameters (ignored when allocation_tier=static)
+# -------------------------------------------------------------------------
+
+compute:
+
+  sigma_window_days: 60
+    # Rolling window (trading days) for sigma estimation in Tier 2.
+    # Valid: 20 -- 252. Charter sec 6.1.2 default: 60.
+    # Shorter windows (e.g. 20) are more responsive but noisier;
+    # longer windows (e.g. 252) are stable but slow to adapt.
+
+  correlation_window_days: 60
+    # Rolling window for correlation matrix estimation in Tier 3.
+    # Valid: 20 -- 252. Default: 60, escalating to 120 when history allows.
+    # Ignored when allocation_tier != hrp.
+
+  linkage: ward
+    # Hierarchical clustering linkage method for HRP (Tier 3).
+    # Valid: "ward" | "single" | "complete" | "average"
+    # Default: ward (more stable on small samples; scipy default).
+    # Lopez de Prado 2016 uses "single"; a follow-up ADR may revisit.
+
+  sigma_floor: 0.000001
+    # Numerical guard against division-by-zero when sigma is unobservable
+    # or estimated as zero (e.g., a strategy that made zero trades in the
+    # window). Very small but non-zero.
+
+  shadow_mode: false
+    # If true, the allocator computes the target tier's weights, writes
+    # them to `portfolio:allocation:shadow:{strategy_id}` (separate Redis
+    # namespace), and publishes `portfolio.allocation.shadow` on ZMQ, but
+    # does NOT act on them. The previous tier continues to drive live
+    # allocation. Used during the 4-week shadow window before a tier
+    # cutover per ADR-0013 sec 7.
+
+
+# -------------------------------------------------------------------------
+# 5. Blacklist (strategies barred from allocation)
+# -------------------------------------------------------------------------
+# Strategies that failed a Gate criterion (CPCV PBO > 50%, PSR < 0.5,
+# 3 consecutive DD breaches, 9 months of negative Sharpe, etc.) are
+# moved here with weight forced to 0. Their share is redistributed
+# pro-rata to active strategies.
+#
+# Reactivation requires a fresh Gate 2 PR per Playbook sec 9. Entries
+# here are permanent in git history -- do not delete rows, mark them
+# with `reactivated_at:` when they are re-admitted (future schema
+# extension; for now just move back to `strategies:` with fresh history).
+# -------------------------------------------------------------------------
+
+blacklist:
+
+  - id: experimental_mean_rev
+    reason: "CPCV PBO = 62% on 2026-Q1 walk-forward; benched pending re-derivation"
+      # Free-form text describing why the strategy was benched. Should
+      # reference the failing metric (CPCV PBO, PSR, DSR, DD, etc.) and
+      # the evaluation window. Searchable in `git log -p`.
+
+    benched_since: "2026-04-01"
+      # ISO-8601 date (YYYY-MM-DD) when the strategy entered the blacklist.
+      # Useful for auditing how long a strategy has been benched.
+
+
+# -------------------------------------------------------------------------
+# End of file.
+# -------------------------------------------------------------------------
+# Validation command (planned, Phase B):
+#   $ apex-strategy-yaml-validate config/strategies.yaml
+#
+# Which runs the Pydantic loader against the schema and reports any
+# violations with line numbers. The same validator runs as a CI gate
+# on every PR that touches config/strategies.yaml.
+# -------------------------------------------------------------------------

--- a/docs/adr/ADR-0013-capital-allocation-trajectory.md
+++ b/docs/adr/ADR-0013-capital-allocation-trajectory.md
@@ -1,0 +1,471 @@
+# ADR-0013 — Capital Allocation Trajectory (Static YAML → Risk Parity → HRP)
+
+> *This ADR specifies the **trajectory of allocation algorithms** the APEX platform will walk as the strategy count grows from 1 to 6+, tied mechanically to the Phase Gates of [`PHASE_5_v3_MULTI_STRAT_ALIGNED_ROADMAP.md`](../phases/PHASE_5_v3_MULTI_STRAT_ALIGNED_ROADMAP.md). It does not replace [ADR-0008 (Capital Allocator Topology)](ADR-0008-capital-allocator-topology.md); it refines its algorithmic content by introducing a pre-allocator Tier 1 (static YAML) and a post-Phase-2 Tier 3 (Hierarchical Risk Parity).*
+
+| Field | Value |
+|---|---|
+| Status | Proposed |
+| Date | 2026-04-20 |
+| Decider | Clement Barbier (CIO) |
+| Supersedes | None |
+| Superseded by | None |
+| Related | [ADR-0008](ADR-0008-capital-allocator-topology.md) (allocator topology); [ADR-0007](ADR-0007-strategy-as-microservice.md) (strategy microservice); ADR-0012 (per-strategy sub-books, authored in parallel); [ADR-0014](ADR-0014-timescaledb-schema-v2.md) (`apex_strategy_metrics` as input data source); Charter §5.5, §6 |
+
+---
+
+## 1. Status
+
+Proposed.
+
+This ADR is authored during Phase A (the Pydantic `strategy_id` lift) to settle the algorithmic progression of the allocator **before** any allocator code is written in Phase C. The decision is non-urgent — no live allocation code depends on it — but authoring it now crystallises the interface contract the allocator service must respect across all three tiers.
+
+---
+
+## 2. Context
+
+### 2.1 Why this ADR exists separately from ADR-0008
+
+[ADR-0008](ADR-0008-capital-allocator-topology.md) ratifies the **topology** of the capital allocator: a dedicated microservice at `services/portfolio/strategy_allocator/`, its position in the 7-step VETO chain, its Pydantic contract, and its two-phase algorithmic sketch (Phase 1 Risk Parity, Phase 2 Sharpe overlay). That ADR was authored alongside Document 3 (Roadmap v3) and is necessarily coarse on algorithmic content — it ratifies the *shape*, not the *trajectory*.
+
+This ADR fills in the algorithmic trajectory with three refinements ADR-0008 did not make:
+
+1. **Tier 1 (static YAML)** is introduced as a pre-allocator state for Phase B Gate 2, where the allocator microservice does not yet exist in code. Without Tier 1, there is a chicken-and-egg problem: Strategy #1 needs a capital envelope at Gate 2 (paper) but the allocator service lands in Phase C (after Gate 2). Tier 1 resolves this by parking the weights in a YAML file that each strategy's own config loader reads at startup.
+2. **Tier 2 (Risk Parity)** is the first live activation of the ADR-0008 allocator microservice, at Gate 3 (live-micro). It is the exact Phase 1 algorithm specified in ADR-0008 §D2, repeated here for authoritative reference with cross-tier context.
+3. **Tier 3 (HRP)** is introduced as the Phase C / post-Phase-C evolution once 5+ strategies exist, *in addition to* the Sharpe overlay (ADR-0008 Phase 2). HRP (Lopez de Prado 2016) is orthogonal to the Sharpe overlay: HRP replaces the base allocation formula; the Sharpe overlay tilts whatever the base produces. The two can stack (HRP base + Sharpe tilt), or ship independently.
+
+### 2.2 Constraints that shape the trajectory
+
+- **Phase B starts with 1–2 strategies**; adaptive allocation has no signal to work with (n=1 means 100% allocation trivially; n=2 with two months of live returns produces a volatility estimate whose 95% CI is ±40% of the point estimate per Lo 2002).
+- **Phase C grows to 5+ strategies** as Strategy #2, #3, #4 come online per Roadmap §7.2 — at this scale, cross-strategy correlation matrices become non-trivial and HRP's clustering starts to matter.
+- **Static allocation is auditable and deterministic**: a human can reason about "Strategy A has 50%, Strategy B has 30%, cash buffer is 20%" without running code. Adaptive allocation is performance-aware but introduces **instability risk** — a bad volatility estimate or a correlation matrix near-singularity can produce weight oscillations that churn the book for no alpha.
+- **The apex_strategy_metrics table** (ADR-0014 §2.1) is the authoritative source of per-strategy returns, vol, and Sharpe. Tier 2 and Tier 3 **depend** on this table being populated with at least 60 days of daily rows per strategy before their allocation decisions are trustworthy.
+- **Phase Gates are trigger-based, not calendar-based** (Roadmap §1.2). The trajectory below is phrased in Gate terms, not month terms, so a strategy that takes longer to pass Gate 2 simply delays Tier 2 activation — it does not force a premature cutover.
+
+### 2.3 What this ADR is NOT
+
+- It is **not** a re-litigation of ADR-0008's topology decision. The allocator remains a dedicated microservice.
+- It is **not** a commitment to specific live rebalance timestamps. The exact cadence per tier is specified below but may be refined in a follow-up ADR based on live evidence.
+- It is **not** a per-strategy tuning document — per-strategy caps and burn-in values belong in `config/strategies/<strategy_id>.yaml` (per-strategy configs) and are discussed only illustratively here.
+- It is **not** production code. No Python lands in this ADR or its companion.
+
+---
+
+## 3. Decision — 3-tier progression tied to Phase Gates
+
+The APEX capital allocator walks three tiers of algorithmic sophistication, each tied to a specific Phase Gate in the Roadmap. A tier change requires this ADR to be amended (or a new ADR to supersede the relevant tier). Feature flag: `APEX_ALLOCATION_TIER=static|risk_parity|hrp`.
+
+### 3.1 Tier 1 — Static YAML (Phase B, Gate 2, paper trading, 1–2 strategies)
+
+**When.** Phase B has opened (Roadmap §3); Strategy #1 (LegacyConfluenceStrategy) is the first strategy to reach Gate 2 and enter paper trading with explicit `strategy_id="default"`. Optionally Strategy #2 begins Gate 1/Gate 2 during this window. The dedicated allocator microservice **does not yet exist in code** — it is scheduled for Phase C (Roadmap §4.2).
+
+**How.** A single YAML file at `config/strategies.yaml` declares per-strategy weights as human-authored Decimal values. Each strategy microservice loads this file at startup and reads its own slice (the `capital_usd` field, derived from `weight × portfolio_capital_usd`, is consumed by the strategy's sub-book per ADR-0012). Reloaded on service restart only — no hot reload, no Redis pub/sub on config changes.
+
+**Why.**
+
+- **Deterministic.** The weights at any moment are exactly whatever is checked into `config/strategies.yaml` in the current HEAD commit. Git blame is the audit trail.
+- **No math dependencies at runtime.** Tier 1 does not depend on `apex_strategy_metrics` being populated, does not depend on the covariance matrix being non-singular, does not depend on any rolling window of live returns. It ships as soon as a YAML loader exists.
+- **Forces discipline before automation.** The operator (CIO) has to consciously think about each weight. This avoids the failure mode where an adaptive allocator silently allocates 80% to a strategy that happened to have low vol for the last 60 days — a failure mode documented in Clarke, de Silva & Thorley (2011) as "vol-minimisation producing concentration in recently-quiet assets."
+- **Rationale aligns with institutional practice.** Millennium's new pods start at a fixed capital envelope set by the PM committee; Risk Parity does not apply until the pod has a track record. Tier 1 is the APEX-scale equivalent.
+
+**Exit criteria.** Tier 1 ends when (i) the allocator microservice is deployed in Phase C (Roadmap §4.2), (ii) ≥ 2 strategies have accumulated ≥ 60 days of live paper trading returns in `apex_strategy_metrics`, (iii) a shadow-mode evaluation (see §7) confirms Tier 2 would produce stable weights under the observed volatility regime.
+
+### 3.2 Tier 2 — Risk Parity (Phase C, Gate 3, live-micro, 3–5 strategies)
+
+**When.** Phase C has delivered `services/portfolio/strategy_allocator/` (Roadmap §4.2); Strategy #1 has reached Gate 3 (live-micro) with a 60-day paper history; at least one other strategy exists with ≥ 60 days of history. The `apex_strategy_metrics` table has a non-empty daily time series for each active strategy.
+
+**How.** The allocator microservice computes **inverse-volatility** weights per Maillard, Roncalli & Teiletche (2010, "The Properties of Equally Weighted Risk Contribution Portfolios," *Journal of Portfolio Management* 36(4), 60–70) under a diagonal covariance assumption. Widely published as Bridgewater All Weather's foundational layer (Qian 2005, "Risk Parity Portfolios: Efficient Portfolios Through True Diversification," PanAgora white paper).
+
+**Formula.**
+
+```
+σ_i         = stddev( returns_i, rolling 60 days from apex_strategy_metrics )
+w_raw_i     = 1 / σ_i
+w_norm_i    = w_raw_i / Σ_j w_raw_j
+w_clipped_i = clip( w_norm_i, min_weight=0.05, max_weight=0.40 )
+w_final_i   = w_clipped_i × (1 - cash_buffer) / Σ_j w_clipped_j
+```
+
+where `σ_i` is the 60-day rolling standard deviation of daily returns for strategy `i` consumed from the `apex_strategy_metrics` table (ADR-0014 §2.1, row #9).
+
+**Parameters.**
+
+| Parameter | Value | Justification |
+|---|---|---|
+| σ window | 60 days rolling | Noise ~1/√60 ≈ 13% on σ estimate; tight enough to adapt within a quarter, loose enough to not churn on one bad week. Matches ADR-0008 §D2. |
+| Rebalance cadence | Weekly, **Sunday 23:00 UTC** | Before Asia open Monday; AQR Risk Parity published cadence. Matches ADR-0008 §D2. |
+| `min_weight` floor | 5% | Prevents starvation; guarantees drift-monitor (S09) has enough trade flow per strategy for attribution. Matches ADR-0008 §D2 and Charter §6.1.2. |
+| `max_weight` ceiling | 40% | Prevents single-strategy dominance. Matches ADR-0008 §D2. |
+| `cash_buffer` | 20% (configurable) | Held as idle USD; protects against margin surprise; emergency buffer for hard-CB redemption. |
+
+**Why.**
+
+- **Diagonal inverse-volatility is the canonical simplification** under the Risk Parity family (Maillard, Roncalli & Teiletche 2010 §3.1). It assumes cross-strategy correlations are either zero or roughly uniform — a plausible first approximation when strategies target orthogonal edges per the Charter's §4 boot-strategy selection.
+- **Qian (2005)** established Risk Parity as Bridgewater's production sizing rule. It is battle-tested over 20+ years of All Weather performance.
+- **Clear upgrade path.** If live evidence at Tier 2 shows cross-strategy correlations are persistently non-zero (e.g., a pairwise correlation matrix with average off-diagonal > 0.3), Tier 3 (HRP) naturally handles correlated clusters — see §3.3.
+
+**Rebalance mechanics.** Detailed in §5 below.
+
+**Exit criteria.** Tier 2 ends when (i) ≥ 5 strategies are active with ≥ 6 months of daily returns each in `apex_strategy_metrics`, (ii) the observed cross-strategy correlation matrix has at least one pair with |ρ| > 0.3 persistently for ≥ 8 weeks, (iii) a shadow-mode evaluation (§7) shows HRP's allocation would differ from Tier 2's by > 5% on at least 2 strategies, justifying the complexity upgrade.
+
+### 3.3 Tier 3 — Hierarchical Risk Parity (Phase C+, 5+ strategies, diversified book)
+
+**When.** Phase C is complete; ≥ 5 strategies are active in live-full; cross-strategy correlations are non-negligible (per Tier 2 exit criteria). Phase D or later.
+
+**How.** The allocator implements **Hierarchical Risk Parity (HRP)** per Lopez de Prado (2016, "Building Diversified Portfolios That Outperform Out of Sample," *Journal of Portfolio Management* 42(4), 59–69). HRP is a multi-step algorithm that combines hierarchical clustering with recursive bisection:
+
+1. **Compute correlation matrix** ρ from strategy daily returns in `apex_strategy_metrics` over a rolling window (60 days matches Tier 2; a longer window, e.g. 120 days, may be used once history allows).
+2. **Compute distance matrix** `d_ij = sqrt( 0.5 × (1 - ρ_ij) )` (Lopez de Prado 2016 eq. 5). This converts correlations into a metric distance suitable for hierarchical clustering.
+3. **Hierarchical clustering** via Ward linkage on `d`, producing a dendrogram of strategy groupings.
+4. **Quasi-diagonalisation** reorders the correlation matrix so that correlated strategies sit adjacent (Lopez de Prado 2016 §2.3). This concentrates large correlations near the diagonal and makes the recursive bisection step meaningful.
+5. **Recursive bisection** splits the reordered universe into two halves at each level of the dendrogram, allocating weight to each half inversely proportional to the cluster's inverse-variance portfolio variance. Within each final cluster, the residual weight is distributed by inverse-variance.
+
+**Full algorithm.** Refer to Lopez de Prado (2016) §2 for the complete mathematical specification. This ADR does not reproduce the full pseudocode — the paper is the authoritative reference and is open-access via SSRN. The APEX implementation will follow the paper verbatim in `risk_parity_hrp.py`, with unit tests that reproduce the paper's Table 1 worked example.
+
+**Parameters.**
+
+| Parameter | Value | Justification |
+|---|---|---|
+| ρ window | 60 days rolling (initially), escalating to 120 days once history allows | Matches Tier 2 σ window. Lopez de Prado 2016 uses 260-day Ledoit-Wolf shrinkage in the paper; APEX's smaller history forces a shorter window initially. |
+| Linkage | Ward (default) | Lopez de Prado 2016 §2.2 uses single linkage. Ward is more stable on small samples and is the scipy default; a follow-up ADR can revisit if live evidence favors single linkage. |
+| Rebalance cadence | **Monthly**, first trading day UTC | HRP is more expensive computationally than Risk Parity and less susceptible to high-frequency noise; monthly cadence matches institutional HRP deployments (Lopez de Prado 2020 textbook). |
+| `min_weight` / `max_weight` / `cash_buffer` | Unchanged from Tier 2 (5% / 40% / 20%) | Caps apply **after** the HRP allocation, with overflow redistribution. |
+
+**Why.**
+
+- **Lopez de Prado (2016)** demonstrates in out-of-sample Monte Carlo that HRP outperforms Markowitz MVO and inverse-variance (i.e., Tier 2 Risk Parity) on both Sharpe and max drawdown for portfolios of 10+ assets with non-trivial correlation structure. The paper is the highest-cited allocation paper of the last decade.
+- **Handles correlated strategies gracefully.** If Strategies #3, #4, #5 are all variants of crypto momentum (high pairwise correlation), Tier 2 over-allocates to the cluster because each strategy "looks" diversified in isolation. HRP identifies the cluster and allocates within-cluster first, avoiding concentration.
+- **Matrix singularity robustness.** HRP does **not** invert the covariance matrix (unlike Markowitz). It works on distances. This makes it robust to near-singular correlation matrices that would destabilise a Markowitz solver.
+
+**Rebalance mechanics.** Identical to Tier 2 (§5) but monthly instead of weekly.
+
+**Exit criteria.** Tier 3 is the terminal tier contemplated in this ADR. Further evolution (Black-Litterman, regime-conditional HRP, Kelly meta-allocation) is out of scope and parked for a future ADR (see §10).
+
+### 3.4 Sharpe overlay (orthogonal to the tier progression)
+
+ADR-0008 §D3 specifies a **Phase 2 Sharpe overlay** that tilts the base allocation by ±20% based on rolling 6-month Sharpe spread. This overlay is **orthogonal** to the tier progression:
+
+- It can sit on top of Tier 2 (Risk Parity + Sharpe tilt) — this is exactly ADR-0008's Phase 2 vision.
+- It can sit on top of Tier 3 (HRP + Sharpe tilt) — a natural extension once HRP is stable.
+- It cannot sit on top of Tier 1 (static YAML) — Tier 1 is deliberately manual; performance tilts at Tier 1 defeat the purpose.
+
+Activation of the Sharpe overlay is governed by ADR-0008 §D3 (6 months of live data on 3+ strategies + bootstrap CI stability). This ADR does not re-specify the overlay; it simply notes that Tier 2 and Tier 3 are compatible substrates for it.
+
+---
+
+## 4. Mathematical specifications
+
+### 4.1 Tier 1 — trivial
+
+```
+w_i = static_weight_i  (read from config/strategies.yaml)
+Σ_i w_i + cash_buffer ≤ 1.0  (enforced by schema validator at load time)
+```
+
+No runtime computation. The YAML file is the specification.
+
+### 4.2 Tier 2 — Risk Parity (inverse volatility, diagonal covariance)
+
+Given daily return series `r_i[t]` for strategy `i` over the last 60 trading days:
+
+```
+μ_i         = mean(r_i[t-59:t])
+σ_i         = sqrt( Σ_t (r_i[t] - μ_i)² / 59 )   # sample stdev, T-1 denominator
+w_raw_i     = 1 / max(σ_i, σ_floor)               # σ_floor = 1e-6 guards /0
+w_norm_i    = w_raw_i / Σ_j w_raw_j
+w_clipped_i = clip( w_norm_i, min_weight, max_weight )
+w_final_i   = w_clipped_i × (1 - cash_buffer) / Σ_j w_clipped_j
+```
+
+**Notes.**
+
+- Annualisation is **not required** for the formula — `1/σ_daily` and `1/σ_annual` produce identical normalised weights because the annualisation constant (`sqrt(252)`) cancels in the ratio. `apex_strategy_metrics.sigma_annualized` is persisted for observability; the allocator can use either column.
+- The clip-then-renormalise step is standard in Risk Parity implementations (AQR 2012 white paper §4). Without renormalisation after clipping, `Σ w_final < 1 - cash_buffer`, leaving unallocated capital.
+- If a strategy's σ is unobservable (e.g., < 20 days of history), the strategy is **excluded** from the current rebalance and its share redistributes pro-rata. See §9.
+
+**Worked example.** Three strategies, σ = (10%, 15%, 20%), cash_buffer = 20%:
+
+```
+w_raw     = (10.00, 6.67, 5.00)
+w_norm    = (0.461, 0.308, 0.231)
+w_clipped = (0.400, 0.308, 0.231)   # clipped at 40%
+Σ w_clip  = 0.939
+w_final   = (0.341, 0.262, 0.197)   # sums to 0.80 = 1 - cash_buffer
+```
+
+(Checked in the companion research doc §1 with the full 2-year simulation.)
+
+### 4.3 Tier 3 — Hierarchical Risk Parity
+
+The HRP algorithm is specified exhaustively in Lopez de Prado (2016) §2 with full pseudocode. Summary:
+
+```
+# Step 1: correlation and distance matrices
+ρ    = corr(R)                                     # R = returns matrix, shape (T, N)
+D    = sqrt(0.5 × (1 - ρ))                         # distance matrix, eq. 5
+
+# Step 2: hierarchical clustering
+link = scipy.cluster.hierarchy.linkage(D, method='ward')
+
+# Step 3: quasi-diagonal order
+order = get_quasi_diag(link)                       # recursive leaf extraction
+D'    = D[order, :][:, order]
+
+# Step 4: recursive bisection
+w = recursive_bisection(cov=cov(R)[order][:,order], indices=order)
+#   at each split point k:
+#     left  = indices[:k]
+#     right = indices[k:]
+#     V_L   = inverse_variance_portfolio_variance(cov[left, left])
+#     V_R   = inverse_variance_portfolio_variance(cov[right, right])
+#     α     = 1 - V_L / (V_L + V_R)
+#     w[left]  *= α
+#     w[right] *= (1 - α)
+
+# Step 5: clip + renormalise (same as Tier 2)
+w = clip(w, min_weight, max_weight)
+w = w × (1 - cash_buffer) / sum(w)
+```
+
+Lopez de Prado's companion code is published at Quantresearch.org (referenced from his SSRN papers). The APEX implementation will port it to asyncio and wrap it in the `BaseAllocator` interface, not reinvent it.
+
+---
+
+## 5. Rebalance mechanics
+
+### 5.1 Tier 1 — no rebalance at runtime
+
+Changes to Tier 1 weights require a commit to `config/strategies.yaml` and a service restart for every strategy whose weight changed. This is deliberate — Tier 1 is manual by design.
+
+### 5.2 Tier 2 / Tier 3 — rebalance job
+
+At the configured cadence (Tier 2: weekly Sunday 23:00 UTC; Tier 3: monthly first trading day), the allocator service:
+
+1. Reads returns from `apex_strategy_metrics` for all active strategies.
+2. Computes target weights per §4.2 (Tier 2) or §4.3 (Tier 3).
+3. Applies the Sharpe overlay if ADR-0008 §D3 conditions hold.
+4. Computes the **delta** between target and currently deployed capital per `portfolio:allocation:{strategy_id}` (Redis).
+5. For each strategy where `|delta_i| > trigger_threshold_pct × portfolio_capital`:
+   - Writes the new target to `portfolio:allocation:{strategy_id}`.
+   - Publishes `portfolio.allocation.updated` on ZMQ.
+   - The per-strategy sub-book (ADR-0012) subsequently emits `OrderCandidate` messages to bring positions to the new target.
+6. For each strategy where `|delta_i| ≤ trigger_threshold_pct × portfolio_capital`, the rebalance is **skipped** for that strategy — Redis and ZMQ state is unchanged. This avoids trading noise.
+7. Persists the full `AllocatorResult` (ADR-0008 §D8) to TimescaleDB `apex_allocation_history` (a new table introduced in a follow-up ADR; see §8).
+
+### 5.3 Transition cost estimation
+
+Before emitting rebalance orders, the allocator estimates the transition cost:
+
+```
+transition_cost_i = (half_spread_usd × |delta_notional_i|) + market_impact_i
+market_impact_i   = k × |delta_notional_i|^1.5 / ADV_symbol   (Almgren-Chriss 2000)
+```
+
+where `k` is a per-asset constant calibrated from S06 execution telemetry. If the summed transition cost exceeds **20% of the expected incremental Sharpe contribution** from the rebalance, the rebalance is deferred to the next cycle with a Telemetry alert. This prevents the allocator from trading its own slippage.
+
+### 5.4 Minimum delta threshold
+
+`trigger_threshold_pct = 0.5%` of portfolio value per strategy. Below this threshold, the rebalance is skipped for that strategy — the weight in Redis stays at the previous value, and no orders are emitted. Rationale: small deltas are indistinguishable from σ estimation noise; acting on them churns the book for no expected alpha.
+
+---
+
+## 6. Configuration schema
+
+### 6.1 Tier 1 YAML schema (authoritative)
+
+```yaml
+# config/strategies.yaml — Tier 1 static allocation
+allocation_tier: static          # static | risk_parity | hrp
+cash_buffer: 0.20                # 20% held as USD, not allocated
+portfolio_capital_usd: 250000.00 # total capital under APEX management (reference only)
+
+strategies:
+  - id: legacy_confluence
+    enabled: true
+    weight: 0.50
+    min_weight: 0.30             # lower bound when Tier >= 2 activates
+    max_weight: 0.60             # upper bound when Tier >= 2 activates
+    burn_in_days: 0              # established strategy; no burn-in
+    capital_usd: 125000.00       # weight x portfolio_capital_usd (computed)
+
+  - id: har_rv_momentum
+    enabled: true
+    weight: 0.30
+    min_weight: 0.10
+    max_weight: 0.40
+    burn_in_days: 30             # new strategy; 30 days observation before adaptive
+
+rebalance:
+  policy: static                 # static | weekly | monthly
+  weekly_day: sun
+  weekly_time_utc: "23:00"       # aligned to ADR-0008 §D2
+  monthly_day: 1
+  trigger_threshold_pct: 0.5     # min weight change (%) before rebalance actually trades
+
+blacklist:
+  # strategies that failed a gate (CPCV PBO > 50%, PSR < 0.5, etc.) — weight forced to 0
+  - id: experimental_mean_rev
+    reason: "CPCV PBO = 62% on 2026-Q1 walk-forward; benched pending re-derivation"
+    benched_since: "2026-04-01"
+```
+
+**Schema validation rules** (enforced by Pydantic loader at Tier 1 service startup):
+
+- `sum(strategies[enabled].weight) + cash_buffer ≤ 1.0` (strict).
+- `0 ≤ strategies[*].weight ≤ 1.0` per entry.
+- `0 ≤ strategies[*].min_weight ≤ strategies[*].weight ≤ strategies[*].max_weight ≤ 1.0`.
+- `cash_buffer ≥ 0.0`.
+- `rebalance.trigger_threshold_pct > 0.0`.
+- Every `strategies[*].id` is unique; blacklisted ids cannot also appear in the `strategies` list.
+
+### 6.2 Tier 2 / Tier 3 additional fields
+
+Tier 2 and Tier 3 use the same schema plus:
+
+```yaml
+allocation_tier: risk_parity    # or hrp
+
+# Tier 2 / Tier 3 compute weights at runtime; the `weight` field above
+# becomes the **seed** weight for the first rebalance and the **fallback**
+# if the compute job fails.
+
+compute:
+  sigma_window_days: 60
+  correlation_window_days: 60   # Tier 3 only
+  linkage: ward                 # Tier 3 only: ward | single | complete
+  sigma_floor: 0.000001         # numerical guard
+  shadow_mode: false            # if true, compute + log + do NOT act
+```
+
+---
+
+## 7. Migration path between tiers
+
+Each tier change requires:
+
+1. **ADR amendment** (or new ADR) formally authorising the transition.
+2. **Feature flag** flipped in `config/strategies.yaml` (`allocation_tier: <new_tier>`).
+3. **Shadow mode** enabled for **4 weeks** before the cutover (`compute.shadow_mode: true`). During shadow mode:
+   - The new tier's compute job runs on its cadence and writes its would-be weights to `portfolio:allocation:shadow:{strategy_id}` (a separate Redis namespace).
+   - The allocator publishes `portfolio.allocation.shadow` on ZMQ for observability.
+   - The Telemetry stack records per-strategy deltas between current-tier and shadow-tier weights.
+   - **No orders** are emitted from the shadow computation. The current tier continues to drive live allocation.
+4. **Cutover criteria** (CIO-ratified):
+   - Shadow-mode weights are stable (no single-strategy weight change > 10% week-over-week during the 4-week window).
+   - No missing-data or numerical failures in the shadow compute job for 4 consecutive cycles.
+   - The shadow tier's ex-ante Sharpe estimate (on a 30-day backtest replay) is ≥ the current tier's.
+5. **Cutover execution**: flip `shadow_mode: false` + `allocation_tier: <new_tier>`, restart allocator service. The next scheduled rebalance acts on the new tier.
+6. **Deprecation** of the previous tier: the old compute path is removed only after the new tier has run cleanly for **8 more weeks** post-cutover. Until then, the previous tier's code stays in the repo as a rollback target (guarded by the feature flag).
+
+This shadow-then-cutover protocol is adapted from standard canary-deployment practice in production software, applied with the Sharpe-CI stability checks from ADR-0008 §D3.
+
+---
+
+## 8. Observability
+
+Every rebalance emits the following telemetry:
+
+- **Current weights per strategy_id**, persisted to TimescaleDB `apex_allocation_history` (schema: `rebalance_ts_utc TIMESTAMPTZ, strategy_id TEXT, tier TEXT, weight_target NUMERIC(20,8), weight_effective NUMERIC(20,8), sigma_60d NUMERIC(20,8), overlay_tilt NUMERIC(20,8) NULL, algorithm_metadata JSONB, PRIMARY KEY (rebalance_ts_utc, strategy_id)`). This table is additive to ADR-0014's 11 tables and will be introduced in a follow-up ADR that amends the schema.
+- **Input data for the tier**: σ per strategy (Tier 2), correlation matrix and dendrogram structure (Tier 3), in `algorithm_metadata` JSONB.
+- **Deltas from previous weights** — absolute and pct-of-portfolio per strategy.
+- **Transition cost estimate** — total USD across the rebalance.
+- **Rebalance duration** — wall-clock time from compute start to Redis write end.
+- **Dashboard**: a new "Allocation" tab in `services/command_center/` showing:
+  - Current weights per strategy (bar chart).
+  - Weight history (time series per strategy, stacked).
+  - Blacklist status with benched-since dates.
+  - Shadow-mode delta panel during tier transitions.
+  - Rebalance log (last 20 rebalances with status, delta, cost).
+
+---
+
+## 9. Failure modes
+
+| Failure | Tier | Response |
+|---|---|---|
+| Strategy volatility spike (σ × 2 in 1 week) | Tier 2 | Risk Parity auto-reduces the strategy's weight via `1/σ`; the 40% ceiling on **other** strategies prevents runaway reallocation into a newly low-vol outlier. Emit `telemetry.allocator.vol_spike` for audit. |
+| New strategy added (enabled=true, burn_in_days=30) | All | Strategy allocated at `min_weight` (5% by default) for the `burn_in_days` window. During burn-in, the strategy is **excluded** from the adaptive compute — its allocation is pinned at the floor until the timer elapses. Prevents a new strategy with no history from dominating via spuriously low σ. |
+| Strategy blacklisted (CPCV PBO > 50%, PSR < 0.5, 3 consecutive DD breaches) | All | `weight = 0`; the strategy's share is redistributed pro-rata to active strategies. The blacklist entry persists in `config/strategies.yaml`. Reactivation requires a fresh Gate 2 PR (Playbook §9). |
+| Correlation matrix singular (Tier 3) | Tier 3 | Fallback to Tier 2 Risk Parity for that rebalance cycle; emit `telemetry.allocator.hrp_fallback`. If singular for ≥ 3 consecutive cycles, raise a CIO alert. |
+| Missing data in `apex_strategy_metrics` for active strategy | All | If < 20 days of history, strategy is excluded from the rebalance (as if disabled). If 20–60 days, strategy is included at `min_weight`. Alert raised via Telemetry `apex.metrics.missing_for_allocation`. |
+| Allocator compute job fails (exception, timeout) | Tier 2 / 3 | Weights in Redis remain at previous values — **fail-static**, not fail-closed, consistent with ADR-0008 §3.3. The Risk Manager's 7-step chain continues to read the last-written allocation. A CIO pager alert fires. |
+| Hard circuit breaker trips globally | All | Allocator publishes `portfolio.allocation.suspended` on ZMQ and skips the rebalance. See ADR-0008 §D6. |
+
+---
+
+## 10. References
+
+### 10.1 Academic
+
+- Qian, E. (2005). "Risk Parity Portfolios: Efficient Portfolios Through True Diversification." *PanAgora Asset Management white paper.* [Foundational Risk Parity publication.]
+- Maillard, S., Roncalli, T., & Teiletche, J. (2010). "The Properties of Equally Weighted Risk Contribution Portfolios." *Journal of Portfolio Management* 36(4), 60–70. [Formal ERC specification; diagonal-covariance simplification.]
+- Lopez de Prado, M. (2016). "Building Diversified Portfolios That Outperform Out of Sample." *Journal of Portfolio Management* 42(4), 59–69. [Hierarchical Risk Parity original paper; out-of-sample superiority demonstrated via Monte Carlo.]
+- Lopez de Prado, M. (2020). *Machine Learning for Asset Managers.* Cambridge University Press. [Chapter 4 expands HRP with NCO (Nested Clustered Optimisation) extensions; parked for future tier.]
+- Kelly, J. L. (1956). "A New Interpretation of Information Rate." *Bell System Technical Journal* 35(4), 917–926. [Referenced for future Tier 4 Kelly meta-allocation; see §10.2 below — parked.]
+- Lo, A. W. (2002). "The Statistics of Sharpe Ratios." *Financial Analysts Journal* 58(4), 36–52. [Sharpe estimation uncertainty; motivates the 4-week shadow window.]
+- Michaud, R. O. (1989). "The Markowitz Optimization Enigma." *Financial Analysts Journal* 45(1), 31–42. [Estimation-error critique motivating rejection of MVO — see companion research doc §3.]
+- Almgren, R., & Chriss, N. (2000). "Optimal Execution of Portfolio Transactions." *Journal of Risk* 3, 5–39. [Transition-cost model used in §5.3.]
+- Clarke, R., de Silva, H., & Thorley, S. (2011). "Minimum-Variance Portfolio Composition." *Journal of Portfolio Management* 37(2), 31–45. [Concentration failure mode of unconstrained vol-minimisation; motivates floor + ceiling.]
+- MacLean, L. C., Thorp, E. O., & Ziemba, W. T. (eds.) (2011). *The Kelly Capital Growth Investment Criterion: Theory and Practice.* World Scientific. [Survey motivating Kelly meta-allocation being parked as Tier 4.]
+- Black, F., & Litterman, R. (1992). "Global Portfolio Optimization." *Financial Analysts Journal* 48(5), 28–43. [Operator-view extension contemplated as future ADR.]
+
+### 10.2 Parked for future ADRs
+
+- **Kelly meta-allocation** (Kelly 1956; MacLean, Thorp & Ziemba 2011) — an aggressive, leverage-maximising allocation that sizes each strategy by its expected growth rate. Noted as a future Tier 4 candidate; rejected for Tier 3 on the grounds that Kelly is extraordinarily sensitive to input noise (Kelly fraction > 1 is routinely produced by noisy Sharpe estimates, inducing ruinous leverage).
+- **Regime-conditional allocation** — different weights per S03 RegimeDetector regime (risk-on vs risk-off). Plausible Phase 6+ extension.
+- **Black-Litterman overlay** (Black & Litterman 1992) — allows operator views to be incorporated as prior beliefs. Useful once APEX has 10+ strategies and the operator develops conviction views.
+
+### 10.3 Internal
+
+- [ADR-0007 — Strategy as Microservice](ADR-0007-strategy-as-microservice.md)
+- [ADR-0008 — Capital Allocator Topology](ADR-0008-capital-allocator-topology.md)
+- ADR-0012 — Multi-Strategy Order Netting *(sub-books receive the capital allocated here; authored in parallel on `docs/adr-0012-multi-strat-netting`)*
+- [ADR-0014 — TimescaleDB Schema v2](ADR-0014-timescaledb-schema-v2.md) *(`apex_strategy_metrics` is the input data source)*
+- [Charter §5.5 — per-strategy identity](../strategy/ALPHA_THESIS_AND_MULTI_STRAT_CHARTER.md)
+- [Charter §6 — Capital Allocation Framework](../strategy/ALPHA_THESIS_AND_MULTI_STRAT_CHARTER.md)
+- [Phase 5 v3 Roadmap](../phases/PHASE_5_v3_MULTI_STRAT_ALIGNED_ROADMAP.md)
+- [Companion research: docs/research/CAPITAL_ALLOCATION_TRAJECTORY.md](../research/CAPITAL_ALLOCATION_TRAJECTORY.md)
+- [Sample config: config/strategies.example.yaml](../../config/strategies.example.yaml)
+
+---
+
+## 11. Consequences
+
+### 11.1 Positive
+
+- **Complexity grows only when justified.** Tier 1 ships with Gate 2; Tier 2 is deferred until live data exists; Tier 3 is deferred until cross-strategy correlations become material. No premature optimisation.
+- **Gate 2 unblocked on day 1.** Tier 1 is trivial — a YAML loader. Strategy #1 can reach Gate 2 paper without waiting for the allocator service to exist. Roadmap §3 Phase B can ship.
+- **Blacklist mechanism makes the gates operational.** CPCV PBO > 50% and PSR < 0.5 are already Charter requirements (Charter §7.2 Gate 2 criteria); the `blacklist:` section of the YAML is the mechanism that makes them bite — a strategy that fails a gate has weight forced to 0 until a CIO-ratified reactivation commit.
+- **Shadow-mode cutover is paranoid by design.** 4 weeks of shadow + 8 weeks post-cutover rollback-readiness protects against algorithmic surprise. The cost is latency on tier upgrades; the benefit is that a bad upgrade cannot silently destroy the book.
+- **Aligns with published institutional practice.** Qian 2005 → Maillard/Roncalli/Teiletche 2010 → Lopez de Prado 2016 is the canonical trajectory of multi-strat capital allocation at quant firms over the last 20 years.
+
+### 11.2 Negative
+
+- **Tier 2 and Tier 3 hinge on the quality of `apex_strategy_metrics`.** If S09 FeedbackLoop's persistence is incorrect (e.g., daily returns are computed wrong, or the aggregation job silently drops rows during a DB failover), the allocator silently produces wrong weights. Mitigated by CI invariants on `apex_strategy_metrics` and a daily reconciliation job (to be specified in a follow-up ADR).
+- **Four tables of dependency** — `apex_strategy_metrics`, `apex_allocation_history`, `apex_risk_limits`, `portfolio:allocation:{strategy_id}` (Redis) — must all be in sync. Schema drift between ADR-0014's tables and the follow-up `apex_allocation_history` table is a real risk.
+- **Tier transitions are expensive in shadow time.** 12 weeks total (4 shadow + 8 post-cutover stability) per transition. Two transitions (Tier 1→2 and Tier 2→3) = 24 weeks of operational overhead. This is the price of stability.
+- **ADR-0008 alignment required** — any future drift between this ADR and ADR-0008 must be reconciled by amendment. The binding-precedence rule says ADR-0008 prevails on topology; this ADR prevails on algorithmic trajectory. Any genuine conflict is an escalation to the CIO.
+
+### 11.3 Mitigations
+
+- The CI gate on `apex_strategy_metrics` freshness (daily row count ≥ expected, no gaps > 48h) is a proposed addition to the allocator's startup checks. To be specified alongside the `apex_allocation_history` table in the follow-up ADR.
+- The rollback path from any tier transition is a single `config/strategies.yaml` edit (`allocation_tier:` flag) + service restart. The previous tier's compute code remains in the repo for 8 weeks post-cutover specifically to enable this.
+
+---
+
+## 12. Implementation plan (mapped to Phase Gates)
+
+| Phase | Tier | Deliverables | Estimate |
+|---|---|---|---|
+| Phase B (weeks 6–14) | Tier 1 | (i) YAML schema + Pydantic loader in `core/config/strategies.py`. (ii) Per-strategy `capital_usd` field consumed by each strategy's sub-book (ADR-0012). (iii) `make-strategy-yaml-validate` CI gate. (iv) Strategy #1 Gate 2 PR includes a valid `config/strategies.yaml`. | ~1 sprint |
+| Phase C (weeks 14–22) | Tier 2 | (i) `services/portfolio/strategy_allocator/` microservice scaffolding (per ADR-0008 §5.1). (ii) `risk_parity.py` per §4.2 of this ADR. (iii) Weekly Sunday 23:00 UTC rebalance scheduler (asyncio). (iv) `apex_allocation_history` TimescaleDB table (follow-up ADR). (v) 4-week shadow-mode evaluation before cutover. (vi) Tier 2 cutover on Strategy #1 Gate 3 entry + 2nd active strategy. | ~2 sprints |
+| Phase C+ / Phase D (weeks 22+) | Tier 3 | (i) `risk_parity_hrp.py` implementing Lopez de Prado 2016 §2 verbatim, with property tests reproducing Table 1. (ii) Correlation matrix compute job (daily). (iii) Monthly rebalance scheduler. (iv) "Allocation" dashboard tab upgraded to show HRP dendrogram + clusters. (v) 4-week shadow + 8-week post-cutover stability window. (vi) Cutover contingent on Tier 2 exit criteria (§3.2). | ~3–4 sprints |
+
+### 12.1 Acceptance tests per tier
+
+- **Tier 1**: given `config/strategies.yaml` with three strategies summing to 80% + 20% cash buffer, the loader returns a validated object; an invalid file (sum > 1.0, duplicate ids, missing fields) raises `ValidationError` with a descriptive message.
+- **Tier 2**: given σ = (10%, 15%, 20%) and cash_buffer = 0.20, the allocator returns w = (0.341, 0.262, 0.197) ± 1e-6 (worked example §4.2). Property test: for any valid σ vector, `Σ w + cash_buffer ≤ 1.0` and `min_weight ≤ w_i ≤ max_weight` for every i.
+- **Tier 3**: the Lopez de Prado 2016 Table 1 example (10 simulated assets) is reproduced by `risk_parity_hrp.py` within Decimal tolerance 1e-6. Property test: for any correlation matrix with spectral decomposition eigenvalues ≥ 0, HRP returns a valid weight vector (no NaNs, sum ≤ 1 - cash_buffer, per-strategy caps respected).
+
+---
+
+**END OF ADR-0013.**

--- a/docs/research/CAPITAL_ALLOCATION_TRAJECTORY.md
+++ b/docs/research/CAPITAL_ALLOCATION_TRAJECTORY.md
@@ -1,0 +1,427 @@
+# Capital Allocation Trajectory — Research Companion to ADR-0013
+
+> *This document is the long-form research companion to [ADR-0013](../adr/ADR-0013-capital-allocation-trajectory.md). The ADR ratifies **what** the trajectory is; this document explains **why** through simulation, comparison to rejected alternatives, and implementation notes for future developers. Read the ADR first, then this document.*
+
+| Field | Value |
+|---|---|
+| Version | 1.0 (co-authored with ADR-0013) |
+| Date | 2026-04-20 |
+| Author | Clement Barbier (CIO) + Claude Opus 4.7 |
+| Status | Research — informs ADR-0013 but not binding |
+| Primary references | ADR-0013, ADR-0008, Charter §6, Lopez de Prado 2016, Qian 2005, Maillard et al. 2010 |
+
+---
+
+## 1. Toy simulation — three strategies over two years
+
+To make the Tier 1 / Tier 2 / Tier 3 progression concrete, we simulate a portfolio of three hypothetical strategies over two years of daily returns and run each tier's allocation formula. The goal is not to predict APEX performance — the strategies are caricatures — but to visualise **how each tier responds to regime shifts and how turnover differs between tiers**.
+
+### 1.1 Setup
+
+Three synthetic strategies with the following stationary moments over the full two-year window:
+
+| Strategy | Annualised Sharpe | Annualised volatility | Correlation structure |
+|---|---|---|---|
+| **A — low-vol mean reversion** | 1.0 | 10% | ρ(A, B) ≈ 0.1, ρ(A, C) ≈ −0.2 |
+| **B — medium-vol momentum** | 0.7 | 15% | ρ(A, B) ≈ 0.1, ρ(B, C) ≈ 0.0 |
+| **C — high-vol crypto vol arb** | 1.2 | 20% | ρ(A, C) ≈ −0.2, ρ(B, C) ≈ 0.0 |
+
+Daily returns are drawn from `N(μ_i, σ_i / sqrt(252))` with `μ_i = Sharpe_i × σ_i` (annualised), then injected with a **regime shift at day 250**: Strategy C's volatility doubles (σ_C: 20% → 40%) for 50 days (days 250–300), reverting thereafter. This is the canonical stress test for allocator stability.
+
+Three tiers are simulated:
+
+- **Tier 1 (static)**: `w = (0.33, 0.33, 0.33)`, cash_buffer = 0.01 (kept at ~zero so the tier comparisons focus on allocation, not cash drag).
+- **Tier 2 (Risk Parity)**: `w_i ∝ 1/σ_i` with σ estimated on a rolling 60-day window, weekly rebalance, caps (5%, 40%), cash_buffer = 0.20.
+- **Tier 3 (HRP)**: full Lopez de Prado 2016 algorithm, monthly rebalance, 120-day correlation window, same caps, cash_buffer = 0.20.
+
+### 1.2 Expected results (reference numbers, closed-form estimates)
+
+The simulation is not run in code in this document (per the hard stop: no Python). Instead, we compute **reference numbers from first principles** using the closed-form expectations for each tier:
+
+**Static (Tier 1):**
+- Portfolio variance: `σ_P² = (1/9) × (0.10² + 0.15² + 0.20²) + 2×(1/9)×(0.1×0.10×0.15 - 0.2×0.10×0.20)` ≈ `(1/9) × (0.01 + 0.0225 + 0.04) + (2/9) × (0.00015 - 0.004)` ≈ `0.00806 - 0.00086` ≈ `0.0072` → σ_P ≈ **8.5%**
+- Expected portfolio Sharpe: (0.33 × 1.0 × 0.10 + 0.33 × 0.7 × 0.15 + 0.33 × 1.2 × 0.20) / 0.085 ≈ (0.033 + 0.035 + 0.079) / 0.085 ≈ **1.73**
+- Rebalance turnover: **0% (static)**
+- Vulnerability to regime shift: C's vol spike inflates portfolio vol to ≈ 12% during days 250–300; Sharpe drops to ≈ 1.2 during the window.
+
+**Risk Parity (Tier 2):**
+- Steady-state weights (cash_buffer = 0.20): `w_raw = (10, 6.67, 5)` → `w_norm = (0.461, 0.308, 0.231)` → clipped at 40% → `w_clipped = (0.400, 0.308, 0.231)` → `w_final = (0.341, 0.262, 0.197)`
+- Portfolio vol (steady state, 80% invested): √((0.341 × 0.10)² + (0.262 × 0.15)² + (0.197 × 0.20)² + 2 × 0.1 × 0.341 × 0.262 × 0.10 × 0.15 − 2 × 0.2 × 0.341 × 0.197 × 0.10 × 0.20) ≈ √(0.00116 + 0.00154 + 0.00155 + 0.00027 − 0.00054) ≈ √0.00398 ≈ **6.3%**
+- Portfolio Sharpe (steady state): (0.341 × 0.10 + 0.262 × 0.105 + 0.197 × 0.24) / 0.063 ≈ **1.94**
+- Regime response: when C's σ doubles to 40% at day 250, Risk Parity rebalances C from 0.197 → ~0.10 within 2 weekly rebalance cycles; corresponding weight flows to A and B. Portfolio vol during shift peaks at ≈ 7.5% (vs 12% for static).
+- Turnover: ≈ 2–3 rebalance trades per strategy per quarter; estimated round-trip cost (at 10 bps per rebalance delta) ≈ 15 bps/year drag on gross Sharpe.
+
+**HRP (Tier 3):**
+- HRP's behaviour with three strategies is **not meaningfully different from Risk Parity** because the algorithm's clustering value-add is most visible at 5+ strategies. For this toy example, HRP's steady-state weights land within ±3% of Tier 2's. The correlation-aware step matters only when a cluster of highly correlated strategies exists.
+- Where HRP *would* differ: if Strategies A and B were both low-vol mean-reversion with ρ(A, B) = 0.7 (instead of 0.1), Tier 2 Risk Parity would over-allocate to the A+B cluster (because it treats them as independent); HRP would identify the cluster and split the combined cluster allocation further.
+- Portfolio vol (steady state, same inputs as Tier 2): ≈ **6.1%** (marginally lower due to correlation-aware weighting on the negative A-C correlation).
+- Portfolio Sharpe (steady state): ≈ **1.95** (essentially identical to Tier 2).
+- Regime response: monthly rebalance means the response to C's vol spike is delayed by ~2 weeks relative to Tier 2; peak portfolio vol during shift is slightly higher (≈ 8.0% vs 7.5% for Tier 2). This is the **cost of monthly cadence**: slower to react. At 5+ strategies with correlation structure, HRP's better steady-state allocation more than compensates; at 3 strategies, it does not.
+
+### 1.3 Summary table
+
+| Metric | Tier 1 (Static) | Tier 2 (Risk Parity) | Tier 3 (HRP) |
+|---|---|---|---|
+| Steady-state portfolio Sharpe | ~1.73 | ~1.94 | ~1.95 |
+| Steady-state portfolio vol | ~8.5% | ~6.3% | ~6.1% |
+| Peak vol during C regime shift | ~12% | ~7.5% | ~8.0% |
+| Rebalance cadence | Never (manual) | Weekly | Monthly |
+| Estimated turnover cost drag | 0 bps | ~15 bps/year | ~8 bps/year |
+| Robustness to matrix singularity | N/A | N/A | High (no inversion) |
+| Auditability | Highest | High | Medium |
+
+**Interpretation.**
+
+- Tier 1 ships fast and is bulletproof, but **leaves Sharpe on the table** (1.73 vs 1.94) and is vulnerable to single-strategy vol spikes.
+- Tier 2 captures the Sharpe pickup (+0.21) at the cost of 15 bps/year in rebalance friction and dependency on `apex_strategy_metrics`. Net: +15-20 bps/year of Sharpe, conservatively.
+- Tier 3 delivers marginal improvement over Tier 2 at 3 strategies. At 5+ strategies with meaningful correlation structure (the trigger criterion in ADR-0013 §3.2), the gap widens.
+
+The trajectory is therefore well-justified: **each tier buys a measurable improvement over the previous at the cost of additional complexity**, and the improvement is only realised once the preconditions (live data volume, strategy count, correlation structure) are met.
+
+### 1.4 Two-year Sharpe trajectory sketch
+
+(ASCII representation — the shape is what matters, not the exact numbers.)
+
+```
+Sharpe
+ 2.0 ┤                                   ╭── HRP (1.95, flat)
+     │                                   ╰── Risk Parity (1.94, flat)
+ 1.8 ┤
+     │
+ 1.6 ┤──────────────╮            ╭────── Static (1.73, dips on shift)
+     │              │            │
+ 1.4 ┤              │            │
+     │              │            │
+ 1.2 ┤              ╰────────────╯ <-- C regime shift window
+     │                (days 250-300)
+ 1.0 ┤
+     └─────┬─────────┬─────────┬─────────┬─────────┬──────→ day
+           0        200       400       500       730
+```
+
+Static dips by ~0.5 Sharpe during the regime shift because it cannot reduce C's allocation. Risk Parity and HRP dip by ~0.1 Sharpe because they reduce C's weight within a cycle. HRP's monthly cadence produces a slightly wider dip than Tier 2's weekly cadence, but the steady-state is marginally better.
+
+---
+
+## 2. Visual — weight evolution
+
+### 2.1 Static (Tier 1)
+
+```
+Weight
+ 1.0 ┤ █████ │  Cash buffer (1%)   │ ████
+ 0.8 ┤ █████ │                     │ ████
+     │
+ 0.6 ┤ █████ │ ████ ████ ████ ████ │ ████  Strategy C (33.3%)
+     │
+ 0.4 ┤ █████ │ ████ ████ ████ ████ │ ████  Strategy B (33.3%)
+     │
+ 0.2 ┤ █████ │ ████ ████ ████ ████ │ ████  Strategy A (33.3%)
+     │
+ 0.0 └────────┬────────┬────────┬──────────→ day
+              0       250      500      730
+```
+
+Flat lines. The regime shift at day 250 has no effect on weights.
+
+### 2.2 Risk Parity (Tier 2)
+
+```
+Weight
+ 1.0 ┤ ┃ Cash buffer (20%) ┃
+ 0.8 ┤ ┃                   ┃
+     │
+ 0.6 ┤ ┃ ╱  Strategy A (~34%) ╲      ╱
+     │ ┃╱   ──────────          ╲────╱
+ 0.4 ┤ ┃    Strategy B (~26%)                   
+     │ ┃    ──────────                          
+     │ ┃    Strategy C (~20%)       ↑          
+ 0.2 ┤ ┃    ────╲                    ╲          
+     │         ╲   drops to ~10%       ╲rebounds
+ 0.0 └─────────┬─────────┬─────────┬───────→ day
+              0        250      300       730
+```
+
+Weights track inverse volatility. Strategy C's weight drops from ~20% to ~10% during the vol spike and recovers afterward. A and B absorb the freed capital.
+
+### 2.3 HRP (Tier 3)
+
+```
+Weight
+ 1.0 ┤ ┃ Cash buffer (20%)
+ 0.8 ┤ ┃
+     │
+ 0.6 ┤ ┃ Strategy A (~35%)  (slight premium vs Tier 2 for -ρ with C)
+     │ ┃──────────────────
+ 0.4 ┤ ┃ Strategy B (~25%)
+     │ ┃──────────────
+     │ ┃ Strategy C (~20%)     ↓ (slower response: ~30 day lag)
+ 0.2 ┤ ┃────────────            ╲
+     │                           ╲____________
+ 0.0 └─────────┬─────────┬─────────┬───────→ day
+              0        250       300       730
+```
+
+Weights are similar to Tier 2's steady state but respond to the regime shift with a ~30-day lag (one monthly rebalance cycle). A's weight is marginally higher than Tier 2 because HRP rewards A's negative correlation with C within the Ward cluster.
+
+### 2.4 Mermaid dendrogram (Tier 3 cluster structure)
+
+```mermaid
+graph TD
+    Root((Root)) --> Cluster_AC[Cluster A+C]
+    Root --> B[Strategy B]
+    Cluster_AC --> A[Strategy A]
+    Cluster_AC --> C[Strategy C]
+```
+
+At 3 strategies the dendrogram is trivial: A and C cluster because of their negative correlation (distance `d_AC = sqrt(0.5 × 1.2)` ≈ 0.77 is smaller than `d_BC ≈ 0.71`, depending on exact sample correlations; Ward linkage may also produce the alternative (A-B cluster) depending on the realisation). At 5+ strategies, the dendrogram has real structure and HRP's allocation differs meaningfully from Tier 2.
+
+---
+
+## 3. Compared to alternative allocation schemes we rejected
+
+### 3.1 Equal weight (1/N)
+
+**Description**: each of the N active strategies gets weight `1/N` of the invested capital; no dependence on volatility, correlation, or performance.
+
+**Pros**:
+- Trivially simple.
+- No dependence on any data.
+- Provably robust in the limit of maximum uncertainty (DeMiguel, Garlappi & Uppal 2009, *Review of Financial Studies*, 22(5), 1915–1953, show that 1/N is hard to beat out-of-sample for some portfolio sizes).
+
+**Rejection rationale**: 1/N makes no use of the volatility information APEX will have once `apex_strategy_metrics` is populated. It is dominated by Tier 2 Risk Parity in every dimension once ≥ 60 days of returns per strategy exist. It also fails to handle the regime shift — Strategy C keeps 1/3 weight even as its vol doubles, which is precisely the failure mode the ADR's cap (40% ceiling) + Risk Parity is designed to prevent. 1/N is retained as a **seed fallback** (the `weight` field in `config/strategies.yaml` doubles as the Tier 2 cold-start seed when `apex_strategy_metrics` is empty).
+
+### 3.2 Markowitz mean-variance optimisation (MVO)
+
+**Description**: solve `max_w w'μ - (γ/2) w'Σw` subject to `Σ w = 1, w ≥ 0`, where `μ` is the expected return vector and `Σ` is the full covariance matrix. The classical Markowitz 1952 formulation, extended with risk-aversion coefficient `γ`.
+
+**Pros**:
+- Optimal under the assumption that `μ` and `Σ` are known exactly.
+- Uses full covariance structure (unlike diagonal Risk Parity).
+- Well-understood mathematically.
+
+**Rejection rationale**:
+- **Estimation-error instability.** Michaud (1989, *Financial Analysts Journal* 45(1), 31–42) demonstrates that MVO is an "error-maximiser": small errors in `μ` produce large changes in `w` because the optimal portfolio lies at the intersection of the efficient frontier with the investor's indifference curve, where the sensitivity is high. With 60–120 days of strategy returns, the 95% CI on `μ_i` is wide enough that the MVO solution is dominated by noise.
+- **Concentration pathology.** Unconstrained MVO typically produces corner solutions — one or two strategies at 80%+ weight, others at 0%. Constraining away from corners requires ad-hoc `max_weight` caps that themselves become the dominant design choice, at which point the MVO solver adds little over Risk Parity + caps.
+- **Full covariance is noisy with few observations.** `N × (N+1) / 2` covariance entries × 60-day sample with 6 strategies = 21 entries estimated from 360 observations each. The off-diagonal entries' 95% CIs typically span (−0.5, +0.5), so the MVO solver is effectively randomising between strategies based on which noisy correlation happened to be sampled.
+- **Lopez de Prado (2016)** explicitly positions HRP as a response to MVO's instability: HRP beats MVO in out-of-sample Sharpe by 31% on average in the paper's Monte Carlo, despite MVO being "theoretically optimal" under known parameters.
+- Industry practice confirms: AQR, Bridgewater, and Citadel publications consistently favour Risk Parity or HRP over unconstrained MVO for multi-strategy allocation.
+
+MVO is rejected for Tier 2 and Tier 3. It may be considered as a **Black-Litterman-constrained** variant in a future ADR if the operator wants to inject prior views, but not as a pure-data-driven allocator.
+
+### 3.3 Kelly meta-allocation
+
+**Description**: size each strategy by the Kelly-optimal fraction of portfolio capital, where `f_i = μ_i / σ_i²` (continuous Kelly, Thorp 2006, *Handbook of Asset and Liability Management*).
+
+**Pros**:
+- Maximises long-term geometric growth rate under known `μ`, `σ`.
+- Theoretically elegant — Kelly (1956) established it as the growth-optimal strategy.
+- Widely used by individual quantitative traders (Thorp, Simons).
+
+**Rejection rationale**:
+- **Extreme sensitivity to `μ` noise.** Kelly is proportional to `μ/σ²`. A 95% CI on `μ` that spans (−0.5σ, +1.5σ) produces a Kelly fraction CI that spans (−0.5/σ, +1.5/σ) — regularly crossing the sign and routinely exceeding 1 (full leverage). See MacLean, Thorp & Ziemba (2011, *The Kelly Capital Growth Investment Criterion*, World Scientific), especially Chapter 2's discussion of "fractional Kelly" as a practical response to this instability.
+- **Leverage pathology.** Pure Kelly routinely prescribes 2× or 5× leverage on high-Sharpe strategies, which violates the Charter's §8 hard circuit breakers. Shrinking to half-Kelly or quarter-Kelly is the standard patch but pushes the allocation back toward Risk Parity in practice.
+- **No diversification benefit at the portfolio level.** Kelly meta-allocation sizes each strategy independently on its own `μ_i / σ_i²`; it does not account for correlations. This is worse than even diagonal Risk Parity for correlated strategies.
+- APEX already uses a **bounded Kelly (0.25× Kelly typical)** at the **per-strategy** level within each strategy's sizing logic (Charter §6.3). Meta-allocating via Kelly at the portfolio level would stack two Kelly layers, doubling the noise amplification.
+
+Kelly meta-allocation is parked as a **Tier 4** candidate in ADR-0013 §10.2. If it ships, it will be a shrunken Kelly variant (e.g., `0.25 × Kelly` capped at `max_weight`) and will require its own ADR with extensive simulation evidence.
+
+### 3.4 Equal Risk Contribution (ERC) full-covariance
+
+**Description**: solve `w_i × (Σ w)_i = constant ∀ i`, i.e., each strategy contributes equal ex-ante risk to the portfolio, using the **full** covariance matrix (not diagonal). This is the ERC specification of Maillard, Roncalli & Teiletche 2010.
+
+**Pros**:
+- Mathematically principled — matches the formal Risk Parity definition.
+- Accounts for correlations.
+- Production-grade (AQR Risk Parity product uses this variant).
+
+**Rejection rationale for Tier 2 specifically**:
+- Requires solving an optimisation problem at each rebalance (no closed form). Tier 2's `1/σ_i` closed form is transparent, auditable, and CI-testable with a 10-line property test.
+- Sample-size constraints (60-day window, 3–6 strategies) make the full covariance matrix noisy; the incremental value of full-cov over diagonal is small when cross-strategy correlations are close to zero (the Charter's §10.3 target).
+- If correlations become meaningful (Tier 2 exit criterion), **HRP is a better response than ERC full-cov**: HRP handles correlations hierarchically, which is more robust to estimation error than solving for ERC with a noisy `Σ`.
+
+ERC full-covariance is **not rejected on principle** — it sits in the same algorithmic family as Tier 2. It is deferred in favour of the simpler `1/σ` formulation for Tier 2 and leapfrogged by HRP at Tier 3. A follow-up ADR could introduce "Tier 2.5 ERC full-cov" if live evidence shows HRP is overkill but diagonal Risk Parity is inadequate.
+
+### 3.5 Minimum-variance portfolio
+
+**Description**: solve `min_w w'Σw` subject to `Σ w = 1, w ≥ 0`. Ignore expected returns entirely.
+
+**Rejection rationale**:
+- Concentrates allocation in the lowest-volatility strategies, which is **exactly the failure mode** Clarke, de Silva & Thorley (2011) document: min-var portfolios are dominated by recently-quiet assets whose vol will mean-revert. Leads to portfolio concentration in whichever strategy happened to have the lowest realised vol in the last 60 days.
+- The 5% floor + 40% ceiling in Risk Parity mitigates this, but at that point you are halfway to Risk Parity anyway.
+
+Not considered further.
+
+### 3.6 Regime-conditional allocation
+
+**Description**: run different allocation formulas per market regime (risk-on, risk-off, crisis), with S03 RegimeDetector's current regime selecting which formula applies.
+
+**Pros**:
+- Naturally responsive to regime shifts.
+- Matches the adaptive-design principle (CLAUDE.md §3).
+
+**Deferral rationale (not outright rejection)**:
+- Requires a clean regime label from S03. The current S03 RegimeDetector classifies macro regime, not cross-strategy regime, and its label history is too short to validate regime-conditional allocation at the portfolio level.
+- Doubles the parameter count (each regime has its own σ window, caps, cash_buffer), which doubles the overfitting risk.
+- Deferred to Phase 6+ per Charter §6; ADR-0013 §10.2 notes this as a parked future evolution.
+
+---
+
+## 4. Implementation notes for future developers
+
+### 4.1 When to use which tier
+
+**Rule of thumb for the CIO (or future agent) deciding tier transitions:**
+
+- **Stay at Tier 1 until** you have ≥ 2 strategies with ≥ 60 days of live paper returns in `apex_strategy_metrics`. Without that data, Tier 2's σ estimates are meaningless.
+- **Transition to Tier 2 when** you want performance-aware allocation and you can tolerate a weekly rebalance's turnover cost (~15 bps/year drag). The transition is worth it if the expected Sharpe pickup exceeds the turnover cost by a factor of 2 (i.e., expected pickup ≥ 30 bps/year). With 3+ strategies of meaningfully different volatility, this threshold is easily cleared.
+- **Transition to Tier 3 when** (i) you have 5+ active strategies, (ii) at least one pairwise correlation exceeds 0.3 persistently, (iii) the shadow-mode evaluation shows HRP would meaningfully differ from Tier 2 (≥ 5% weight delta on ≥ 2 strategies). If these conditions don't hold, Tier 2 is good enough and the operational overhead of HRP is not justified.
+
+**Rule of thumb for tier downgrades (rare but allowed):**
+
+- **Downgrade Tier 2 → Tier 1** if the allocator's numerical stability is compromised (e.g., the sample σ is swinging wildly because of a transition in the portfolio composition). Fall back to static until you can diagnose the instability.
+- **Downgrade Tier 3 → Tier 2** if the correlation matrix is singular for ≥ 3 consecutive cycles. The ADR §9 failure-mode table already specifies this as the automatic fallback behaviour.
+
+### 4.2 How to debug weight divergence between tiers in shadow mode
+
+During a shadow-mode transition (ADR §7), the allocator computes both the current tier's weights (acted on) and the candidate tier's weights (logged-only). Debugging the divergence:
+
+1. **Read both Redis namespaces**: `portfolio:allocation:{strategy_id}` (live) and `portfolio:allocation:shadow:{strategy_id}` (shadow). Compute the per-strategy delta.
+2. **Check the input data.** For Tier 2 → Tier 3, the divergence is driven by the correlation matrix. Run `SELECT * FROM apex_strategy_metrics WHERE strategy_id IN (...) AND ts >= now() - interval '120 days'` and compute the correlation matrix manually. If a single strategy has a large negative correlation with another, HRP's cluster assignment will differ from Tier 2 and the weights will diverge.
+3. **Check the clustering output.** Serialise the dendrogram (scipy returns a `linkage matrix`) and inspect the cluster hierarchy. A single outlier strategy can dominate the clustering and produce surprising allocations; a sanity check is that strategies targeting similar edges (both momentum, both mean-reversion) end up in the same cluster.
+4. **Check the caps.** After the HRP recursive bisection, the clip-to-cap step can redistribute up to 20% of capital. If a cluster has strategies at both the floor and the ceiling, redistribution may look non-intuitive.
+5. **Replay on historical data.** The `apex_allocation_history` table (to be introduced in a follow-up ADR) should have daily snapshots of the allocator's inputs and outputs. Running the candidate tier's algorithm on a 30-day historical window and comparing to the current tier's history is the most rigorous check.
+
+### 4.3 How to add a new strategy cleanly
+
+Adding a new strategy to the portfolio is not trivial — it requires sequencing the Gate 1 → Gate 2 → Gate 3 → Gate 4 lifecycle (Charter §7) with the allocator's burn-in protocol:
+
+1. **Gate 1–2 research phase**: the new strategy is researched and backtested. No impact on the allocator. Its Charter (per-strategy Charter in `docs/strategy/per_strategy/<strategy_id>.md`) specifies its target Sharpe, expected volatility, and category (directional / mean-reversion / carry per Charter §9.1).
+2. **Gate 2 PR lands**: add an entry to `config/strategies.yaml`:
+   ```yaml
+   - id: new_strategy_id
+     enabled: true
+     weight: 0.05              # starts at the floor — minimal disturbance
+     min_weight: 0.05
+     max_weight: 0.20          # initially capped below other strategies
+     burn_in_days: 30          # excluded from adaptive compute for 30 days
+   ```
+   Simultaneously reduce the `weight` fields of other strategies proportionally so `Σ weight + cash_buffer ≤ 1.0`.
+3. **Gate 3 paper-trade phase**: the new strategy starts paper trading with `weight = 0.05`. For the first 30 days (burn_in_days), the Tier 2 adaptive compute **excludes** this strategy (its weight stays pinned at 0.05). During this window, the strategy accumulates daily returns in `apex_strategy_metrics`.
+4. **Burn-in expiration**: after 30 days, the adaptive compute starts considering the new strategy. Its σ estimate is based on the first 30 days of live returns (which is below the 60-day window — see ADR §9: strategies with 20–60 days of history are included at `min_weight`). The next 30 days fill out the window.
+5. **Full incorporation**: at day 60, the new strategy has a full 60-day σ history and participates normally in Risk Parity / HRP.
+6. **Gate 4 live-micro**: once the new strategy passes Gate 3 paper, it enters Gate 4 live-micro at the Charter §6.1.3 cold-start ramp (20% → 100% over 60 calendar days). This ramp is **orthogonal** to the allocator's burn-in — it is a separate cap applied by ADR-0008 §D4.
+7. **Long-term**: once Gate 4 is complete (Sharpe > 70% of paper Sharpe over 60 days), the strategy transitions to standard allocation. Its `max_weight` in `config/strategies.yaml` can be raised from 0.20 to 0.40 via an ADR amendment or a CIO-ratified config edit with change note.
+
+**Common mistakes:**
+- Adding a strategy with `weight = 0.30` on Day 1. This violates the burn-in discipline and forces the operator to reason about why weights don't sum to 1.0 after the addition.
+- Forgetting to reduce other strategies' weights. The schema validator will reject the YAML, but the error message "sum of weights exceeds 1 - cash_buffer" isn't always clearly traced to the newly-added strategy.
+- Setting `burn_in_days = 0` for a genuinely new strategy. Burn-in protects the adaptive compute from spurious σ estimates derived from too-short history; skipping it can cause the new strategy to dominate allocation on day 10 (before its returns are representative).
+
+### 4.4 How to retire a strategy cleanly
+
+Retirement is the reverse of addition, but more delicate because it involves closing open positions:
+
+1. **CIO decision**: retire by CIO ratification, typically triggered by Charter §9.2 decommissioning rules (9 consecutive months of negative Sharpe, etc.).
+2. **Blacklist edit**: move the strategy from the `strategies:` list to the `blacklist:` list in `config/strategies.yaml`, with a `reason:` and `benched_since:` date.
+3. **Weight goes to 0**: the allocator's next rebalance (or service restart for Tier 1) sees `weight = 0`. The strategy's share is redistributed pro-rata to the remaining active strategies.
+4. **Close open positions**: the strategy microservice continues to run in `review_mode` (Charter §9.2), closing existing positions per its exit logic. No new positions are opened because the sub-book's capital envelope is 0.
+5. **Archive `apex_strategy_metrics`**: the historical daily rows for the retired strategy remain in the table (never deleted — append-only per ADR-0014). A `retired_at TIMESTAMPTZ` field on `apex_strategy_metrics` (to be added in a follow-up ADR) flags the retirement date.
+6. **Remove the strategy microservice**: after a safety window (typically 30 days, so operators can audit the close-out), the microservice Docker container can be removed from `supervisor/orchestrator.py`. The code stays in the repo as reference.
+
+**Common mistakes:**
+- Deleting the strategy entry from `config/strategies.yaml` instead of blacklisting it. This would re-enable the strategy's position IDs for a future strategy with the same `strategy_id`, polluting the attribution in `apex_strategy_metrics`. Blacklisting preserves the id as a reserved string.
+- Retiring while the strategy has open positions. The microservice needs to stay alive to close them; only its allocation goes to 0, not its service lifecycle.
+
+### 4.5 Observability during tier transitions
+
+During a 4-week shadow window, the dashboard's Allocation tab should show:
+
+- **Current weights** (from live tier), updated on rebalance.
+- **Shadow weights** (from candidate tier), updated on the candidate tier's cadence.
+- **Delta panel**: per-strategy weight delta (shadow − current), sorted by absolute delta. If any delta exceeds 10% in absolute terms, highlight in red — this is the "stop the cutover" signal per ADR §7.4.
+- **Delta stability chart**: per-strategy delta over the 4-week window as a time series. If the delta is itself volatile (swinging between +5% and −5% week-over-week), the shadow tier is not stable enough to cut over to, regardless of the point-in-time delta magnitude.
+- **Input-data health check**: σ estimates per strategy (Tier 2) / correlation-matrix condition number (Tier 3) with warning thresholds.
+
+---
+
+## 5. Open questions (parked for future ADRs)
+
+### 5.1 Should `cash_buffer` be dynamic?
+
+Currently, `cash_buffer` is a static parameter in `config/strategies.yaml`. A dynamic `cash_buffer` could respond to:
+
+- Regime (higher buffer in crisis regime from S03).
+- Allocator confidence (higher buffer when σ estimates have wide CIs).
+- Portfolio drawdown (higher buffer after a ≥ 5% drawdown, per Charter §8 soft CB tier).
+
+**Research direction**: model `cash_buffer` as the complement of a Kelly-growth-rate-weighted allocation, with dynamic shrinkage based on the 95% CI on portfolio Sharpe. This is essentially a meta-Kelly on the cash-vs-strategies axis. Parked for Tier 4 (ADR-0013 §10.2) alongside Kelly meta-allocation.
+
+### 5.2 Should cross-strategy correlation feed into allocation or only into Risk Manager aggregation?
+
+The current design:
+- **Allocation**: Tier 2 uses diagonal Σ; Tier 3 uses correlation via HRP clustering.
+- **Risk Manager (STEP 5 aggregation per the 7-step chain)**: uses correlation to compute aggregate portfolio exposure.
+
+The question: are these two uses of correlation consistent? If Tier 2 ignores correlation for sizing but the Risk Manager uses correlation for veto, the allocator can produce weights that the Risk Manager then vetoes because the aggregate is too correlated. This is a **silent coordination failure**.
+
+**Proposed mitigation**: the allocator's Tier 2 compute should **check** the resulting portfolio's aggregate correlation post-hoc (before writing to Redis), and if the aggregate correlation exceeds Charter §10.3's target, fall back to Tier 3 HRP for that cycle. This preserves Tier 2's auditability in the common case while ensuring consistency with the Risk Manager. To be specified in a follow-up ADR.
+
+### 5.3 How to handle strategies with very different capital-at-risk per trade?
+
+A high-frequency crypto strategy may trade 100× per day at 0.1% position size each; a swing equity strategy may trade 5× per week at 5% position size each. Both report daily returns to `apex_strategy_metrics`, but their volatility-of-returns is **not a clean proxy for their capital-at-risk**:
+
+- The HFT strategy's daily return vol may be 2% (high activity, small positions averaging to low aggregate vol).
+- The swing strategy's daily return vol may be 3% (fewer, larger positions).
+
+Under Tier 2, the HFT strategy gets more weight than the swing strategy (because `1/σ_HFT > 1/σ_swing`), which is counterintuitive if the HFT strategy is also running at higher leverage per position.
+
+**Research direction**: define a **capital-adjusted return vol** metric in `apex_strategy_metrics` that normalises by the strategy's average trade notional. Use this in the allocator instead of raw daily return vol. This introduces a per-strategy calibration step but better reflects actual capital-at-risk. To be specified in a follow-up ADR, likely alongside Tier 4.
+
+### 5.4 When does the Sharpe overlay (ADR-0008 Phase 2) activate relative to the tier progression?
+
+ADR-0008 §D3 specifies activation on 6 months of live data on 3+ strategies + bootstrap CI stability. ADR-0013 Tier 2 activates at Phase C Gate 3 (which could be as early as month 6–7 per the Roadmap timeline). The overlay activation thus likely occurs **during** Tier 2's lifetime.
+
+**Open question**: does the overlay stack cleanly onto Tier 3 (HRP) or does it need a different spec when the base is HRP rather than Risk Parity? The overlay tilts `w_i` by `±20%` based on Sharpe spread; this should work mechanically with either base, but the effective tilt magnitude may differ because HRP's weights are already more structured than Risk Parity's. To be validated in shadow mode when the Tier 2 → Tier 3 transition is planned.
+
+### 5.5 What granularity should `apex_allocation_history` have?
+
+The follow-up ADR defining `apex_allocation_history` must choose the persistence granularity:
+- **Per rebalance**: row inserted once per weekly/monthly rebalance, one row per active strategy. Granular but write-heavy if future tiers rebalance daily.
+- **Per significant change**: row inserted only when the weight changes by > `trigger_threshold_pct`. Smaller table, easier to query for "when did weights change."
+- **Both**: all rebalances logged, plus a separate `apex_allocation_changes` table for the significant-change subset. Redundant but flexible.
+
+**Leaning toward option 3** (both tables) given the storage cost is small (a few rows per week per strategy) and the query patterns differ (dashboards want the full timeline; audits want only the significant changes). To be decided when the follow-up ADR is authored.
+
+---
+
+## 6. References
+
+### 6.1 Academic (full citations; a subset appears in ADR-0013 §10)
+
+- Black, F., & Litterman, R. (1992). "Global Portfolio Optimization." *Financial Analysts Journal* 48(5), 28–43.
+- Clarke, R., de Silva, H., & Thorley, S. (2011). "Minimum-Variance Portfolio Composition." *Journal of Portfolio Management* 37(2), 31–45.
+- DeMiguel, V., Garlappi, L., & Uppal, R. (2009). "Optimal Versus Naive Diversification: How Inefficient Is the 1/N Portfolio Strategy?" *Review of Financial Studies* 22(5), 1915–1953.
+- Kelly, J. L. (1956). "A New Interpretation of Information Rate." *Bell System Technical Journal* 35(4), 917–926.
+- Lo, A. W. (2002). "The Statistics of Sharpe Ratios." *Financial Analysts Journal* 58(4), 36–52.
+- Lopez de Prado, M. (2016). "Building Diversified Portfolios That Outperform Out of Sample." *Journal of Portfolio Management* 42(4), 59–69.
+- Lopez de Prado, M. (2020). *Machine Learning for Asset Managers.* Cambridge University Press.
+- MacLean, L. C., Thorp, E. O., & Ziemba, W. T. (eds.) (2011). *The Kelly Capital Growth Investment Criterion: Theory and Practice.* World Scientific.
+- Maillard, S., Roncalli, T., & Teiletche, J. (2010). "The Properties of Equally Weighted Risk Contribution Portfolios." *Journal of Portfolio Management* 36(4), 60–70.
+- Markowitz, H. (1952). "Portfolio Selection." *Journal of Finance* 7(1), 77–91.
+- Michaud, R. O. (1989). "The Markowitz Optimization Enigma." *Financial Analysts Journal* 45(1), 31–42.
+- Qian, E. (2005). "Risk Parity Portfolios: Efficient Portfolios Through True Diversification." *PanAgora Asset Management white paper.*
+- Thorp, E. O. (2006). "The Kelly Criterion in Blackjack, Sports Betting and the Stock Market." In *Handbook of Asset and Liability Management*, Volume 1. Elsevier.
+
+### 6.2 Internal
+
+- [ADR-0013 — Capital Allocation Trajectory](../adr/ADR-0013-capital-allocation-trajectory.md)
+- [ADR-0008 — Capital Allocator Topology](../adr/ADR-0008-capital-allocator-topology.md)
+- [ADR-0014 — TimescaleDB Schema v2](../adr/ADR-0014-timescaledb-schema-v2.md)
+- [Charter — Alpha Thesis & Multi-Strat](../strategy/ALPHA_THESIS_AND_MULTI_STRAT_CHARTER.md)
+- [Phase 5 v3 Roadmap](../phases/PHASE_5_v3_MULTI_STRAT_ALIGNED_ROADMAP.md)
+- [Sample config: strategies.example.yaml](../../config/strategies.example.yaml)
+
+---
+
+**END OF RESEARCH COMPANION.**


### PR DESCRIPTION
## Summary

Proposes **ADR-0013 — Capital Allocation Trajectory**: a 3-tier progression tied to Phase Gates.

- **Tier 1** (Phase B Gate 2, paper, 1–2 strategies): static YAML config at `config/strategies.yaml`. Deterministic, auditable, no math dependencies at runtime.
- **Tier 2** (Phase C Gate 3, live-micro, 3–5 strategies): Risk Parity inverse-volatility scaling, weekly rebalance (Sunday 23:00 UTC). Matches ADR-0008 §D2 Phase 1.
- **Tier 3** (Phase C+, 5+ strategies, diversified book): Hierarchical Risk Parity (Lopez de Prado 2016), monthly rebalance, Ward-linkage clustering on correlation-derived distance matrix.

## Deliverables (3 files, pure docs + config template — no production code)

- `docs/adr/ADR-0013-capital-allocation-trajectory.md` — 471 lines, 12 sections: context / decision / math / rebalance mechanics / schema / migration path (4-week shadow + 8-week post-cutover stability) / observability / failure modes / references / consequences / implementation plan.
- `docs/research/CAPITAL_ALLOCATION_TRAJECTORY.md` — 427 lines, ~5,300 words companion: toy 3-strategy / 2-year simulation with closed-form reference numbers, ASCII weight-evolution charts, mermaid dendrogram, rejected alternatives (1/N, Markowitz MVO, Kelly meta-allocation, ERC full-cov, min-var, regime-conditional), implementation notes for adding/retiring strategies, open questions for future ADRs.
- `config/strategies.example.yaml` — 284 lines fully commented Tier 1 template with realistic strategy_ids (`legacy_confluence`, `har_rv_momentum`, `vol_arb`), burn-in example, and blacklist entry. NOT wired into any loader — template only.

## Cross-references

- **ADR-0008** (Capital Allocator Topology): this ADR refines the algorithmic trajectory; ADR-0008's topology decision (dedicated microservice at `services/portfolio/strategy_allocator/`) is unchanged.
- **ADR-0012** (Multi-Strategy Order Netting): sub-books receive the capital allocated here.
- **ADR-0014** (TimescaleDB Schema v2): `apex_strategy_metrics` is the input data source for Tier 2 (σ) and Tier 3 (correlation matrix).
- **Charter §5.5, §6**: per-strategy identity, capital allocation framework.

## Academic references (cited with author/year/venue)

Qian 2005 (PanAgora white paper); Maillard, Roncalli & Teiletche 2010 (JPM 36(4)); Lopez de Prado 2016 (JPM 42(4)); Lopez de Prado 2020 (CUP); Kelly 1956 (BSTJ 35(4)); Lo 2002 (FAJ 58(4)); Michaud 1989 (FAJ 45(1)); Almgren-Chriss 2000 (Journal of Risk 3); Clarke/de Silva/Thorley 2011 (JPM 37(2)); DeMiguel/Garlappi/Uppal 2009 (RFS 22(5)); Markowitz 1952 (JF 7(1)); Black-Litterman 1992 (FAJ 48(5)); MacLean/Thorp/Ziemba 2011 (World Scientific); Thorp 2006 (Elsevier HB ALM).

## Test plan

- [ ] Review Tier 2 worked example (σ = 10/15/20%, cash_buffer = 20%) produces weights (0.341, 0.262, 0.197). Manual arithmetic checks out.
- [ ] Review schema validation rules in ADR §6.1 against the sample YAML — all 6 rules satisfied.
- [ ] Review the migration path (§7): 4-week shadow + 8-week post-cutover stability window is defensible.
- [ ] Review the failure-mode table (§9) for completeness vs ADR-0008 §D6.
- [ ] Confirm no production code was introduced (grep for `.py` in diff — none).
- [ ] Confirm alignment with Charter §6 (Risk Parity as Phase 1 base) and ADR-0008 (Sunday 23:00 UTC weekly rebalance, 5% floor, 40% ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)