### PR TITLE
fix(backtesting): resolve mypy strict failure on data_loader.py:116 (#240)

### DIFF
--- a/backtesting/data_loader.py
+++ b/backtesting/data_loader.py
@@ -113,7 +113,11 @@ def save_parquet(ticks: list[NormalizedTick], path: str | Path) -> None:
         for t in ticks
     ]
     df = pd.DataFrame(rows)
-    pq.write_table(pa.Table.from_pandas(df), str(path))
+    # pyarrow 24.0 ships py.typed but pq.write_table lacks annotations on its
+    # inline stubs, so mypy --strict raises no-untyped-call. pyarrow-stubs is
+    # pinned at 20.x (checked 2026-04-22) and cannot override an inline py.typed
+    # marker, so a targeted ignore is the cleanest fix. See issue #240.
+    pq.write_table(pa.Table.from_pandas(df), str(path))  # type: ignore[no-untyped-call]
     logger.info("Saved parquet", path=str(path), rows=len(rows))
 
 

--- a/docs/audits/CICD_RESET_AUDIT_2026-04-21.md
+++ b/docs/audits/CICD_RESET_AUDIT_2026-04-21.md
@@ -190,7 +190,7 @@ Changes vs. old `ci.yml`:
 
 ## 7. Pre-existing mypy debt on main — **RESOLVED 2026-04-22 (issue #240)**
 
-From Sprint 3B close-out and confirmed by reading `backtesting/data_loader.py:116`:
+From Sprint 3B close-out and confirmed by reading `backtesting/data_loader.py` at the `pq.write_table` call site:
 
 ```python
 pq.write_table(pa.Table.from_pandas(df), str(path))
@@ -290,7 +290,7 @@ Focus targets (ordered by marginal yield for the 3.6pp gap):
 
 **Defer to follow-up**:
 - Coverage gate raise — handed off to **issue #203 (phase-A.13)**, activation condition in §10.2, exact diff in §10.1. **Not committed on this branch.**
-- ~~mypy debt fix on `backtesting/data_loader.py:116` (see §7)~~ — **RESOLVED via issue #240 (2026-04-22)**
+- ~~mypy debt fix on `backtesting/data_loader.py` at the `pq.write_table` call site (see §7)~~ — **RESOLVED via issue #240 (2026-04-22)**
 - Branch protection on `main` requiring `quality`, `rust`, `unit-tests`, `integration-tests`
 
 **Tracked upstream, do not touch in this PR**:

--- a/docs/audits/CICD_RESET_AUDIT_2026-04-21.md
+++ b/docs/audits/CICD_RESET_AUDIT_2026-04-21.md
@@ -188,7 +188,7 @@ Changes vs. old `ci.yml`:
 
 ---
 
-## 7. Pre-existing mypy debt on main
+## 7. Pre-existing mypy debt on main — **RESOLVED 2026-04-22 (issue #240)**
 
 From Sprint 3B close-out and confirmed by reading `backtesting/data_loader.py:116`:
 
@@ -196,19 +196,15 @@ From Sprint 3B close-out and confirmed by reading `backtesting/data_loader.py:11
 pq.write_table(pa.Table.from_pandas(df), str(path))
 ```
 
-`mypy . --strict` flags this as **`[no-untyped-call]`** because `pyarrow.parquet.write_table` has no stubs in the version we install. The call is `df → pa.Table → pq.write_table(Table, str)`. The fix is either:
+`mypy . --strict` flagged this as **`[no-untyped-call]`** because pyarrow 24.0 ships `py.typed` but leaves `pyarrow.parquet.write_table` without annotations in its inline stubs.
 
-- add `pyarrow` to the `[[tool.mypy.overrides]]` `ignore_missing_imports` block (already has `pyarrow.*` — but `disallow_untyped_calls` still fires on the specific call); or
-- explicitly annotate the call site / cast the bound function; or
-- switch to `pa.parquet.write_table` via a thin typed helper.
+**Resolution** (PR resolving #240):
 
-**Decision for this PR: option (a) — leave mypy strict as-is.** Rationale:
+Targeted `# type: ignore[no-untyped-call]` on the call site with a documented rationale. `pyarrow-stubs` was evaluated and rejected — the package is pinned at 20.x (checked 2026-04-22 via `pip index versions`) against our pyarrow 24.0 requirement, and an inline `py.typed` marker takes precedence over external stubs in mypy's resolution, so the external package cannot supply the missing annotations here.
 
-- Any PR that does NOT touch `backtesting/data_loader.py` is unaffected.
-- A PR that does touch it carries the fix with it — that's the usual forcing-function for debt like this.
-- Silencing it globally (options (b), (c)) is strictly worse: it either normalizes a band-aid or downgrades the whole repo's type safety.
+A round-trip Parquet write/read smoke test was added at `tests/unit/backtesting/test_data_loader_writes.py` to catch any future pyarrow API drift that the silenced call would otherwise hide.
 
-**Track this debt** in a fresh Phase-A issue (suggested title: `[infra] Fix mypy no-untyped-call on backtesting/data_loader.py:116`). Not opened as part of this PR — mission brief says this PR does not fix the debt, only documents it.
+**Effect**: `mypy --strict backtesting/` is clean. Future PRs touching `data_loader.py` no longer require `--admin` bypass to land. Quality CI returns to fully gating.
 
 ---
 
@@ -294,7 +290,7 @@ Focus targets (ordered by marginal yield for the 3.6pp gap):
 
 **Defer to follow-up**:
 - Coverage gate raise — handed off to **issue #203 (phase-A.13)**, activation condition in §10.2, exact diff in §10.1. **Not committed on this branch.**
-- mypy debt fix on `backtesting/data_loader.py:116` (see §7)
+- ~~mypy debt fix on `backtesting/data_loader.py:116` (see §7)~~ — **RESOLVED via issue #240 (2026-04-22)**
 - Branch protection on `main` requiring `quality`, `rust`, `unit-tests`, `integration-tests`
 
 **Tracked upstream, do not touch in this PR**:

--- a/tests/unit/backtesting/test_data_loader_writes.py
+++ b/tests/unit/backtesting/test_data_loader_writes.py
@@ -51,4 +51,8 @@ def test_save_parquet_round_trip(tmp_path: Path) -> None:
         assert back.timestamp_ms == original.timestamp_ms
         assert back.price == original.price
         assert back.volume == original.volume
+        assert back.side == original.side
+        assert back.bid == original.bid
+        assert back.ask == original.ask
+        assert back.spread_bps == original.spread_bps
         assert back.session == original.session

--- a/tests/unit/backtesting/test_data_loader_writes.py
+++ b/tests/unit/backtesting/test_data_loader_writes.py
@@ -1,0 +1,54 @@
+"""Round-trip smoke test for ``backtesting.data_loader`` parquet I/O.
+
+Guards against pyarrow API drift. The module pins ``pq.write_table`` with a
+targeted ``# type: ignore[no-untyped-call]`` (see issue #240) because
+pyarrow 24.0 ships ``py.typed`` without annotations for that symbol. If
+pyarrow ever changes its public signature or return semantics, this test
+will fail loudly instead of silently shipping a broken writer.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+from backtesting.data_loader import load_parquet, save_parquet
+from core.models.tick import Market, NormalizedTick, Session, TradeSide
+
+
+def _make_tick(ts_ms: int, price: str) -> NormalizedTick:
+    return NormalizedTick(
+        symbol="BTC/USDT",
+        market=Market.CRYPTO,
+        timestamp_ms=ts_ms,
+        price=Decimal(price),
+        volume=Decimal("0.5"),
+        side=TradeSide.UNKNOWN,
+        bid=Decimal(price),
+        ask=Decimal(price),
+        spread_bps=Decimal("1.0"),
+        session=Session.AFTER_HOURS,
+    )
+
+
+def test_save_parquet_round_trip(tmp_path: Path) -> None:
+    ticks = [
+        _make_tick(1_700_000_000_000, "42000.00"),
+        _make_tick(1_700_000_060_000, "42010.50"),
+        _make_tick(1_700_000_120_000, "42005.25"),
+    ]
+    out = tmp_path / "ticks.parquet"
+
+    save_parquet(ticks, out)
+    assert out.exists()
+    assert out.stat().st_size > 0
+
+    loaded = load_parquet(out)
+    assert len(loaded) == len(ticks)
+    for original, back in zip(ticks, loaded, strict=True):
+        assert back.symbol == original.symbol
+        assert back.market == original.market
+        assert back.timestamp_ms == original.timestamp_ms
+        assert back.price == original.price
+        assert back.volume == original.volume
+        assert back.session == original.session


### PR DESCRIPTION
Resolves #240.

## Problem

`backtesting/data_loader.py:116` triggered `Call to untyped function 'write_table' in typed context [no-untyped-call]` under mypy --strict. This error pre-dated Sprint 3B and was blocking the `quality` CI check on every PR that touched the file or any related module. The workaround in flight across Sprint 3B/3C was merging via `--admin` bypass — unsustainable going into Phase B.

## Fix

**Option B** (targeted `# type: ignore[no-untyped-call]` with documented rationale).

Option A (`pyarrow-stubs` in `requirements-dev.txt`) was evaluated and rejected:

- `pip index versions pyarrow-stubs` (checked 2026-04-22) tops out at 20.0, while `requirements.txt` pins `pyarrow>=18` and the local resolution picks pyarrow 24.0.
- pyarrow 24.0 ships its own `py.typed` marker. Per PEP 561 / mypy's stub resolution, inline `py.typed` takes precedence over any external stubs package, so installing `pyarrow-stubs` would not supply the missing annotations on `write_table` even if it had them.

The ignore is scoped to the single call site with an inline comment pointing to this issue and explaining the decision, so future readers have the full context without reading the PR log.

## Verification

- `mypy --strict backtesting/` — **Success: no issues found in 5 source files** (was: 1 error).
- `mypy --strict services/ core/ backtesting/` — **35 errors in 21 files** (was: 36). The 35 services/ errors match the Sprint 3C close-out baseline exactly; no regression introduced in services/ or core/.
- New round-trip test `tests/unit/backtesting/test_data_loader_writes.py::test_save_parquet_round_trip` — **PASSED** locally. Writes three `NormalizedTick` instances via `save_parquet`, loads them back via `load_parquet`, and asserts field-level equality on symbol, market, timestamp_ms, price, volume, and session. If pyarrow ever changes its public `write_table` semantics, this test fails loudly instead of the ignore silently hiding a real regression.

## Documentation

`docs/audits/CICD_RESET_AUDIT_2026-04-21.md` §7 rewritten to mark this debt **RESOLVED** with the rationale above. The §11 "Defer to follow-up" list now shows the item struck through with a pointer to #240.

## Closes

- #240

## Impact

Future PRs touching `backtesting/data_loader.py` no longer require `--admin` bypass. Quality CI returns to fully gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)