### PR TITLE
fix(features): kyle_lambda validation message + reinstate w=250 bench (#239)

### DIFF
--- a/benchmarks/python/bench_kyle_lambda.py
+++ b/benchmarks/python/bench_kyle_lambda.py
@@ -6,12 +6,14 @@ Current mean latency: 1.56 s @ 5k ticks (w=50), 7.86 s @ 20k ticks (w=50)
 Rust port feasibility: high (rolling OLS is trivial in Rust with ndarray)
 Estimated Rust speedup: 10x-20x (rolling regression is the hottest loop)
 Recommendation: port -- Phase B Rust candidate #1 (top of list).
-                Parametrization w=250 currently errors in the calculator
-                (kyle_zscore_lookback=252 leaves no buffer); skipped here
-                and flagged for a separate fix.
 
 The kyle_window parametrization isolates how rolling-OLS cost scales with
 window size; this is the bottleneck Rust would replace.
+
+kyle_zscore_lookback is set to max(252, 2 * kyle_window) so the production
+default (252) is preserved for w in {50, 100} while the w=250 sweep uses
+the minimum valid lookback of 500 (per calculator invariant lookback >=
+2 * kyle_window; see #239).
 """
 
 from __future__ import annotations
@@ -23,7 +25,7 @@ from features.calculators.cvd_kyle import CVDKyleCalculator
 from .conftest import TickFrameFactory
 
 
-@pytest.mark.parametrize("kyle_window", [50, 100])
+@pytest.mark.parametrize("kyle_window", [50, 100, 250])
 @pytest.mark.parametrize("n_ticks", [5_000, 20_000])
 def test_bench_kyle_lambda(
     benchmark: object,
@@ -35,6 +37,6 @@ def test_bench_kyle_lambda(
     calc = CVDKyleCalculator(
         cvd_window=20,
         kyle_window=kyle_window,
-        kyle_zscore_lookback=252,
+        kyle_zscore_lookback=max(252, kyle_window * 2),
     )
     benchmark(calc.compute, df)  # type: ignore[operator]

--- a/benchmarks/results/baseline_2026-04-21.md
+++ b/benchmarks/results/baseline_2026-04-21.md
@@ -24,6 +24,8 @@ will move, but relative ranking is what matters for Rust-port triage).
 | Kyle lambda only    | 5 000 ticks / w=100  | 1.71 s             | 2.07 s                | 0.58     | **High**           | Widening window barely helps Python (loop cost) |
 | Kyle lambda only    | 20 000 ticks / w=50  | 7.86 s             | 10.18 s               | 0.13     | **High**           | 4× data → 5× time (rolling-OLS dominated) |
 | Kyle lambda only    | 20 000 ticks / w=100 | 7.84 s             | 9.08 s                | 0.13     | **High**           | Essentially same as w=50 in Python |
+| Kyle lambda only    | 5 000 ticks / w=250  | 2.92 s             | 3.36 s                | 0.34     | **High**           | Reinstated 2026-04-22 post-#239 fix; lookback=500 |
+| Kyle lambda only    | 20 000 ticks / w=250 | 12.53 s            | 15.27 s               | 0.08     | **High**           | Reinstated 2026-04-22 post-#239 fix; rolling-OLS cost scales with w |
 | Kelly fraction      | 1 call               | 3.17 µs            | 11.7 µs               | 315 040  | **Don't port**     | Sub-microsecond after first call; arithmetic-bound |
 | Kelly position_size | 1 call               | 19.6 µs            | ~4 368 µs *           | 50 979   | **Don't port**     | * p99 is Decimal allocator outliers — not structural |
 | Kelly full pipeline | 1 call (equity)      | 24.7 µs            | ~14 425 µs *          | 40 413   | **Don't port**     | Dominated by Decimal boundary crossings |
@@ -41,13 +43,14 @@ will move, but relative ranking is what matters for Rust-port triage).
   shows the full 6-step chain runs in 2–4 ms end-to-end in-process,
   dominated by `await` roundtrips to Redis — clearly not a Rust-port
   candidate.
-- **Kyle lambda with `kyle_window=250`** — the two 250-window
-  parametrizations errored at `features/calculators/cvd_kyle.py:138`
-  (`kyle_zscore_lookback=252` + `kyle_window=250` leaves almost no
-  z-score buffer → `ValueError`). The 50 and 100 windows run cleanly
-  and are the production-typical values; the 250 sweep has been
-  dropped from the parametrization. Reinstate once the calculator
-  validates `kyle_zscore_lookback >= kyle_window * 2` at construction.
+- **Kyle lambda with `kyle_window=250`** — originally errored at
+  `features/calculators/cvd_kyle.py:138` because the default
+  `kyle_zscore_lookback=252` left no z-score history buffer for
+  `kyle_window=250` (calculator enforces `lookback >= 2 * kyle_window`).
+  **Fixed in #239** (2026-04-22): the benchmark now sets
+  `kyle_zscore_lookback = max(252, kyle_window * 2)`, and the calculator
+  error message includes the offending values plus the recommendation.
+  Both `w=250` rows in the table above were captured under that fix.
 
 ## Rust port prioritization — Top 3 candidates for Phase B
 

--- a/features/calculators/cvd_kyle.py
+++ b/features/calculators/cvd_kyle.py
@@ -136,8 +136,11 @@ class CVDKyleCalculator(FeatureCalculator):
             raise ValueError(f"kyle_window must be >= 10 for stable OLS, got {kyle_window}")
         if kyle_zscore_lookback < kyle_window * 2:
             raise ValueError(
-                f"kyle_zscore_lookback must be >= 2 * kyle_window, "
-                f"got {kyle_zscore_lookback} < {2 * kyle_window}"
+                f"kyle_zscore_lookback ({kyle_zscore_lookback}) must be "
+                f">= 2 * kyle_window ({2 * kyle_window}) to leave sufficient "
+                f"history for rolling z-score normalization. "
+                f"Recommended: kyle_zscore_lookback >= 2 * kyle_window "
+                f"(got kyle_window={kyle_window})."
             )
         if abs(sum(combined_weights) - 1.0) > 1e-9:
             raise ValueError(f"combined_weights must sum to 1.0, got {sum(combined_weights)}")

--- a/tests/unit/features/calculators/test_cvd_kyle.py
+++ b/tests/unit/features/calculators/test_cvd_kyle.py
@@ -164,12 +164,72 @@ class TestConstructorValidation:
             CVDKyleCalculator(kyle_window=5)
 
     def test_kyle_zscore_lookback_too_small_raises(self) -> None:
-        with pytest.raises(ValueError, match="kyle_zscore_lookback must be >= 2"):
+        with pytest.raises(ValueError, match=r"must be\s+>= 2 \* kyle_window"):
             CVDKyleCalculator(kyle_window=10, kyle_zscore_lookback=15)
+
+    def test_kyle_zscore_lookback_equals_window_raises(self) -> None:
+        """lookback == kyle_window violates 2x rule -> fail with clear msg."""
+        with pytest.raises(ValueError, match=r"must be\s+>= 2 \* kyle_window"):
+            CVDKyleCalculator(kyle_window=250, kyle_zscore_lookback=250)
+
+    def test_kyle_zscore_lookback_exceeds_window_but_below_2x_raises(self) -> None:
+        """The #239 reproducer: kyle_window=250 with default lookback=252."""
+        with pytest.raises(ValueError, match=r"must be\s+>= 2 \* kyle_window"):
+            CVDKyleCalculator(kyle_window=250, kyle_zscore_lookback=252)
+
+    def test_kyle_zscore_lookback_exactly_2x_window_valid(self) -> None:
+        """Boundary: lookback == 2 * kyle_window is the minimum valid value."""
+        calc = CVDKyleCalculator(kyle_window=250, kyle_zscore_lookback=500)
+        assert calc._kyle_window == 250
+        assert calc._kyle_zscore_lookback == 500
+
+    def test_kyle_zscore_lookback_error_message_includes_offending_values(self) -> None:
+        """Error message must include both provided and required values."""
+        with pytest.raises(ValueError, match=r"kyle_zscore_lookback") as excinfo:
+            CVDKyleCalculator(kyle_window=250, kyle_zscore_lookback=252)
+        msg = str(excinfo.value)
+        assert "252" in msg
+        assert "500" in msg
+        assert "kyle_window=250" in msg
 
     def test_combined_weights_not_summing_to_one_raises(self) -> None:
         with pytest.raises(ValueError, match=r"sum to 1\.0"):
             CVDKyleCalculator(combined_weights=(0.6, 0.6))
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Constructor validation — Hypothesis property test (#239)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestConstructorValidationProperties:
+    """Property-based tests for the (kyle_window, kyle_zscore_lookback) rule."""
+
+    @given(
+        kyle_window=st.integers(min_value=10, max_value=2000),
+        kyle_zscore_lookback=st.integers(min_value=1, max_value=5000),
+    )
+    @settings(
+        max_examples=50 if os.environ.get("CI") else 300,
+        deadline=None,
+    )
+    def test_init_accepts_iff_lookback_geq_2x_window(
+        self, kyle_window: int, kyle_zscore_lookback: int
+    ) -> None:
+        """Init must reject exactly when kyle_zscore_lookback < 2 * kyle_window."""
+        if kyle_zscore_lookback < kyle_window * 2:
+            with pytest.raises(ValueError, match=r"kyle_zscore_lookback"):
+                CVDKyleCalculator(
+                    kyle_window=kyle_window,
+                    kyle_zscore_lookback=kyle_zscore_lookback,
+                )
+        else:
+            calc = CVDKyleCalculator(
+                kyle_window=kyle_window,
+                kyle_zscore_lookback=kyle_zscore_lookback,
+            )
+            assert calc._kyle_window == kyle_window
+            assert calc._kyle_zscore_lookback == kyle_zscore_lookback
 
 
 # ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Resolves #239.

## Problem

`CVDKyleCalculator` already validated `kyle_zscore_lookback >= 2 * kyle_window` at `__init__` (cvd_kyle.py:137), but two loose ends remained after PR #222:

1. The error message was terse (`"kyle_zscore_lookback must be >= 2 * kyle_window, got X < Y"`) and didn't hint at the recommendation or echo the offending `kyle_window` back to the caller.
2. The benchmark had removed its `kyle_window=250` parametrization because the hardcoded `kyle_zscore_lookback=252` violated the invariant (252 < 500). No automated regression path detected this — the note in `baseline_2026-04-21.md` explicitly flagged the fix as pending.

## Fix

- **Error message** (cvd_kyle.py): expand to include offending values, the minimum required (`2 * kyle_window`), and the recommendation. Validation logic unchanged.
- **Benchmark** (bench_kyle_lambda.py): reinstate `kyle_window=250`; set `kyle_zscore_lookback = max(252, 2 * kyle_window)` so w=50/100 stays on the production default (252) and w=250 uses the minimum valid (500).

## Tests

- `TestConstructorValidation` gains 5 boundary cases (lookback==window; the #239 reproducer w=250/lookback=252; the exact 2x boundary is valid; error-message content assertion).
- New `TestConstructorValidationProperties` with a Hypothesis property test asserting init accepts iff `lookback >= 2 * kyle_window` across `(kyle_window in [10, 2000]) × (kyle_zscore_lookback in [1, 5000])` — 300 examples locally, 50 in CI.
- All 9 constructor tests pass. Full `test_cvd_kyle.py`: 34/36 (2 failures unrelated — `scipy.constants` import error in the local env's `TestIntegration` path).

## Benchmark baseline

Reinstated rows added to `benchmarks/results/baseline_2026-04-21.md` (captured 2026-04-22):

| Input size            | Mean     | p99      | OPS   |
|---                    |---       |---       |---    |
| 5 000 ticks / w=250   | 2.92 s   | 3.36 s   | 0.34  |
| 20 000 ticks / w=250  | 12.53 s  | 15.27 s  | 0.08  |

Confirms the Rust-port #1 ranking: rolling-OLS cost scales with `kyle_window` as expected (~30% mean-time bump from w=100 to w=250 at 20k ticks).

## Files touched

- `features/calculators/cvd_kyle.py`
- `tests/unit/features/calculators/test_cvd_kyle.py`
- `benchmarks/python/bench_kyle_lambda.py`
- `benchmarks/results/baseline_2026-04-21.md`

## Closes

- #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)