### PR TITLE
fix(feedback_loop): PositionAggregator orphan-read on portfolio:positions (#199)

### DIFF
--- a/docs/audits/POSITION_KEY_AUDIT_2026-04-21.md
+++ b/docs/audits/POSITION_KEY_AUDIT_2026-04-21.md
@@ -1,0 +1,224 @@
+# Redis `portfolio:positions` Writer Audit — Phase A.9 Scoping Verification
+
+**Audit date**: 2026-04-22
+**Scope**: locate the production writer for the Redis key `portfolio:positions`
+read by the S05 Risk Manager pre-trade context loader, in order to scope the
+"PositionAggregator in S09" deliverable mandated by Roadmap §2.2.4 and
+Issue #199 (Phase A.9).
+**Referenced artefacts**:
+- [Issue #199 — Phase A.9 PositionAggregator orphan-read](https://github.com/clement-bbier/APEX/issues/199)
+- [Roadmap v3.0 §2.2.4](../phases/PHASE_5_v3_MULTI_STRAT_ALIGNED_ROADMAP.md)
+- [PHASE_5_SPEC v2 §3.2 — Event Sourcing producers](../phases/PHASE_5_SPEC_v2.md)
+- [REDIS_KEYS_WRITER_AUDIT_2026-04-17.md](REDIS_KEYS_WRITER_AUDIT_2026-04-17.md) (parent orphan-read finding)
+- [TRADES_KEY_WRITER_AUDIT_2026-04-20.md](TRADES_KEY_WRITER_AUDIT_2026-04-20.md) (template)
+- [Charter §5.5 — Per-strategy Redis partitioning](../strategy/ALPHA_THESIS_AND_MULTI_STRAT_CHARTER.md)
+- [ADR-0007 §D8 — Per-strategy Redis namespace](../adr/ADR-0007-strategy-as-microservice.md)
+- [ADR-0012 §D3 / §D5 — Sub-book Redis layout, aggregate veto](../adr/ADR-0012-multi-strategy-netting-and-sub-books.md)
+
+---
+
+## 1. Method
+
+1. Grep every occurrence of the literal keys `"portfolio:positions"`, `"positions:"`,
+   and the f-string fragments `f"positions:{...}"` / `f"portfolio:..."` in
+   `services/`, `core/`, and `tests/`.
+2. Grep every Redis write primitive (`set`, `hset`, `lpush`, `xadd`, `sadd`)
+   in `services/` to surface dynamic-key writers.
+3. Cross-reference readers and writers; classify outcome per the Phase A
+   audit decision tree (CASE A / B / C).
+
+All commands executed on branch `fix/issue-199-position-aggregator` at
+HEAD `~37f44c4 chore(deps): apply connector + benchmark dependency declarations`.
+
+---
+
+## 2. Readers found
+
+| # | File | Line | Operation | Consumer context |
+|---|------|------|-----------|------------------|
+| 1 | [`services/risk_manager/context_loader.py`](../../services/risk_manager/context_loader.py#L37) | 37 | `"portfolio:positions"` in `REQUIRED_KEYS` | Pre-trade S05 batch read; `_require()` raises `RuntimeError` on `None` (ADR-0006 §D4 fail-loud) |
+| 2 | [`services/risk_manager/context_loader.py`](../../services/risk_manager/context_loader.py#L79) | 79 | `self._require("portfolio:positions", results[5])` | Validates the payload is a `list`; per element does `Position.model_validate(p)`; per-element failures are logged and skipped (line 91) |
+
+**Storage shape implied by the reader**: a JSON-encoded **list** of dict-shaped
+position records, each conforming to `services.risk_manager.models.Position`
+(`symbol: str`, `size: Decimal > 0`, `entry_price: Decimal > 0`,
+`asset_class: str = "equity"`).
+
+The fail-closed contract (ADR-0006 §D4) means any of: missing key, `None`
+payload, non-`list` payload — rejects the candidate as
+`SYSTEM_UNAVAILABLE`. In production this would block 100% of orders if no
+producer ever runs.
+
+---
+
+## 3. Writers found
+
+### 3.1 Aggregate key `portfolio:positions`
+
+| Primitive | Target key | File | Line |
+|-----------|------------|------|------|
+| `set` | `portfolio:positions` | (none) | (none) |
+
+**No production writer exists for `portfolio:positions`.** The exhaustive grep
+across `services/` returned only the two reader hits above plus documentation
+mentions in `MANIFEST.md`, `docs/audits/REDIS_KEYS_WRITER_AUDIT_2026-04-17.md`,
+and `docs/phases/PHASE_5_SPEC_v2.md`. The only writes to this exact key live
+in test fixtures (`tests/unit/risk_manager/test_*` seeds via fakeredis
+`redis.set("portfolio:positions", ...)`).
+
+### 3.2 Sibling per-symbol key `positions:{symbol}`
+
+| Primitive | Target key | File | Line | Owner |
+|-----------|------------|------|------|-------|
+| `state.set` | `f"positions:{symbol}"` | [`services/execution/service.py`](../../services/execution/service.py#L153) | 153 | S06 ExecutionService `_on_filled` |
+
+S06 writes a per-symbol JSON object on every fill with the following shape:
+
+```python
+{
+    "symbol":       str,            # e.g. "AAPL"
+    "direction":    "LONG" | "SHORT",
+    "entry":        str,            # Decimal-as-str — note: NOT "entry_price"
+    "size":         str,            # Decimal-as-str
+    "stop_loss":    str,
+    "target_scalp": str,
+    "target_swing": str,
+    "opened_at_ms": int,
+    "is_paper":     bool,
+}
+```
+
+This is the **per-symbol fill record**, not a Position-model envelope: the
+key is `entry`, not `entry_price`; `direction` is carried separately rather
+than being signed into `size`; and the dict carries extra trade-context
+fields the Position model does not declare. **No collision with
+`portfolio:positions`**: distinct namespace, distinct shape, distinct
+consumer.
+
+---
+
+## 4. Current atomicity pattern
+
+**Not applicable**: the writer does not exist, so there is no pattern to
+preserve. For reference, the analogous Phase A.7 / A.8 fixes
+([PR #210 PortfolioTracker](https://github.com/clement-bbier/APEX/pull/210),
+[PR #214 PnLTracker](https://github.com/clement-bbier/APEX/pull/214))
+introduced **dual-key readers**, not writers. Phase A.9 is the **first
+new producer in this Phase A orphan-read sweep** and so sets the writer
+template for the remaining producer issues.
+
+---
+
+## 5. Decision-tree outcome
+
+> Decision tree per the Phase A.9 mission brief:
+> - **CASE A**: writer exists and reader works (false alarm).
+> - **CASE B**: writer exists but uses a different key structure (alignment fix).
+> - **CASE C**: writer doesn't exist (orphan read; need to create writer).
+
+### Result: **CASE C — no writer exists**
+
+S05's `ContextLoader` reads `portfolio:positions` as a `list[Position]`. No
+production code anywhere in `services/` or `core/` writes this key. The S06
+per-symbol writer at `services/execution/service.py:153` writes the
+**source data** (`positions:{symbol}`) but no service rolls these per-symbol
+records up into the consolidated list shape S05 expects.
+
+The S05 fail-closed guard (STEP 0 in the chain, ADR-0006 §D1) is the only
+reason production has not paged: it short-circuits to `REJECTED_SYSTEM_UNAVAILABLE`
+on the missing-key `RuntimeError`. The orphan read is masked but not fixed.
+
+---
+
+## 6. Architecture decision — aggregator topology
+
+Two architectures are in play:
+
+### 6.1 Phase A topology (current, this PR)
+
+The S06 per-symbol record at `positions:{symbol}` is the **source of truth**.
+A new `PositionAggregator` in S09 (per Roadmap §2.2.4 row 4 +
+PHASE_5_SPEC_v2 §3.2 module-structure block) scans `positions:*`, transforms
+each record into the `Position` model envelope expected by S05, and writes
+the aggregated list to `portfolio:positions`. No dual-write. No new ZMQ
+topic. The aggregator runs as a background task on a fixed cadence
+(snapshot interval `15s`, configurable via constructor).
+
+This is path **(i)** from the Issue #199 mission brief: "PositionAggregator
+becomes a true aggregator that reads … and emits aggregate views". Phase A
+inherits a single-strategy world (`strategy_id="default"`), so per-symbol
+aggregation collapses to a 1:1 transform per record. The aggregation
+**math** (signed-size summation) is identical to the multi-strategy
+formulation; only the input cardinality differs.
+
+### 6.2 Phase B topology (forward compat, NOT implemented here)
+
+Per [ADR-0012 §D2](../adr/ADR-0012-multi-strategy-netting-and-sub-books.md),
+in Phase B the source of truth becomes `subbook:{strategy_id}:position:{symbol}`
+and the broker net is `Σ_{sid} subbook[sid].position(symbol)`. The
+PositionAggregator's source-key scan can swap `positions:*` →
+`subbook:*:position:*` without changing its output contract.
+
+The **aggregation function** in this PR is implemented as a pure
+`aggregate_records(records: dict[str, dict]) -> list[Position]` so the
+Phase B refactor that adds sub-book scanning can reuse the same algebra.
+This is the **only** forward-compat hook we add now — no parallel sub-book
+namespace, no premature multi-strategy abstraction. See
+CLAUDE.md §3 ("Don't add features beyond what the task requires") and
+§5 ("Only validate at system boundaries").
+
+---
+
+## 7. ADR alignment
+
+| ADR | Section | Alignment |
+|-----|---------|-----------|
+| [ADR-0006](../adr/ADR-0006-fail-closed-risk-controls.md) | §D4 | Reader stays fail-loud; aggregator failure surfaces via missing key + STEP 0 reject. **Preserved.** |
+| [ADR-0007](../adr/ADR-0007-strategy-as-microservice.md) | §D8 | Per-strategy Redis namespace covers `kelly:*`, `trades:*`, `pnl:*`, `portfolio:allocation:*`. **`portfolio:positions` is explicitly NOT in §D8 enumeration**: it is the consolidated aggregate (broker-realized net), not a per-strategy intent. No `portfolio:{strategy_id}:positions` variant introduced. **Aligned.** |
+| [ADR-0012](../adr/ADR-0012-multi-strategy-netting-and-sub-books.md) | §D2 | Per ADR-0012 §D2, `broker_net(symbol) = Σ subbook[sid].position(symbol)`. The aggregator output contract (consolidated list) is identical; only the input-source migration is deferred to Phase B per §6.2 above. **Aligned forward.** |
+| [ADR-0012](../adr/ADR-0012-multi-strategy-netting-and-sub-books.md) | §D5 | The aggregator is a **read-only producer** of the aggregate list. STEP 7 PortfolioExposureMonitor still consumes through the same S05 `ContextLoader.load()` path. **Aligned.** |
+| [Charter §5.5](../strategy/ALPHA_THESIS_AND_MULTI_STRAT_CHARTER.md) | per-strategy keys | Charter §5.5 enumerated keys do not include `portfolio:positions`. Aggregator output remains a single global key. **Aligned.** |
+
+---
+
+## 8. Action taken by this PR
+
+1. **New module** [`services/feedback_loop/position_aggregator.py`](../../services/feedback_loop/position_aggregator.py)
+   implementing `PositionAggregator` with three public surfaces:
+   - `aggregate_records(records: dict[str, dict]) -> list[Position]` —
+     pure transform (Phase B reuse).
+   - `aggregate_from_redis() -> list[Position]` — scans `positions:*`,
+     applies the transform, returns the list.
+   - `snapshot_to_redis() -> int` — calls `aggregate_from_redis` and
+     writes the result to `portfolio:positions`; returns the count for
+     observability.
+   - `run_loop(interval_s: float)` — background task wrapper for
+     periodic snapshotting.
+2. **Unit tests** [`tests/unit/feedback_loop/test_position_aggregator.py`](../../tests/unit/feedback_loop/test_position_aggregator.py)
+   covering: empty-input, single position, multi-symbol aggregation,
+   zero-size skip, malformed-record skip-with-debug-log, asset-class
+   inference, key-prefix isolation (`positionable:*` not captured),
+   round-trip via Redis, and a Hypothesis property test confirming
+   N input records → N output Positions for the Phase A 1:1 transform.
+3. **Integration test** [`tests/integration/test_position_aggregator_pipeline.py`](../../tests/integration/test_position_aggregator_pipeline.py)
+   walking through the S06 → aggregator → S05 ContextLoader path on
+   shared fakeredis to prove the orphan read closes end-to-end.
+4. **No change to ADR-0012 substantive content.** Only this audit
+   document and the implementation files. ADR-0012 §D5 cross-reference
+   cited in commit message and PR body.
+
+---
+
+## 9. Appendix — reproduced search commands
+
+```text
+grep -rn "portfolio:positions" services/ core/ tests/
+grep -rn "positions:" services/ core/
+grep -rn "f\"positions:" services/ core/
+grep -rn "portfolio:" services/ core/ | grep -v "portfolio:capital\|portfolio:allocation"
+grep -rn "\.set(" services/ | grep -i position
+grep -rn "PositionAggregator" .
+```
+
+Final result of the writer search: 0 hits in `services/`, 0 hits in `core/`,
+0 hits outside test fixtures and documentation.

--- a/services/feedback_loop/position_aggregator.py
+++ b/services/feedback_loop/position_aggregator.py
@@ -117,11 +117,13 @@ def aggregate_records(records: dict[str, dict[str, Any]]) -> list[Position]:
             authoritative).
 
     Returns:
-        List of :class:`Position` instances. Records with non-positive
-        size, missing required fields, or unparseable Decimal values are
-        logged at DEBUG and skipped — never raise. The output is sorted
-        by symbol for deterministic test assertions and stable
-        downstream diffing.
+        List of :class:`Position` instances. Records with zero size,
+        missing required fields, or unparseable Decimal values are
+        logged at DEBUG and skipped — never raise. Signed sizes are
+        accepted; negative values are normalized via ``abs()`` so feeds
+        encoding SHORT positions with a negative size remain valid. The
+        output is sorted by symbol for deterministic test assertions
+        and stable downstream diffing.
     """
     positions: list[Position] = []
     for symbol, record in records.items():
@@ -230,19 +232,28 @@ class PositionAggregator:
             production this is :class:`core.state.StateStore`; in tests
             a ``fakeredis``-backed adapter (see
             ``tests/unit/feedback_loop/test_position_aggregator.py``).
-        ttl: Optional TTL applied to the aggregate Redis key. ``None``
-            (default) preserves the StateStore default TTL; pass an
-            explicit value to override (e.g. for tests that need
-            persistence across long-running scenarios).
+        interval_s: Snapshot cadence used by :meth:`run_loop` when no
+            per-call override is supplied, and to derive the default
+            short TTL on the aggregate key (``max(75, 5 * interval_s)``).
+            Defaults to :data:`DEFAULT_SNAPSHOT_INTERVAL_S`.
+        ttl: Optional explicit TTL applied to the aggregate Redis key.
+            ``None`` (default) enables the fail-fast short TTL derived
+            from ``interval_s`` — if the aggregator stops producing
+            snapshots, the key expires within 5 cadences so downstream
+            readers see the absence rather than a frozen value. Pass an
+            explicit positive value to override (e.g. for tests that
+            need persistence across long-running scenarios).
     """
 
     def __init__(
         self,
         state: _StateProtocol,
         *,
+        interval_s: float = DEFAULT_SNAPSHOT_INTERVAL_S,
         ttl: int | None = None,
     ) -> None:
         self._state = state
+        self._interval_s = interval_s
         self._ttl = ttl
 
     async def aggregate_from_redis(self) -> list[Position]:
@@ -306,7 +317,8 @@ class PositionAggregator:
         """
         positions = await self.aggregate_from_redis()
         payload = [p.model_dump(mode="json") for p in positions]
-        await self._state.set(AGGREGATE_KEY, payload, ttl=self._ttl)
+        effective_ttl = self._ttl if self._ttl is not None else max(75, int(self._interval_s * 5))
+        await self._state.set(AGGREGATE_KEY, payload, ttl=effective_ttl)
         logger.info(
             "position_aggregator_snapshot",
             count=len(positions),
@@ -316,22 +328,32 @@ class PositionAggregator:
 
     async def run_loop(
         self,
-        interval_s: float = DEFAULT_SNAPSHOT_INTERVAL_S,
+        interval_s: float | None = None,
         *,
         running: Any = None,  # noqa: ANN401
     ) -> None:
         """Periodically snapshot until cancelled.
 
         Args:
-            interval_s: Seconds between snapshots. Defaults to
-                :data:`DEFAULT_SNAPSHOT_INTERVAL_S`.
+            interval_s: Seconds between snapshots. Defaults to the
+                aggregator's configured ``interval_s`` (set at
+                ``__init__`` time, itself defaulting to
+                :data:`DEFAULT_SNAPSHOT_INTERVAL_S`).
             running: Optional flag-like object; the loop polls
                 ``bool(running)`` between iterations and exits cleanly on
                 ``False``. ``None`` means "run until cancelled".
         """
+        effective_interval = interval_s if interval_s is not None else self._interval_s
         while running is None or bool(running):
             try:
                 await self.snapshot_to_redis()
+            except asyncio.CancelledError:
+                # CancelledError is BaseException on Py3.8+ so the
+                # broader ``except Exception`` would not catch it, but
+                # this explicit branch documents the contract: any
+                # cancel propagates immediately, never a "quiet swallow".
+                logger.info("position_aggregator_loop_cancelled")
+                raise
             except Exception as exc:
                 # Snapshot failures must not crash the background loop;
                 # the next interval retries. Hot-path errors surface in
@@ -340,8 +362,13 @@ class PositionAggregator:
                     "position_aggregator_snapshot_failed",
                     error=str(exc),
                 )
+            # Re-check the running flag before sleeping so shutdown is
+            # responsive on the interval boundary rather than paying up
+            # to ``effective_interval`` seconds of latency.
+            if running is not None and not bool(running):
+                break
             try:
-                await asyncio.sleep(interval_s)
+                await asyncio.sleep(effective_interval)
             except asyncio.CancelledError:
                 logger.info("position_aggregator_loop_cancelled")
                 raise

--- a/services/feedback_loop/position_aggregator.py
+++ b/services/feedback_loop/position_aggregator.py
@@ -1,0 +1,347 @@
+"""Aggregates per-symbol fill records into the consolidated portfolio:positions list.
+
+Phase A.9 (issue #199, Roadmap v3.0 §2.2.4 row 4, PHASE_5_SPEC_v2 §3.2).
+
+Audit finding (2026-04-22, see ``docs/audits/POSITION_KEY_AUDIT_2026-04-21.md``)
+------------------------------------------------------------------------------
+The S05 Risk Manager pre-trade context loader
+(:class:`services.risk_manager.context_loader.ContextLoader`) reads
+``portfolio:positions`` as a JSON-encoded ``list[Position]``. The exhaustive
+producer grep returned **zero** writers for that key in ``services/`` or
+``core/``. The S06 ExecutionService writes per-symbol fill records under
+``positions:{symbol}`` (``services/execution/service.py:153``) but no
+component rolls those records up into the consolidated list shape S05
+expects. The S05 fail-closed guard (ADR-0006 §D1, STEP 0 in the chain)
+masks the orphan read by short-circuiting to
+``REJECTED_SYSTEM_UNAVAILABLE``, which would block 100% of orders in
+production.
+
+Fix
+---
+:class:`PositionAggregator` runs in S09 FeedbackLoop, scans the
+``positions:*`` namespace, transforms each per-symbol record into the
+:class:`services.risk_manager.models.Position` envelope, and writes the
+aggregated list to ``portfolio:positions``. Snapshotting is periodic
+(default 15 s); the cadence is decoupled from S06 fills because S05's
+pre-trade context tolerates seconds-old position state (positions move
+on order-fill timescales, not on tick timescales).
+
+Phase B forward-compat
+----------------------
+Per ADR-0012 §D2, the broker net per symbol is
+``Σ subbook[strategy_id].position(symbol)``. The :meth:`aggregate_records`
+function below is a pure ``records → list[Position]`` transform that
+accepts the per-symbol records currently produced by S06 today and that
+will accept the sub-book records produced in Phase B without any change to
+its algebra (signed-size summation reduces to a 1:1 transform when each
+symbol has one source record). Only the :meth:`aggregate_from_redis`
+caller will swap its source-key prefix from ``positions:*`` to
+``subbook:*:position:*`` when Phase B lands.
+
+Compliance notes
+----------------
+- CLAUDE.md §2 — :class:`Decimal` (never float) for sizes/prices;
+  :mod:`structlog` only; ``asyncio`` (no threading); UTC datetimes only.
+- CLAUDE.md §3 — single responsibility (read source, transform, snapshot);
+  no premature multi-strategy abstraction.
+- CLAUDE.md §10 — per-record decode failures are logged at DEBUG and
+  skipped (a corrupted broker record on one symbol must not silently
+  block snapshots for other symbols); a structurally malformed source
+  surface (e.g. unparseable JSON at the Redis layer) propagates to
+  :meth:`aggregate_from_redis` so the periodic loop logs and moves on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal, InvalidOperation
+from typing import Any, Protocol
+
+from core.logger import get_logger
+from services.risk_manager.models import Position
+
+logger = get_logger("feedback_loop.position_aggregator")
+
+PER_SYMBOL_KEY_PREFIX = "positions:"
+"""Source-key prefix written by the S06 ExecutionService on every fill."""
+
+AGGREGATE_KEY = "portfolio:positions"
+"""Consolidated aggregate read by S05's :class:`ContextLoader`."""
+
+DEFAULT_SNAPSHOT_INTERVAL_S: float = 15.0
+"""Snapshot cadence default. Positions move on fill timescales, not tick
+timescales; 15 s is conservatively faster than the typical fill rate of
+the current single-strategy paper book and well inside S05's
+``DEGRADED`` staleness budget (10 s for in-memory state per
+PHASE_5_SPEC_v2 §3.2 — but ``portfolio:positions`` lives on the slower
+context-loader path that re-reads on every order, so eventual consistency
+within seconds is acceptable)."""
+
+
+class _StateProtocol(Protocol):
+    """Duck-type for the subset of :class:`core.state.StateStore` used here.
+
+    Mirrors the protocol pattern used by
+    :class:`services.risk_manager.portfolio_tracker.PortfolioTracker` and
+    :class:`services.risk_manager.pnl_tracker.PnLTracker` so a
+    ``fakeredis``-backed adapter satisfies it in unit tests.
+    """
+
+    @property
+    def client(self) -> Any: ...  # noqa: ANN401
+
+    async def get(self, key: str) -> Any | None: ...  # noqa: ANN401
+
+    async def set(
+        self,
+        key: str,
+        value: Any,  # noqa: ANN401
+        ttl: int | None = ...,
+    ) -> None: ...
+
+
+def aggregate_records(records: dict[str, dict[str, Any]]) -> list[Position]:
+    """Transform a ``{symbol: per_symbol_record}`` map into a list of Positions.
+
+    Pure function, no I/O. Phase B will reuse this entry point with
+    sub-book inputs (ADR-0012 §D2) — the algebra is identical because
+    each ``records`` entry already represents the consolidated signed
+    size for its symbol.
+
+    Args:
+        records: Map ``symbol → record`` where ``record`` is the dict
+            shape written by S06 (``services/execution/service.py:153``)
+            with at least ``size`` and ``entry``/``entry_price`` numeric
+            fields. The map key (``symbol``) takes precedence over any
+            ``record["symbol"]`` mismatch (defensive: the source key is
+            authoritative).
+
+    Returns:
+        List of :class:`Position` instances. Records with non-positive
+        size, missing required fields, or unparseable Decimal values are
+        logged at DEBUG and skipped — never raise. The output is sorted
+        by symbol for deterministic test assertions and stable
+        downstream diffing.
+    """
+    positions: list[Position] = []
+    for symbol, record in records.items():
+        if not isinstance(record, dict):
+            logger.debug(
+                "position_record_not_dict",
+                symbol=symbol,
+                record_type=type(record).__name__,
+            )
+            continue
+
+        size_raw = record.get("size")
+        entry_raw = record.get("entry_price", record.get("entry"))
+        if size_raw is None or entry_raw is None:
+            logger.debug(
+                "position_record_missing_field",
+                symbol=symbol,
+                has_size=size_raw is not None,
+                has_entry=entry_raw is not None,
+            )
+            continue
+
+        try:
+            size = Decimal(str(size_raw))
+            entry_price = Decimal(str(entry_raw))
+        except (InvalidOperation, ValueError) as exc:
+            logger.debug(
+                "position_record_decimal_decode_failed",
+                symbol=symbol,
+                size=size_raw,
+                entry=entry_raw,
+                error=str(exc),
+            )
+            continue
+
+        # Position model rejects size <= 0; closed positions / shorts
+        # carrying a negative magnitude are filtered here so the
+        # constructor never raises ValidationError on a known-bad row.
+        # Direction (long/short) is carried separately in S06 records and
+        # is intentionally not propagated to the Position model — the
+        # ExposureMonitor's class checks operate on |size| × entry_price
+        # and a future signed-position refactor is tracked in ADR-0012 §D2.
+        magnitude = abs(size)
+        if magnitude == Decimal("0"):
+            logger.debug("position_record_zero_size_skipped", symbol=symbol)
+            continue
+        if entry_price <= Decimal("0"):
+            logger.debug(
+                "position_record_non_positive_entry_skipped",
+                symbol=symbol,
+                entry=str(entry_price),
+            )
+            continue
+
+        try:
+            positions.append(
+                Position(
+                    symbol=symbol,
+                    size=magnitude,
+                    entry_price=entry_price,
+                    asset_class=_infer_asset_class(symbol, record),
+                )
+            )
+        except Exception as exc:
+            # Belt-and-suspenders: filtering above should already prevent
+            # validator errors; an exception here means a pydantic
+            # contract drift that must surface as a debug log so the
+            # snapshot keeps producing the remaining symbols.
+            logger.debug(
+                "position_model_validate_failed",
+                symbol=symbol,
+                error=str(exc),
+            )
+
+    positions.sort(key=lambda p: p.symbol)
+    return positions
+
+
+_CRYPTO_SUFFIXES: frozenset[str] = frozenset({"USDT", "BTC", "ETH", "BNB"})
+
+
+def _infer_asset_class(symbol: str, record: dict[str, Any]) -> str:
+    """Return ``"crypto"`` for known crypto suffixes, else fall back.
+
+    Mirrors the convention used by
+    :func:`services.risk_manager.exposure_monitor._asset_class` so the
+    aggregator does not introduce a divergent classification rule. If
+    the source record carries an explicit ``asset_class`` field
+    (forward-compat with sub-book records that may include it), that
+    value wins.
+    """
+    explicit = record.get("asset_class")
+    if isinstance(explicit, str) and explicit:
+        return explicit
+    upper = symbol.upper()
+    if any(upper.endswith(sfx) for sfx in _CRYPTO_SUFFIXES):
+        return "crypto"
+    return "equity"
+
+
+class PositionAggregator:
+    """Periodic aggregator: ``positions:*`` → ``portfolio:positions``.
+
+    Args:
+        state: Any object satisfying :class:`_StateProtocol`. In
+            production this is :class:`core.state.StateStore`; in tests
+            a ``fakeredis``-backed adapter (see
+            ``tests/unit/feedback_loop/test_position_aggregator.py``).
+        ttl: Optional TTL applied to the aggregate Redis key. ``None``
+            (default) preserves the StateStore default TTL; pass an
+            explicit value to override (e.g. for tests that need
+            persistence across long-running scenarios).
+    """
+
+    def __init__(
+        self,
+        state: _StateProtocol,
+        *,
+        ttl: int | None = None,
+    ) -> None:
+        self._state = state
+        self._ttl = ttl
+
+    async def aggregate_from_redis(self) -> list[Position]:
+        """Scan ``positions:*`` and return the aggregated Position list.
+
+        Uses ``SCAN`` (via ``redis.scan_iter``) rather than ``KEYS`` so
+        the call remains safe on a production-sized keyspace. Per-key
+        decode failures are logged at DEBUG and skipped via
+        :func:`aggregate_records` so a single corrupted broker record
+        cannot block snapshots for other symbols.
+
+        Returns:
+            List of :class:`Position` envelopes, sorted by symbol.
+        """
+        records: dict[str, dict[str, Any]] = {}
+        client = self._state.client
+        async for raw_key in client.scan_iter(match=f"{PER_SYMBOL_KEY_PREFIX}*"):
+            if isinstance(raw_key, (bytes, bytearray)):
+                key = raw_key.decode("utf-8")
+            else:
+                key = str(raw_key)
+            # Defensive: scan_iter's match pattern is a glob, not a strict
+            # prefix; an exact-prefix re-check defends against keys whose
+            # name happens to start with "positions" (e.g. "positionable:")
+            # if the namespace ever extends.
+            if not key.startswith(PER_SYMBOL_KEY_PREFIX):
+                continue
+            symbol = key[len(PER_SYMBOL_KEY_PREFIX) :]
+            if not symbol:
+                continue
+            try:
+                payload = await self._state.get(key)
+            except Exception as exc:
+                logger.debug(
+                    "position_record_read_failed",
+                    key=key,
+                    error=str(exc),
+                )
+                continue
+            if not isinstance(payload, dict):
+                logger.debug(
+                    "position_record_not_dict_at_read",
+                    key=key,
+                    payload_type=type(payload).__name__,
+                )
+                continue
+            records[symbol] = payload
+
+        return aggregate_records(records)
+
+    async def snapshot_to_redis(self) -> int:
+        """Aggregate and write to ``portfolio:positions``; return the count.
+
+        Writes an empty list when no source records exist. This is
+        intentional: S05's ContextLoader requires the key to be present
+        and a list — an empty list is a valid "flat book" answer, where
+        a missing key would trip the fail-closed guard.
+
+        Returns:
+            Number of positions written to the aggregate key.
+        """
+        positions = await self.aggregate_from_redis()
+        payload = [p.model_dump(mode="json") for p in positions]
+        await self._state.set(AGGREGATE_KEY, payload, ttl=self._ttl)
+        logger.info(
+            "position_aggregator_snapshot",
+            count=len(positions),
+            key=AGGREGATE_KEY,
+        )
+        return len(positions)
+
+    async def run_loop(
+        self,
+        interval_s: float = DEFAULT_SNAPSHOT_INTERVAL_S,
+        *,
+        running: Any = None,  # noqa: ANN401
+    ) -> None:
+        """Periodically snapshot until cancelled.
+
+        Args:
+            interval_s: Seconds between snapshots. Defaults to
+                :data:`DEFAULT_SNAPSHOT_INTERVAL_S`.
+            running: Optional flag-like object; the loop polls
+                ``bool(running)`` between iterations and exits cleanly on
+                ``False``. ``None`` means "run until cancelled".
+        """
+        while running is None or bool(running):
+            try:
+                await self.snapshot_to_redis()
+            except Exception as exc:
+                # Snapshot failures must not crash the background loop;
+                # the next interval retries. Hot-path errors surface in
+                # the logged event for observability.
+                logger.error(
+                    "position_aggregator_snapshot_failed",
+                    error=str(exc),
+                )
+            try:
+                await asyncio.sleep(interval_s)
+            except asyncio.CancelledError:
+                logger.info("position_aggregator_loop_cancelled")
+                raise

--- a/services/feedback_loop/service.py
+++ b/services/feedback_loop/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from datetime import UTC, datetime
 from typing import Any
 
@@ -10,6 +11,10 @@ from core.base_service import BaseService
 from core.logger import get_logger
 from core.models.order import TradeRecord
 from services.feedback_loop.drift_detector import DriftDetector
+from services.feedback_loop.position_aggregator import (
+    DEFAULT_SNAPSHOT_INTERVAL_S,
+    PositionAggregator,
+)
 from services.feedback_loop.signal_quality import SignalQuality
 from services.feedback_loop.trade_analyzer import TradeAnalyzer
 
@@ -33,6 +38,9 @@ class FeedbackLoopService(BaseService):
         self._analyzer = TradeAnalyzer()
         self._quality = SignalQuality()
         self._drift = DriftDetector()
+        # PositionAggregator is instantiated in run() once self.state is wired
+        # by BaseService.start(). Hold the task handle here for cancellation.
+        self._aggregator_task: asyncio.Task[None] | None = None
 
     async def on_message(self, topic: str, data: dict[str, Any]) -> None:
         """No-op: feedback loop reads from Redis, does not subscribe."""
@@ -40,16 +48,35 @@ class FeedbackLoopService(BaseService):
     async def run(self) -> None:
         """Run feedback analysis loop."""
         logger.info("Feedback loop service starting")
-        while self._running:
-            try:
-                await self._fast_analysis()
-                # Check if it's post-market time (21:00-22:00 UTC)
-                now = datetime.now(UTC)
-                if 21 <= now.hour < 22:
-                    await self._slow_analysis()
-            except Exception as exc:
-                logger.error("Feedback loop error", error=str(exc), exc_info=exc)
-            await asyncio.sleep(300)  # 5 minutes
+
+        # Launch the PositionAggregator background task — it snapshots
+        # positions:* → portfolio:positions every DEFAULT_SNAPSHOT_INTERVAL_S
+        # so S05's ContextLoader sees a live aggregate. Without this wire
+        # portfolio:positions would remain orphan and the S05 fail-closed
+        # guard (ADR-0006 §D1) would reject 100% of orders in production.
+        aggregator = PositionAggregator(
+            self.state,
+            interval_s=DEFAULT_SNAPSHOT_INTERVAL_S,
+        )
+        self._aggregator_task = asyncio.create_task(aggregator.run_loop())
+
+        try:
+            while self._running:
+                try:
+                    await self._fast_analysis()
+                    # Check if it's post-market time (21:00-22:00 UTC)
+                    now = datetime.now(UTC)
+                    if 21 <= now.hour < 22:
+                        await self._slow_analysis()
+                except Exception as exc:
+                    logger.error("Feedback loop error", error=str(exc), exc_info=exc)
+                await asyncio.sleep(300)  # 5 minutes
+        finally:
+            if self._aggregator_task is not None:
+                self._aggregator_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._aggregator_task
+                self._aggregator_task = None
 
     async def _fast_analysis(self) -> None:
         """Fast analysis every 5 minutes: drift detection and Kelly update."""

--- a/tests/integration/test_position_aggregator_pipeline.py
+++ b/tests/integration/test_position_aggregator_pipeline.py
@@ -1,0 +1,195 @@
+"""End-to-end pipeline test: S06 fill → PositionAggregator → S05 ContextLoader.
+
+Phase A.9 (issue #199). Verifies the orphan-read fix closes the producer →
+consumer loop:
+
+1. S06 ExecutionService writes a per-symbol record under
+   ``positions:{symbol}`` (we simulate the production
+   ``services/execution/service.py:_on_filled`` shape directly).
+2. :class:`services.feedback_loop.position_aggregator.PositionAggregator`
+   scans the ``positions:*`` namespace and writes the aggregated list to
+   ``portfolio:positions``.
+3. :class:`services.risk_manager.context_loader.ContextLoader` (the S05
+   pre-trade reader) consumes ``portfolio:positions`` via the same code
+   path used in production and surfaces a ``list[Position]``.
+
+The test uses a ``fakeredis`` backend wrapped in the
+:class:`core.state.StateStore`-shaped adapter that production callers see;
+mirrors the in-process integration approach used by
+``tests/integration/test_circuit_breaker_integration.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from decimal import Decimal
+from typing import Any
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+
+from services.feedback_loop.position_aggregator import (
+    AGGREGATE_KEY,
+    PER_SYMBOL_KEY_PREFIX,
+    PositionAggregator,
+)
+from services.risk_manager.context_loader import ContextLoader
+from services.risk_manager.models import Position
+
+
+class _StateAdapter:
+    """Production-shaped ``StateStore`` substitute over ``fakeredis``.
+
+    Implements the subset of :class:`core.state.StateStore` required by
+    both producers (``set``) and the context loader (``get``) plus the
+    ``client`` property used by the aggregator's ``scan_iter``. All
+    payloads are JSON-encoded on the wire to mirror
+    ``core/state.py:121``/``core/state.py:153``.
+    """
+
+    def __init__(self, redis: fakeredis.aioredis.FakeRedis) -> None:
+        self._redis = redis
+
+    @property
+    def client(self) -> fakeredis.aioredis.FakeRedis:
+        return self._redis
+
+    async def get(self, key: str) -> Any | None:
+        raw = await self._redis.get(key)
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return json.loads(raw)
+
+    async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
+        await self._redis.set(key, json.dumps(value, default=str), ex=ttl)
+
+
+@pytest_asyncio.fixture
+async def state() -> AsyncIterator[_StateAdapter]:
+    client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    try:
+        yield _StateAdapter(client)
+    finally:
+        await client.flushall()
+        await client.aclose()
+
+
+def _s06_filled_record(
+    symbol: str,
+    *,
+    direction: str = "LONG",
+    entry: str = "100",
+    size: str = "1",
+) -> dict[str, Any]:
+    """Reproduce the dict shape S06 writes in ``_on_filled``
+    (``services/execution/service.py:153``)."""
+    return {
+        "symbol": symbol,
+        "direction": direction,
+        "entry": entry,
+        "size": size,
+        "stop_loss": "98",
+        "target_scalp": "102",
+        "target_swing": "105",
+        "opened_at_ms": 1_700_000_000_000,
+        "is_paper": True,
+    }
+
+
+async def _seed_pre_trade_context(state: _StateAdapter) -> None:
+    """Populate the seven *other* pre-trade context keys so that
+    :meth:`ContextLoader.load` does not raise on a sibling miss when we
+    invoke it on the merged state. Aggregator-related assertions remain
+    isolated to the ``portfolio:positions`` slot."""
+    await state.set("portfolio:capital", {"available": "100000"})
+    await state.set("pnl:daily", "0")
+    await state.set("pnl:intraday_30m", "0")
+    await state.set("macro:vix_current", "20.0")
+    await state.set("macro:vix_1h_ago", "20.0")
+    await state.set("correlation:matrix", {})
+    await state.set("session:current", "unknown")
+
+
+@pytest.mark.asyncio
+async def test_orphan_read_closes_end_to_end(state: _StateAdapter) -> None:
+    """Without the aggregator, S05 sees a missing key and rejects.
+
+    With the aggregator running once, the same S05 read returns a
+    populated ``list[Position]`` and the chain proceeds.
+    """
+    # 1. Producer side: simulate two S06 fills.
+    await state.set(
+        f"{PER_SYMBOL_KEY_PREFIX}AAPL", _s06_filled_record("AAPL", entry="150", size="2")
+    )
+    await state.set(
+        f"{PER_SYMBOL_KEY_PREFIX}BTCUSDT",
+        _s06_filled_record("BTCUSDT", entry="50000", size="0.5"),
+    )
+
+    # 2. Confirm the orphan read still fails before snapshot:
+    raw_before = await state.get(AGGREGATE_KEY)
+    assert raw_before is None  # nobody has written the aggregate yet
+
+    # 3. Aggregator runs once.
+    aggregator = PositionAggregator(state)
+    count = await aggregator.snapshot_to_redis()
+    assert count == 2
+
+    # 4. Confirm the aggregate is now present and Position-model shaped.
+    raw_after = await state.get(AGGREGATE_KEY)
+    assert isinstance(raw_after, list)
+    assert len(raw_after) == 2
+
+    # 5. Now seed the seven sibling keys and run the *real* ContextLoader.
+    await _seed_pre_trade_context(state)
+    loader = ContextLoader(state)
+    ctx = await loader.load(symbol="AAPL")
+    positions = ctx["positions"]
+    assert isinstance(positions, list)
+    assert all(isinstance(p, Position) for p in positions)
+    by_sym = {p.symbol: p for p in positions}
+    assert set(by_sym.keys()) == {"AAPL", "BTCUSDT"}
+    assert by_sym["AAPL"].size == Decimal("2")
+    assert by_sym["AAPL"].entry_price == Decimal("150")
+    assert by_sym["BTCUSDT"].size == Decimal("0.5")
+    assert by_sym["BTCUSDT"].entry_price == Decimal("50000")
+    assert by_sym["BTCUSDT"].asset_class == "crypto"
+    assert by_sym["AAPL"].asset_class == "equity"
+
+
+@pytest.mark.asyncio
+async def test_empty_book_pipeline(state: _StateAdapter) -> None:
+    """A flat book emits an empty list — S05 ContextLoader must accept this
+    rather than rejecting on missing-key. This is the load-bearing
+    fail-closed contract that makes the snapshot-to-empty-list call in
+    :meth:`PositionAggregator.snapshot_to_redis` non-trivial."""
+    aggregator = PositionAggregator(state)
+    await aggregator.snapshot_to_redis()
+    await _seed_pre_trade_context(state)
+
+    loader = ContextLoader(state)
+    ctx = await loader.load(symbol="AAPL")
+    assert ctx["positions"] == []
+
+
+@pytest.mark.asyncio
+async def test_position_close_propagates_through_aggregator(state: _StateAdapter) -> None:
+    """When S06 deletes a per-symbol record (position closed), the next
+    aggregator snapshot drops it from the aggregate."""
+    # Open AAPL.
+    await state.set(f"{PER_SYMBOL_KEY_PREFIX}AAPL", _s06_filled_record("AAPL", size="2"))
+    aggregator = PositionAggregator(state)
+    await aggregator.snapshot_to_redis()
+    raw = await state.get(AGGREGATE_KEY)
+    assert isinstance(raw, list)
+    assert len(raw) == 1
+
+    # Close AAPL: S06 would delete the per-symbol key on a flat exit.
+    await state.client.delete(f"{PER_SYMBOL_KEY_PREFIX}AAPL")
+    await aggregator.snapshot_to_redis()
+    raw_after = await state.get(AGGREGATE_KEY)
+    assert raw_after == []

--- a/tests/unit/feedback_loop/test_position_aggregator.py
+++ b/tests/unit/feedback_loop/test_position_aggregator.py
@@ -1,0 +1,525 @@
+"""Unit tests for :class:`services.feedback_loop.position_aggregator.PositionAggregator`.
+
+Phase A.9 (issue #199). Validates the source-scan + transform + snapshot
+contract that closes the ``portfolio:positions`` orphan read identified in
+``docs/audits/POSITION_KEY_AUDIT_2026-04-21.md``.
+
+Test patterns follow CLAUDE.md §2 (fakeredis only, no real Redis) and §7
+(happy path + edge cases + error cases + property test). Mirrors the
+fakeredis adapter pattern used by ``test_portfolio_tracker.py`` (PR #210)
+and ``test_pnl_tracker.py`` (PR #214).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from decimal import Decimal
+from typing import Any
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+from hypothesis import given
+from hypothesis import settings as hyp_settings
+from hypothesis import strategies as st
+
+from services.feedback_loop.position_aggregator import (
+    AGGREGATE_KEY,
+    DEFAULT_SNAPSHOT_INTERVAL_S,
+    PER_SYMBOL_KEY_PREFIX,
+    PositionAggregator,
+    aggregate_records,
+)
+from services.risk_manager.models import Position
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _JsonStateAdapter:
+    """Mirrors :class:`core.state.StateStore` ``get``/``set``/``client`` semantics.
+
+    Encodes via ``json.dumps`` on ``set`` and decodes via ``json.loads`` on
+    ``get`` to match the production wire format
+    (``core/state.py:121``/``core/state.py:136``). Exposes the underlying
+    fakeredis client so :meth:`PositionAggregator.aggregate_from_redis` can
+    use ``scan_iter``.
+    """
+
+    def __init__(self, redis: fakeredis.aioredis.FakeRedis) -> None:
+        self._redis = redis
+
+    @property
+    def client(self) -> fakeredis.aioredis.FakeRedis:
+        return self._redis
+
+    async def get(self, key: str) -> Any | None:
+        raw = await self._redis.get(key)
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return json.loads(raw)
+
+    async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
+        await self._redis.set(key, json.dumps(value, default=str), ex=ttl)
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> AsyncIterator[fakeredis.aioredis.FakeRedis]:
+    """Fresh fakeredis per test."""
+    client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    try:
+        yield client
+    finally:
+        await client.flushall()
+        await client.aclose()
+
+
+@pytest_asyncio.fixture
+async def state(
+    redis_client: fakeredis.aioredis.FakeRedis,
+) -> _JsonStateAdapter:
+    return _JsonStateAdapter(redis_client)
+
+
+@pytest_asyncio.fixture
+async def aggregator(state: _JsonStateAdapter) -> PositionAggregator:
+    return PositionAggregator(state)
+
+
+def _s06_record(
+    symbol: str,
+    *,
+    direction: str = "LONG",
+    entry: str = "100",
+    size: str = "1",
+    is_paper: bool = True,
+) -> dict[str, Any]:
+    """Build a per-symbol record in the exact shape S06 writes today
+    (``services/execution/service.py:153``)."""
+    return {
+        "symbol": symbol,
+        "direction": direction,
+        "entry": entry,
+        "size": size,
+        "stop_loss": "98",
+        "target_scalp": "102",
+        "target_swing": "105",
+        "opened_at_ms": 1_700_000_000_000,
+        "is_paper": is_paper,
+    }
+
+
+async def _seed_position(
+    state: _JsonStateAdapter,
+    symbol: str,
+    **overrides: Any,
+) -> None:
+    record = _s06_record(symbol, **overrides)
+    await state.set(f"{PER_SYMBOL_KEY_PREFIX}{symbol}", record)
+
+
+# ---------------------------------------------------------------------------
+# (a) aggregate_records — pure transform contract
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_records_empty_returns_empty() -> None:
+    assert aggregate_records({}) == []
+
+
+def test_aggregate_records_single_position() -> None:
+    out = aggregate_records({"AAPL": _s06_record("AAPL", entry="150", size="2")})
+    assert len(out) == 1
+    assert out[0].symbol == "AAPL"
+    assert out[0].size == Decimal("2")
+    assert out[0].entry_price == Decimal("150")
+    assert out[0].asset_class == "equity"
+
+
+def test_aggregate_records_multi_symbol_sorted() -> None:
+    out = aggregate_records(
+        {
+            "MSFT": _s06_record("MSFT", entry="320"),
+            "AAPL": _s06_record("AAPL", entry="150"),
+            "BTCUSDT": _s06_record("BTCUSDT", entry="50000"),
+        }
+    )
+    # Sorted by symbol for deterministic test assertions.
+    assert [p.symbol for p in out] == ["AAPL", "BTCUSDT", "MSFT"]
+    assert out[1].asset_class == "crypto"  # BTCUSDT inferred as crypto
+    assert out[0].asset_class == "equity"  # AAPL inferred as equity
+    assert out[2].asset_class == "equity"
+
+
+def test_aggregate_records_negative_size_treated_as_magnitude() -> None:
+    """Phase A: per-symbol record carries direction separately; sign filtered."""
+    out = aggregate_records({"AAPL": _s06_record("AAPL", direction="SHORT", size="-3")})
+    assert len(out) == 1
+    assert out[0].size == Decimal("3")  # magnitude only
+
+
+def test_aggregate_records_zero_size_skipped() -> None:
+    """Closed positions (size 0) are not surfaced to S05."""
+    out = aggregate_records({"AAPL": _s06_record("AAPL", size="0")})
+    assert out == []
+
+
+def test_aggregate_records_non_positive_entry_skipped() -> None:
+    """Position model rejects entry_price <= 0; pre-filter keeps snapshot alive."""
+    assert aggregate_records({"AAPL": _s06_record("AAPL", entry="0")}) == []
+    assert aggregate_records({"AAPL": _s06_record("AAPL", entry="-1")}) == []
+
+
+def test_aggregate_records_missing_size_skipped() -> None:
+    bad = {"symbol": "AAPL", "entry": "100"}  # no 'size'
+    assert aggregate_records({"AAPL": bad}) == []
+
+
+def test_aggregate_records_missing_entry_skipped() -> None:
+    bad = {"symbol": "AAPL", "size": "1"}  # no 'entry' or 'entry_price'
+    assert aggregate_records({"AAPL": bad}) == []
+
+
+def test_aggregate_records_accepts_explicit_entry_price_field() -> None:
+    """Forward-compat: sub-book records may use the canonical 'entry_price' field."""
+    out = aggregate_records({"AAPL": {"size": "1", "entry_price": "150"}})
+    assert len(out) == 1
+    assert out[0].entry_price == Decimal("150")
+
+
+def test_aggregate_records_explicit_entry_price_wins_over_legacy_entry() -> None:
+    out = aggregate_records({"AAPL": {"size": "1", "entry": "200", "entry_price": "150"}})
+    assert out[0].entry_price == Decimal("150")
+
+
+def test_aggregate_records_explicit_asset_class_wins_over_inference() -> None:
+    """Forward-compat: sub-book records may carry an explicit asset_class."""
+    out = aggregate_records({"AAPL": {"size": "1", "entry_price": "150", "asset_class": "futures"}})
+    assert out[0].asset_class == "futures"
+
+
+def test_aggregate_records_non_dict_record_skipped() -> None:
+    assert aggregate_records({"AAPL": "not_a_dict"}) == []  # type: ignore[dict-item]
+    assert aggregate_records({"AAPL": 42}) == []  # type: ignore[dict-item]
+    assert aggregate_records({"AAPL": None}) == []  # type: ignore[dict-item]
+
+
+def test_aggregate_records_undecodable_decimal_skipped() -> None:
+    out = aggregate_records({"AAPL": {"size": "not_a_number", "entry": "100"}})
+    assert out == []
+
+
+def test_aggregate_records_partial_failure_does_not_block_other_symbols() -> None:
+    """A corrupted row on AAPL must not silently block MSFT's snapshot."""
+    out = aggregate_records(
+        {
+            "AAPL": {"size": "garbage", "entry": "100"},  # bad
+            "MSFT": _s06_record("MSFT", entry="320"),
+        }
+    )
+    assert [p.symbol for p in out] == ["MSFT"]
+
+
+# ---------------------------------------------------------------------------
+# (b) aggregate_from_redis — Redis SCAN integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aggregate_from_redis_no_keys_returns_empty(
+    aggregator: PositionAggregator,
+) -> None:
+    assert await aggregator.aggregate_from_redis() == []
+
+
+@pytest.mark.asyncio
+async def test_aggregate_from_redis_single_key(
+    state: _JsonStateAdapter,
+    aggregator: PositionAggregator,
+) -> None:
+    await _seed_position(state, "AAPL", entry="150", size="2")
+    out = await aggregator.aggregate_from_redis()
+    assert len(out) == 1
+    assert out[0].symbol == "AAPL"
+    assert out[0].size == Decimal("2")
+    assert out[0].entry_price == Decimal("150")
+
+
+@pytest.mark.asyncio
+async def test_aggregate_from_redis_multi_key_sorted(
+    state: _JsonStateAdapter,
+    aggregator: PositionAggregator,
+) -> None:
+    await _seed_position(state, "MSFT", entry="320")
+    await _seed_position(state, "AAPL", entry="150")
+    await _seed_position(state, "BTCUSDT", entry="50000")
+    out = await aggregator.aggregate_from_redis()
+    assert [p.symbol for p in out] == ["AAPL", "BTCUSDT", "MSFT"]
+
+
+@pytest.mark.asyncio
+async def test_aggregate_from_redis_ignores_other_namespaces(
+    state: _JsonStateAdapter,
+    redis_client: fakeredis.aioredis.FakeRedis,
+    aggregator: PositionAggregator,
+) -> None:
+    """Non-`positions:*` keys must not be picked up."""
+    await _seed_position(state, "AAPL", entry="150")
+    await redis_client.set("portfolio:capital", json.dumps({"available": "100000"}))
+    await redis_client.set("kelly:default:AAPL", json.dumps({"win_rate": 0.6}))
+    await redis_client.set("trades:all", json.dumps([]))
+    out = await aggregator.aggregate_from_redis()
+    assert [p.symbol for p in out] == ["AAPL"]
+
+
+@pytest.mark.asyncio
+async def test_aggregate_from_redis_corrupted_record_skipped(
+    state: _JsonStateAdapter,
+    redis_client: fakeredis.aioredis.FakeRedis,
+    aggregator: PositionAggregator,
+) -> None:
+    """A non-dict payload at a positions:* key is skipped, not raised."""
+    await _seed_position(state, "MSFT", entry="320")
+    # AAPL is a JSON list at the positions: key — wrong shape.
+    await redis_client.set(f"{PER_SYMBOL_KEY_PREFIX}AAPL", json.dumps(["not", "a", "dict"]))
+    out = await aggregator.aggregate_from_redis()
+    assert [p.symbol for p in out] == ["MSFT"]
+
+
+@pytest.mark.asyncio
+async def test_aggregate_from_redis_empty_symbol_segment_skipped(
+    redis_client: fakeredis.aioredis.FakeRedis,
+    aggregator: PositionAggregator,
+) -> None:
+    """Defensive: a key shaped exactly `positions:` (no symbol) is skipped."""
+    await redis_client.set(PER_SYMBOL_KEY_PREFIX, json.dumps({"size": "1", "entry": "100"}))
+    out = await aggregator.aggregate_from_redis()
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# (c) snapshot_to_redis — write-side contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_snapshot_to_redis_writes_aggregate_key(
+    state: _JsonStateAdapter,
+    aggregator: PositionAggregator,
+) -> None:
+    await _seed_position(state, "AAPL", entry="150", size="2")
+    count = await aggregator.snapshot_to_redis()
+    assert count == 1
+    payload = await state.get(AGGREGATE_KEY)
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    assert payload[0]["symbol"] == "AAPL"
+    assert payload[0]["size"] == "2"
+    assert payload[0]["entry_price"] == "150"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_writes_empty_list_when_no_positions(
+    aggregator: PositionAggregator,
+    state: _JsonStateAdapter,
+) -> None:
+    """A flat book MUST surface as an empty list, not a missing key — the
+    fail-closed reader treats missing-key as ``REJECTED_SYSTEM_UNAVAILABLE``."""
+    count = await aggregator.snapshot_to_redis()
+    assert count == 0
+    assert await state.get(AGGREGATE_KEY) == []
+
+
+@pytest.mark.asyncio
+async def test_snapshot_round_trip_is_position_model_compatible(
+    state: _JsonStateAdapter,
+    aggregator: PositionAggregator,
+) -> None:
+    """Round-trip: snapshot → ContextLoader-style validation → :class:`Position`.
+
+    Reproduces the exact decode path used by
+    :meth:`services.risk_manager.context_loader.ContextLoader.load`
+    so a regression in the wire shape would surface here, not in
+    a downstream S05 production rejection.
+    """
+    await _seed_position(state, "AAPL", entry="150", size="2")
+    await _seed_position(state, "BTCUSDT", entry="50000", size="0.5")
+    await aggregator.snapshot_to_redis()
+    raw = await state.get(AGGREGATE_KEY)
+    assert isinstance(raw, list)
+    rebuilt = [Position.model_validate(p) for p in raw]
+    by_sym = {p.symbol: p for p in rebuilt}
+    assert by_sym["AAPL"].size == Decimal("2")
+    assert by_sym["AAPL"].entry_price == Decimal("150")
+    assert by_sym["BTCUSDT"].asset_class == "crypto"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_overwrites_previous_value(
+    state: _JsonStateAdapter,
+    aggregator: PositionAggregator,
+    redis_client: fakeredis.aioredis.FakeRedis,
+) -> None:
+    """A new snapshot replaces the previous aggregate atomically (StateStore.set)."""
+    await _seed_position(state, "AAPL", entry="150", size="2")
+    await aggregator.snapshot_to_redis()
+    # Now AAPL closes (size 0) and MSFT opens.
+    await redis_client.delete(f"{PER_SYMBOL_KEY_PREFIX}AAPL")
+    await _seed_position(state, "MSFT", entry="320", size="1")
+    await aggregator.snapshot_to_redis()
+    payload = await state.get(AGGREGATE_KEY)
+    assert isinstance(payload, list)
+    assert [p["symbol"] for p in payload] == ["MSFT"]
+
+
+# ---------------------------------------------------------------------------
+# (d) Multi-strategy offsetting (Phase A 1:1; ADR-0012 §D2 forward-compat)
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_multi_strategy_offsetting_via_pure_transform() -> None:
+    """When two strategies offset on the same symbol, the per-symbol record
+    fed to ``aggregate_records`` is already the algebraic sum (Phase A: only
+    one source per symbol; Phase B: the sub-book pre-aggregator pre-sums).
+    A net-flat symbol therefore arrives with ``size=0`` and is filtered.
+
+    This test pins the contract: the aggregator does NOT itself receive
+    raw per-strategy intents — it receives the symbol-level net. The
+    pre-aggregation responsibility is the SubBookAttributor's per
+    ADR-0012 §D8.
+    """
+    # Net-flat AAPL (e.g. +2 from Strategy A, -2 from Strategy B):
+    out = aggregate_records({"AAPL": {"size": "0", "entry_price": "150"}})
+    assert out == []  # filtered: size == 0
+
+
+def test_aggregate_multi_strategy_same_direction_via_pure_transform() -> None:
+    """Two same-direction strategies on AAPL → net-long arrives pre-summed."""
+    out = aggregate_records({"AAPL": {"size": "5", "entry_price": "150"}})
+    assert len(out) == 1
+    assert out[0].size == Decimal("5")
+
+
+# ---------------------------------------------------------------------------
+# (e) Hypothesis property: N input records → N filtered output Positions
+# ---------------------------------------------------------------------------
+
+
+@hyp_settings(max_examples=50, deadline=None)
+@given(
+    st.dictionaries(
+        # Symbol: alpha-only, 3-6 chars, uppercased.
+        keys=st.text(
+            alphabet=st.characters(min_codepoint=65, max_codepoint=90),
+            min_size=3,
+            max_size=6,
+        ),
+        values=st.fixed_dictionaries(
+            {
+                "size": st.decimals(
+                    min_value=Decimal("0.0001"),
+                    max_value=Decimal("1e6"),
+                    places=8,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
+                "entry_price": st.decimals(
+                    min_value=Decimal("0.01"),
+                    max_value=Decimal("1e6"),
+                    places=4,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
+            }
+        ),
+        min_size=0,
+        max_size=10,
+    )
+)
+def test_property_valid_records_round_trip_one_to_one(
+    records_in: dict[str, dict[str, Decimal]],
+) -> None:
+    """For any non-empty, well-formed input, output cardinality equals input
+    cardinality and per-symbol values round-trip exactly."""
+    serialized: dict[str, dict[str, Any]] = {
+        sym: {"size": str(rec["size"]), "entry_price": str(rec["entry_price"])}
+        for sym, rec in records_in.items()
+    }
+    out = aggregate_records(serialized)
+    assert len(out) == len(serialized)
+    by_sym = {p.symbol: p for p in out}
+    for sym, rec in records_in.items():
+        assert by_sym[sym].size == rec["size"]
+        assert by_sym[sym].entry_price == rec["entry_price"]
+
+
+# ---------------------------------------------------------------------------
+# (f) run_loop — periodic snapshot lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_loop_one_shot_with_running_flag(
+    state: _JsonStateAdapter,
+    aggregator: PositionAggregator,
+) -> None:
+    """A ``running`` flag set to False after one snapshot exits the loop cleanly."""
+
+    class _OneShotFlag:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __bool__(self) -> bool:
+            self.calls += 1
+            # First check (entry): True; second check (after sleep): False → exit.
+            return self.calls == 1
+
+    flag = _OneShotFlag()
+    await _seed_position(state, "AAPL", entry="150", size="2")
+    await aggregator.run_loop(interval_s=0.0, running=flag)
+    payload = await state.get(AGGREGATE_KEY)
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_loop_swallows_snapshot_exception(
+    aggregator: PositionAggregator,
+    state: _JsonStateAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient snapshot failure must not crash the loop."""
+    calls: list[int] = []
+
+    class _OneShotFlag:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __bool__(self) -> bool:
+            self.calls += 1
+            return self.calls == 1
+
+    async def _boom() -> int:
+        calls.append(1)
+        raise RuntimeError("simulated transient redis failure")
+
+    monkeypatch.setattr(aggregator, "snapshot_to_redis", _boom)
+    # Should not raise — the loop logs and exits when the flag flips False.
+    await aggregator.run_loop(interval_s=0.0, running=_OneShotFlag())
+    assert calls == [1]
+
+
+# ---------------------------------------------------------------------------
+# (g) Static module contract checks
+# ---------------------------------------------------------------------------
+
+
+def test_module_constants_are_stable_contracts() -> None:
+    """Constants exposed by the module are part of the public contract."""
+    assert PER_SYMBOL_KEY_PREFIX == "positions:"
+    assert AGGREGATE_KEY == "portfolio:positions"
+    assert DEFAULT_SNAPSHOT_INTERVAL_S == 15.0


### PR DESCRIPTION
Resolves #199 (Phase A.9, Roadmap v3.0 §2.2.4 row 4).

## Audit

See [`docs/audits/POSITION_KEY_AUDIT_2026-04-21.md`](docs/audits/POSITION_KEY_AUDIT_2026-04-21.md).

**Classification: CASE C** — no production writer exists for `portfolio:positions`. The S05 `ContextLoader` reads it as `list[Position]`; the only related producer is the S06 per-symbol writer at `services/execution/service.py:153` which writes `positions:{symbol}` (distinct namespace, distinct shape). The ADR-0006 fail-closed guard (STEP 0) was the only thing preventing 100% order rejection in production on the missing-key `RuntimeError`.

## Fix

New module [`services/feedback_loop/position_aggregator.py`](services/feedback_loop/position_aggregator.py) per the [PHASE_5_SPEC_v2 §3.2](docs/phases/PHASE_5_SPEC_v2.md) module-structure block:

- `aggregate_records(records) → list[Position]` — pure transform; reusable for the Phase B sub-book input shape per ADR-0012 §D2.
- `aggregate_from_redis()` — `SCAN`-based read of `positions:*`.
- `snapshot_to_redis()` — writes the aggregated list to `portfolio:positions` (always present, even on a flat book — empty list is a valid answer; missing key would trip the fail-closed guard).
- `run_loop(interval_s)` — periodic background-task wrapper (default 15 s).

No new ZMQ topic. No dual-write. No premature multi-strategy abstraction (per CLAUDE.md §3 / §5). The aggregator is purely **additive** — it does not change any existing code path.

## Tests

- **Unit**: 30 tests in [`tests/unit/feedback_loop/test_position_aggregator.py`](tests/unit/feedback_loop/test_position_aggregator.py). Covers happy path, single/multi-symbol, zero-size skip, malformed-record skip, asset-class inference (matches `services/risk_manager/exposure_monitor.py:_asset_class`), key-prefix isolation, snapshot round-trip via `Position.model_validate`, snapshot overwrite semantics, run-loop lifecycle including exception swallowing, and a Hypothesis property test for the Phase A 1:1 records→positions transform.
- **Integration**: 3 tests in [`tests/integration/test_position_aggregator_pipeline.py`](tests/integration/test_position_aggregator_pipeline.py) walking S06 fill → aggregator → S05 ContextLoader on shared fakeredis. Uses the real `services.risk_manager.context_loader.ContextLoader` to prove the orphan read closes end-to-end (mirrors the in-process integration approach used by `tests/integration/test_circuit_breaker_integration.py`).

All 30 unit + 3 integration tests pass locally; broader unit suite (676 tests across feedback_loop, risk_manager, core, regime_detector, signal_engine, fusion_engine, db, property) also passes — no regressions.

## ADR alignment

| ADR | Section | Alignment |
|-----|---------|-----------|
| ADR-0006 | §D4 | Reader stays fail-loud; aggregator failure surfaces via missing key + STEP 0 reject. **Preserved.** |
| ADR-0007 | §D8 | Per-strategy namespace (`kelly:*`, `trades:*`, `pnl:*`, `portfolio:allocation:*`) — `portfolio:positions` is intentionally NOT in §D8 enumeration; it is the consolidated aggregate, not a per-strategy intent. **Aligned.** |
| ADR-0012 | §D2/§D5 | Aggregator output contract (consolidated list) is identical in Phase A and Phase B; only the source-key prefix migrates from `positions:*` to `subbook:*:position:*` in Phase B (the pure-transform algebra is unchanged). **Aligned forward.** |
| Charter | §5.5 | Aggregator output remains a single global key. **Aligned.** |

Note: the audit doc cites ADR-0012 §D5 inline. ADR-0012 itself is **not modified** by this PR.

## Closes

- #199