### PR TITLE
fix(signal_engine): restore Wilder 1978 ATR smoothing (#254)

### DIFF
--- a/services/signal_engine/technical.py
+++ b/services/signal_engine/technical.py
@@ -314,28 +314,37 @@ class TechnicalAnalyzer:
 
         True Range = max(H − L, |H − prev_C|, |L − prev_C|).
 
+        The seed value is the arithmetic mean of the first ``period`` TR
+        values; subsequent values are produced by the Wilder recurrence
+        ``ATR_t = (ATR_{t-1} * (period - 1) + TR_t) / period`` over the
+        remaining TRs.
+
         Args:
             period: ATR smoothing period (default 14).
             timeframe: Bar timeframe to use (default ``'5m'``).
 
         Returns:
-            ATR as a :class:`~decimal.Decimal`, or ``None`` if insufficient
-            bars exist.
+            ATR as a :class:`~decimal.Decimal`, or ``None`` if fewer than
+            ``period + 1`` bars are available.
+
+        Reference:
+            Wilder J.W. (1978). "New Concepts in Technical Trading Systems".
+            Trend Research, ISBN 978-0-89459-027-6.
         """
+        # Compute TR over ALL available bars (Wilder 1978 canonical formulation).
+        # Previous implementation sliced bars[-(period + 1):] before computing
+        # TRs, yielding exactly `period` TR values, leaving trs[period:] always
+        # empty so the smoothing loop body never executed (#254).
         bars = self._all_bars(timeframe)
         if len(bars) < period + 1:
             return None
 
-        recent = bars[-(period + 1) :]
         trs: list[float] = []
-        for i in range(1, len(recent)):
-            h = recent[i]["high"]
-            lo = recent[i]["low"]
-            prev_c = recent[i - 1]["close"]
+        for i in range(1, len(bars)):
+            h = bars[i]["high"]
+            lo = bars[i]["low"]
+            prev_c = bars[i - 1]["close"]
             trs.append(max(h - lo, abs(h - prev_c), abs(lo - prev_c)))
-
-        if not trs:
-            return None
 
         atr_val = sum(trs[:period]) / period
         for tr in trs[period:]:

--- a/tests/unit/signal_engine/test_technical.py
+++ b/tests/unit/signal_engine/test_technical.py
@@ -254,6 +254,109 @@ class TestATRExtended:
         assert float(atr) == 0.0
 
 
+# ── ATR Wilder 1978 smoothing — regression for #254 ──────────────────────────
+
+
+class TestAtrWilderSmoothing:
+    """Regression tests for the Wilder 1978 ATR smoothing fix (#254).
+
+    Previous implementation sliced ``bars[-(period + 1):]`` which yielded
+    exactly ``period`` TR values, leaving ``trs[period:]`` always empty so
+    the smoothing loop body never executed. The fix consumes all available
+    bars and applies the canonical Wilder recurrence.
+
+    Reference: Wilder J.W. (1978) "New Concepts in Technical Trading Systems".
+
+    With single-tick-per-bar feeds (as built by ``_feed_prices``), each bar
+    has ``high == low == close == price``, so the True Range collapses to
+    ``TR_i = |price_i - price_{i-1}|``. This lets the tests pin down the
+    exact TR sequence the analyzer will see.
+    """
+
+    def test_wilder_smoothing_differs_from_naive_mean_on_ascending_tr(self) -> None:
+        """ATR over an ascending-TR series must differ from the naive mean."""
+        ta = TechnicalAnalyzer("BTCUSDT")
+        # Increments 0.1, 0.2, ..., 4.4 -> TRs ascend from 0.1 to 4.4.
+        prices = [100.0]
+        for i in range(1, 45):
+            prices.append(prices[-1] + i * 0.1)
+        _feed_prices(ta, prices)
+
+        wilder_atr = ta.atr(period=14, timeframe="5m")
+        assert wilder_atr is not None
+
+        # Naive arithmetic mean of the last 14 TRs (the buggy behavior):
+        # (3.1 + 4.4) / 2 = 3.75.
+        naive_buggy_atr = 3.75
+        assert abs(float(wilder_atr) - naive_buggy_atr) > 0.1, (
+            f"Wilder ATR ({wilder_atr}) should differ from the naive mean "
+            f"({naive_buggy_atr}) on this ascending-volatility series. If they "
+            f"match, the smoothing loop body did not execute (#254)."
+        )
+        # Sanity: canonical Wilder over all 44 TRs computes to 3.17036762.
+        assert abs(float(wilder_atr) - 3.17036762) < 1e-6
+
+    def test_wilder_recurrence_against_hand_computed_value(self) -> None:
+        """Hand-computed Wilder value over TR=[1, 2, 3, 4, 5], period=3.
+
+        Seed = (1 + 2 + 3) / 3 = 2.0
+        Step 1: (2.0 * 2 + 4) / 3 = 8 / 3 ≈ 2.66667
+        Step 2: (8/3 * 2 + 5) / 3 = 31 / 9 ≈ 3.44444
+        """
+        ta = TechnicalAnalyzer("BTCUSDT")
+        prices = [100.0, 101.0, 103.0, 106.0, 110.0, 115.0]  # diffs: 1, 2, 3, 4, 5
+        _feed_prices(ta, prices)
+
+        result = ta.atr(period=3, timeframe="5m")
+        assert result is not None
+        expected = Decimal("3.44444444")
+        assert abs(result - expected) < Decimal("0.0001"), (
+            f"Wilder hand-computed expected {expected}, got {result}"
+        )
+
+    def test_wilder_constant_tr_yields_constant_atr(self) -> None:
+        """Constant TR series: Wilder smoothing yields that constant value."""
+        ta = TechnicalAnalyzer("BTCUSDT")
+        # Constant +10 increment -> TR_i = 10.0 for every bar.
+        prices = [100.0 + 10.0 * i for i in range(20)]
+        _feed_prices(ta, prices)
+        result = ta.atr(period=14, timeframe="5m")
+        assert result is not None
+        assert abs(result - Decimal("10.0")) < Decimal("0.001")
+
+    def test_returns_none_for_insufficient_bars(self) -> None:
+        """Fewer than ``period + 1`` bars must return None."""
+        ta = TechnicalAnalyzer("BTCUSDT")
+        _feed_prices(ta, [100.0] * 10)  # 10 bars; period=14 needs >= 15.
+        assert ta.atr(period=14, timeframe="5m") is None
+
+    @given(
+        n_bars=st.integers(min_value=20, max_value=120),
+        seed=st.integers(min_value=1, max_value=10_000),
+    )
+    @settings(max_examples=40, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    def test_wilder_atr_within_tr_range(self, n_bars: int, seed: int) -> None:
+        """Property: Wilder ATR is bounded by ``[min(TR), max(TR)]``."""
+        rng = np.random.default_rng(seed)
+        prices = [100.0]
+        for _ in range(n_bars - 1):
+            prices.append(prices[-1] + float(rng.uniform(-2.0, 2.0)))
+
+        ta = TechnicalAnalyzer("BTCUSDT")
+        _feed_prices(ta, prices)
+        result = ta.atr(period=14, timeframe="5m")
+        if result is None:
+            return  # insufficient data; allowed by contract
+
+        diffs = [abs(prices[i] - prices[i - 1]) for i in range(1, len(prices))]
+        tr_min = min(diffs)
+        tr_max = max(diffs)
+        # Tolerance accounts for the 8-decimal rounding applied to the result.
+        assert tr_min - 1e-6 <= float(result) <= tr_max + 1e-6, (
+            f"ATR={result} outside TR range [{tr_min}, {tr_max}]"
+        )
+
+
 # ── compute_bollinger_score ──────────────────────────────────────────────────
 
 

--- a/tests/unit/signal_engine/test_technical.py
+++ b/tests/unit/signal_engine/test_technical.py
@@ -276,10 +276,14 @@ class TestAtrWilderSmoothing:
     def test_wilder_smoothing_differs_from_naive_mean_on_ascending_tr(self) -> None:
         """ATR over an ascending-TR series must differ from the naive mean."""
         ta = TechnicalAnalyzer("BTCUSDT")
-        # Increments 0.1, 0.2, ..., 4.4 -> TRs ascend from 0.1 to 4.4.
-        prices = [100.0]
+        # Build TR sequence with exact Decimal arithmetic to eliminate FP drift.
+        # Each increment is Decimal(i) / Decimal(10), so TRs target exactly
+        # [0.1, 0.2, ..., 4.4] regardless of platform FP rounding.
+        prices: list[float] = [100.0]
+        running = Decimal("100.0")
         for i in range(1, 45):
-            prices.append(prices[-1] + i * 0.1)
+            running += Decimal(i) / Decimal(10)
+            prices.append(float(running))
         _feed_prices(ta, prices)
 
         wilder_atr = ta.atr(period=14, timeframe="5m")


### PR DESCRIPTION
Resolves #254.

## Bug
Off-by-one in slice arithmetic in `services/signal_engine/technical.py` `atr()` prevented the Wilder smoothing loop body from ever executing. The slice `bars[-(period + 1):]` produced exactly `period` TR values, so `trs[period:]` was always the empty slice. The function returned the unsmoothed arithmetic mean of the **last** `period` TR values rather than the canonical Wilder recurrence over the full bar history.

## Reproduction
44 bars with ascending TR sequence `[0.1, 0.2, ..., 4.4]`, period=14:
- **Buggy:**  `3.75` (mean of last 14 TRs, smoothing loop ran 0 times)
- **Wilder:** `3.17036762` (canonical smoothing across all 44 TRs)

Discrepancy ≈ 18% on this series.

## Fix
- Compute TR over **all** available bars (no `[-(period+1):]` slice)
- Seed = arithmetic mean of the first `period` TRs
- Apply Wilder recurrence `ATR_t = (ATR_{t-1} * (period - 1) + TR_t) / period` across the remaining TRs

Function signature, return type (`Decimal | None`), default period (14), and 8-decimal rounding are all preserved. Docstring updated with the Wilder 1978 reference.

## Alpha impact
ATR is consumed at 3 production sites (verified via audit grep):
- `services/signal_engine/pipeline.py:347` — legacy confluence stop-loss sizing
- `services/signal_engine/pipeline.py:407` — `Signal.features` payload
- `backtesting/engine.py:381` — backtest harness

Degenerate (unsmoothed) ATR over-reacts to single-bar volatility spikes. Strategy #1 (Phase B Gate 2A) depends on stable Wilder ATR for stop-loss exits. None of these consumers were modified — the fix is local to `atr()`.

## Tests
New class `TestAtrWilderSmoothing` in `tests/unit/signal_engine/test_technical.py`:
1. `test_wilder_smoothing_differs_from_naive_mean_on_ascending_tr` — asserts Wilder ATR != naive mean on ascending-TR series, with hard-coded reference value `3.17036762`
2. `test_wilder_recurrence_against_hand_computed_value` — period=3, TR=[1,2,3,4,5], expected `31/9 ≈ 3.4444`
3. `test_wilder_constant_tr_yields_constant_atr` — invariance check
4. `test_returns_none_for_insufficient_bars` — boundary
5. `test_wilder_atr_within_tr_range` — Hypothesis property test (40 examples), ATR ∈ [min(TR), max(TR)]

All 60 tests in `test_technical.py` + `test_technical_analyzer.py` pass. Full `tests/unit/signal_engine/` suite (129 tests) green. The pre-existing 17 ATR tests in `test_technical_analyzer.py` only assert `is not None`, non-negative, and `Decimal`-typed return — they never asserted specific numeric values, so the buggy-vs-correct numerical discrepancy required **zero** expected-value updates in older tests.

## Gates
- mypy strict: passing on both files
- ruff check + format: passing
- Full signal_engine suite: 129 passed

## Reference
Wilder J.W. (1978). *New Concepts in Technical Trading Systems*. Trend Research, ISBN 978-0-89459-027-6.

## Closes
- #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)