### PR TITLE
fix(command_center): integer-ms is_alive boundary (test flake)

### DIFF
--- a/services/command_center/health_checker.py
+++ b/services/command_center/health_checker.py
@@ -45,17 +45,28 @@ class HealthChecker:
     def is_alive(self, service_id: str, timeout_ms: int = 10000) -> bool:
         """Check if a service is alive within the timeout window.
 
+        Boundary semantic: ``elapsed_ms < timeout_ms`` (strict less-than).
+        A heartbeat exactly at the timeout boundary is treated as "just
+        expired" → DEAD. Matches Kubernetes liveness probe, gRPC keepalive,
+        and AWS health check conventions.
+
+        Elapsed time is rounded to integer milliseconds before comparison so
+        the boundary is well-defined under floating-point arithmetic
+        (``time.time()`` returns float seconds; the float→ms round-trip is
+        imprecise for non-integer second values like 512.035).
+
         Args:
             service_id: Service to check.
             timeout_ms: Maximum acceptable silence in milliseconds.
 
         Returns:
-            True if last heartbeat was within timeout.
+            True if last heartbeat was strictly within ``timeout_ms``.
         """
         last = self._last_seen.get(service_id)
         if last is None:
             return False
-        return (time.time() - last) * 1000 < timeout_ms
+        elapsed_ms = round((time.time() - last) * 1000)
+        return elapsed_ms < timeout_ms
 
     def get_dead_services(self) -> list[str]:
         """Return list of service IDs that have not sent a heartbeat within 10s.

--- a/tests/unit/command_center/test_health_checker.py
+++ b/tests/unit/command_center/test_health_checker.py
@@ -363,6 +363,56 @@ class TestLatencyStats:
 
 
 # ---------------------------------------------------------------------------
+# TestBoundary — explicit liveness-window edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestBoundary:
+    """Explicit boundary tests for ``is_alive`` semantics.
+
+    Reinforces the property test by pinning down each side of the
+    ``age < timeout`` boundary with a named case. Originally added after a
+    Hypothesis flake at ``age_ms == timeout_ms`` caused by float-to-ms
+    round-trip imprecision (e.g. ``512035 / 1000 * 1000 == 512034.99...``).
+    """
+
+    def test_age_zero_is_alive(self) -> None:
+        hc = HealthChecker()
+        with patch("services.command_center.health_checker.time.time", return_value=1000.0):
+            hc.record_heartbeat("signal_engine", 0)
+            assert hc.is_alive("signal_engine", timeout_ms=10_000) is True
+
+    def test_age_one_below_timeout_is_alive(self) -> None:
+        hc = HealthChecker()
+        with patch("services.command_center.health_checker.time.time", return_value=1000.0):
+            hc.record_heartbeat("signal_engine", 0)
+        # 9.999s elapsed = 9999ms = timeout − 1
+        with patch("services.command_center.health_checker.time.time", return_value=1009.999):
+            assert hc.is_alive("signal_engine", timeout_ms=10_000) is True
+
+    def test_age_equals_timeout_is_dead(self) -> None:
+        """Boundary case that originally triggered the Hypothesis flake."""
+        hc = HealthChecker()
+        with patch("services.command_center.health_checker.time.time", return_value=0.0):
+            hc.record_heartbeat("signal_engine", 0)
+        # age_ms == timeout_ms, including the FP-pathological 512035 case
+        for boundary_ms in (10_000, 512_035, 1_000_000):
+            with patch(
+                "services.command_center.health_checker.time.time",
+                return_value=boundary_ms / 1000.0,
+            ):
+                assert hc.is_alive("signal_engine", timeout_ms=boundary_ms) is False
+
+    def test_age_above_timeout_is_dead(self) -> None:
+        hc = HealthChecker()
+        with patch("services.command_center.health_checker.time.time", return_value=1000.0):
+            hc.record_heartbeat("signal_engine", 0)
+        # 10.001s elapsed = 10001ms = timeout + 1
+        with patch("services.command_center.health_checker.time.time", return_value=1010.001):
+            assert hc.is_alive("signal_engine", timeout_ms=10_000) is False
+
+
+# ---------------------------------------------------------------------------
 # TestPropertyInvariants — Hypothesis
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes the deterministic Hypothesis flake `test_is_alive_iff_age_strictly_less_than_timeout` in [tests/unit/command_center/test_health_checker.py:399](tests/unit/command_center/test_health_checker.py#L399).

## Bug

**Not** a `<` vs `<=` mismatch — both impl and property test already used strict `<`. The actual root cause is **float-to-ms round-trip imprecision**.

The property test patches `time.time()` → `age_ms / 1000.0`. The implementation then computed `(time.time() - last) * 1000`. For `age_ms = 512_035`:

```
512035 / 1000.0          == 512.035                  (binary-fp, inexact)
(512.035 - 0.0) * 1000   == 512034.99999999994       (round-trip lost a bit)
512034.99999999994 < 512035  → True                  (spurious "alive")
```

So at the boundary `age_ms == timeout_ms`, the impl reported "alive" while the test's clean integer assertion `(age_ms < timeout_ms)` said "dead". CI passed only because Hypothesis randomness had not yet hit the FP-pathological value.

## Decision

Canonical industry semantic: `age < timeout` (strict less-than). A heartbeat exactly at the timeout boundary is **just expired → DEAD**. Matches Kubernetes liveness probe, gRPC keepalive, AWS health check conventions.

## Fix

Round the elapsed seconds → ms product to an integer before comparing to `timeout_ms`:

```python
elapsed_ms = round((time.time() - last) * 1000)
return elapsed_ms < timeout_ms
```

Eliminates FP round-trip imprecision while preserving the canonical strict-`<` semantic. Quantizes to 1ms, which is well below any realistic heartbeat-timeout granularity. Boundary semantic now documented in the `is_alive` docstring.

## Tests

- Property test now passes deterministically across hypothesis seeds (default, 42, 12345, 99999).
- 4 new explicit boundary tests in `TestBoundary` class at `age=0`, `age=timeout-1`, `age=timeout`, `age>timeout`. The `age==timeout` test explicitly probes the FP-pathological 512_035 ms case that triggered the original flake.
- Existing 37 tests in `test_health_checker.py` all still pass.

## Gates

- `mypy --strict services/command_center/health_checker.py` ✓
- `ruff check` + `ruff format --check` ✓
- 41/41 tests pass under multiple Hypothesis seeds ✓

## Background

Discovered by post-Sprint-4 audit. CI passed only because Hypothesis randomness hadn't yet hit the boundary; future re-seeds would have flipped CI red.

Refs #203