### PR TITLE
fix(backtesting): correct PBO computation logic for overfit detection (#266)

### DIFF
--- a/backtesting/metrics.py
+++ b/backtesting/metrics.py
@@ -669,6 +669,31 @@ def minimum_track_record_length(
     return max(1, math.ceil(1.0 + var_f * (z / (sr_raw - sr_star)) ** 2))
 
 
+def _rankdata_average_safe(
+    values: np.ndarray[Any, np.dtype[np.float64]],
+) -> np.ndarray[Any, np.dtype[np.float64]]:
+    """Average-rank wrapper around :func:`scipy.stats.rankdata` robust to ±inf.
+
+    SciPy ``rankdata`` (≤ 1.12) returns an all-NaN vector when the input
+    contains both ``+inf`` and ``-inf`` because its internal tie-detection
+    computes ``inf - inf`` → NaN, which then poisons every rank. We pre-map
+    infinities to finite sentinels that strictly preserve the input order
+    before delegating.
+    """
+    arr = np.asarray(values, dtype=np.float64)
+    finite_mask = np.isfinite(arr)
+    if finite_mask.all():
+        return np.asarray(scipy_stats.rankdata(arr, method="average"), dtype=np.float64)
+    finite_vals = arr[finite_mask]
+    bound = float(np.max(np.abs(finite_vals))) + 1.0 if finite_vals.size else 1.0
+    safe = np.where(
+        np.isposinf(arr),
+        bound,
+        np.where(np.isneginf(arr), -bound, arr),
+    )
+    return np.asarray(scipy_stats.rankdata(safe, method="average"), dtype=np.float64)
+
+
 def probability_of_backtest_overfitting_cpcv(
     strategy_returns: np.ndarray[Any, np.dtype[np.float64]],
     cv: CombinatorialPurgedCV,
@@ -712,19 +737,21 @@ def probability_of_backtest_overfitting_cpcv(
         annual_factor: Annualisation factor (``sqrt(252)`` for daily).
 
     Returns:
-        PBO in ``[0, 1]``. Values ``< 0.1`` suggest a genuine edge,
-        values near ``0.5`` suggest the backtest is statistically
-        indistinguishable from noise selection.
+        Float in ``[0, 1]``. Higher PBO indicates higher overfitting
+        probability. Conventionally, ``PBO < 0.5`` is required for
+        strategy promotion (ADR-0002 §6). Values ``< 0.1`` suggest a
+        genuine edge; values near ``0.5`` suggest the backtest is
+        statistically indistinguishable from noise selection.
 
     Raises:
         ValueError: if ``strategy_returns`` is not 2D, if
             ``n_strategies < 2``, or if the CPCV produces no splits.
 
     Reference:
-        Bailey, D. H., Borwein, J. M., Lopez de Prado, M., & Zhu, Q. J.
-        (2014). The Probability of Backtest Overfitting. Journal of
-        Computational Finance. Equation 11 (logit) and Equation 12
-        (PBO definition).
+        Bailey D., Borwein J., Lopez de Prado M., Zhu Q. (2014).
+        "The Probability of Backtest Overfitting". Journal of
+        Computational Finance, 17(4). Equation 11 (logit) and
+        Equation 12 (PBO definition).
     """
     arr = np.asarray(strategy_returns, dtype=float)
     if arr.ndim != 2:
@@ -758,7 +785,7 @@ def probability_of_backtest_overfitting_cpcv(
             dtype=float,
         )
         best_is = int(np.argmax(is_sharpes))
-        ranks = scipy_stats.rankdata(oos_sharpes, method="average")
+        ranks = _rankdata_average_safe(oos_sharpes)
         rank_best = float(ranks[best_is])
         omega = (rank_best + 0.5) / (n_strats + 1)
         lambda_c = math.log(omega / (1.0 - omega))

--- a/tests/unit/backtesting/test_metrics.py
+++ b/tests/unit/backtesting/test_metrics.py
@@ -13,6 +13,8 @@ from typing import Any
 
 import numpy as np
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from backtesting.metrics import (
     almgren_chriss_impact,
@@ -959,3 +961,99 @@ def test_ac_impact_rejects_invalid_calibration() -> None:
         almgren_chriss_impact(50_000, 1_000_000, 0.02, gamma=float("nan"))
     with pytest.raises(ValueError, match="finite non-negative"):
         almgren_chriss_impact(float("inf"), 1_000_000, 0.02)
+
+
+# ---------------------------------------------------------------------------
+# PBO property tests (issue #266) — Bailey-Borwein-Lopez de Prado-Zhu (2014)
+# ---------------------------------------------------------------------------
+
+
+class TestPBOProperties:
+    """Hypothesis property tests for PBO invariants (#266).
+
+    Reference:
+        Bailey D., Borwein J., Lopez de Prado M., Zhu Q. (2014).
+        "The Probability of Backtest Overfitting".
+        Journal of Computational Finance, 17(4).
+    """
+
+    @given(
+        n_strategies=st.integers(min_value=2, max_value=12),
+        n_obs=st.integers(min_value=60, max_value=200),
+        seed=st.integers(min_value=1, max_value=10_000),
+    )
+    @settings(max_examples=20, deadline=None)
+    def test_pbo_in_unit_interval(self, n_strategies: int, n_obs: int, seed: int) -> None:
+        """PBO must lie in [0, 1] for any well-formed returns matrix."""
+        rng = np.random.default_rng(seed)
+        returns = rng.normal(0.0, 0.01, size=(n_obs, n_strategies))
+        cv = CombinatorialPurgedCV(n_splits=6, n_test_splits=2, embargo_pct=0.0)
+        pbo = probability_of_backtest_overfitting_cpcv(returns, cv)
+        assert math.isfinite(pbo)
+        assert 0.0 <= pbo <= 1.0
+
+    def test_pbo_perfect_overfit_property(self) -> None:
+        """Self-contained regression of the line-247 perfect-overfit fixture.
+
+        Two designed CV splits over 20 observations and 3 strategies. The
+        IS-best strategy is constructed to be the OOS-worst on every split,
+        so PBO must equal 1.0.
+        """
+        n_obs = 20
+        half = n_obs // 2
+        returns = np.zeros((n_obs, 3), dtype=float)
+        returns[:half, 0] = 0.02
+        returns[half:, 0] = -0.02
+        returns[:half, 1] = -0.02
+        returns[half:, 1] = 0.02
+        returns[:, 2] = 0.0001
+        splits = [
+            (list(range(0, half)), list(range(half, n_obs))),
+            (list(range(half, n_obs)), list(range(0, half))),
+        ]
+        cv = _MockCV(splits)
+        pbo = probability_of_backtest_overfitting_cpcv(returns, cv)  # type: ignore[arg-type]
+        assert pbo == 1.0
+
+    def test_pbo_perfect_anti_overfit_returns_zero(self) -> None:
+        """When the IS-best is also the OOS-best on every split, PBO = 0.0.
+
+        Strategy 0 dominates uniformly so it is selected IS and OOS-best
+        on every CPCV path; logits are strictly positive → PBO = 0.0.
+        """
+        rng = np.random.default_rng(11)
+        n_obs, n_strats = 80, 5
+        returns = rng.normal(0.0, 0.001, size=(n_obs, n_strats))
+        returns[:, 0] = 0.02
+        cv = CombinatorialPurgedCV(n_splits=6, n_test_splits=2, embargo_pct=0.0)
+        pbo = probability_of_backtest_overfitting_cpcv(returns, cv)
+        assert pbo == 0.0
+
+    def test_pbo_robust_to_zero_variance_strategies(self) -> None:
+        """Regression for #266: zero-variance series produce ±inf Sharpes.
+
+        The IS/OOS rank step must remain well-defined even when several
+        candidate strategies have constant returns over a fold (e.g. cash,
+        flat-position, or degenerate signal). Pre-fix, scipy ``rankdata``
+        on a vector containing both ``+inf`` and ``-inf`` returned an
+        all-NaN array, which silently zeroed PBO regardless of true
+        overfitting.
+        """
+        n_obs = 40
+        half = n_obs // 2
+        returns = np.zeros((n_obs, 4), dtype=float)
+        returns[:half, 0] = 0.01
+        returns[half:, 0] = -0.01
+        returns[:half, 1] = -0.01
+        returns[half:, 1] = 0.01
+        returns[:, 2] = 0.0001
+        # strategy 3: flat zero — pure noise floor candidate
+        splits = [
+            (list(range(0, half)), list(range(half, n_obs))),
+            (list(range(half, n_obs)), list(range(0, half))),
+        ]
+        cv = _MockCV(splits)
+        pbo = probability_of_backtest_overfitting_cpcv(returns, cv)  # type: ignore[arg-type]
+        assert math.isfinite(pbo)
+        assert 0.0 <= pbo <= 1.0
+        assert pbo == 1.0


### PR DESCRIPTION
Resolves #266. Unblocks #196.

## Bug
`probability_of_backtest_overfitting_cpcv()` in [backtesting/metrics.py](backtesting/metrics.py) returned `0.0` instead of `1.0` for the perfect-overfit fixture in `test_metrics.py:247`.

Root cause: `scipy.stats.rankdata` (≤ 1.12) returns an all-`NaN` vector when its input contains both `+inf` and `-inf` because its internal tie-detection step computes `inf - inf = NaN`, which then poisons every rank entry. The perfect-overfit fixture intentionally produces zero-variance return series per CV fold; `sharpe_ratio()` then returns `±inf`, the OOS ranking step gets `[+inf, -inf, +inf]`, `rankdata` yields `[NaN, NaN, NaN]`, the logit becomes `NaN`, and `NaN <= 0.0` is `False` — so no logits are counted and PBO collapses to `0.0` regardless of actual overfitting.

## Why this matters
PBO is one of the **four institutional validation gates** per [ADR-0002](docs/adr/ADR-0002-quant-methodology-charter.md) (Quant Methodology Charter). Strategy promotion to live trading is gated on `PBO < 0.5` per Charter §6 — **wrong PBO ⇒ wrong promotion decisions ⇒ real money at risk**.

## Fix
Introduced a private `_rankdata_average_safe()` helper that pre-maps `±inf` to finite sentinels (`±(max|finite| + 1)`) preserving the input order, then delegates to `scipy.stats.rankdata`. The PBO function uses the helper for the OOS rank step. Behaviour on all-finite inputs is unchanged (verified against existing `test_pbo_no_overfit_returns_zero` and `test_pbo_random_strategies_around_half`).

Scope is intentionally minimal: the 1893-LOC `metrics.py` god-module is not refactored (deferred to Phase B per audit §14.6); only the PBO function and one new helper are modified.

## Tests
4 new tests under `TestPBOProperties` in `tests/unit/backtesting/test_metrics.py`:
- `test_pbo_in_unit_interval` — Hypothesis-driven (20 examples), PBO must lie in `[0, 1]` for any well-formed returns matrix.
- `test_pbo_perfect_overfit_property` — self-contained replica of the line-247 fixture.
- `test_pbo_perfect_anti_overfit_returns_zero` — uniformly-dominant strategy yields `pbo == 0.0`.
- `test_pbo_robust_to_zero_variance_strategies` — explicit regression for the `+inf/-inf` `rankdata` pathology with mixed flat candidates.

Full suite: `tests/unit/backtesting/test_metrics.py` 68 passed (was 64 before; +4 new).

## Gates
- `python -m ruff check backtesting/metrics.py tests/unit/backtesting/test_metrics.py` — clean
- `python -m ruff format --check ...` — clean
- `python -m mypy --strict backtesting/metrics.py` — clean
- `python -m mypy --strict tests/unit/backtesting/test_metrics.py` — clean
- `python -m pytest tests/unit/backtesting/test_metrics.py` — 68 passed

## Reference
Bailey D., Borwein J., Lopez de Prado M., Zhu Q. (2014). "The Probability of Backtest Overfitting". *Journal of Computational Finance*, 17(4). Equation 11 (logit) and Equation 12 (PBO definition).

## Closes
- #266

## Unblocks
- #196 (un-muzzle CI backtest-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)